### PR TITLE
Add support for inspecting remote repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +154,12 @@ checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bytes"
@@ -1225,6 +1237,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "js-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "jwalk"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1430,8 @@ dependencies = [
  "console",
  "gix",
  "predicates",
+ "ureq",
+ "url",
 ]
 
 [[package]]
@@ -1531,6 +1554,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1579,38 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.3",
+ "sct",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1557,6 +1627,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "serde"
@@ -1594,6 +1674,12 @@ name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "static_assertions"
@@ -1745,6 +1831,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-webpki 0.100.1",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
 name = "url"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,6 +1899,79 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki 0.100.1",
+]
 
 [[package]]
 name = "winapi"

--- a/packages/ploys-cli/Cargo.toml
+++ b/packages/ploys-cli/Cargo.toml
@@ -13,6 +13,8 @@ anyhow = "1.0.72"
 clap = { version = "4.3.21", features = ["derive"] }
 console = "0.15.7"
 gix = "0.51.0"
+ureq = "2.7.1"
+url = "2.4.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.12"

--- a/packages/ploys-cli/src/command/inspect.rs
+++ b/packages/ploys-cli/src/command/inspect.rs
@@ -1,21 +1,30 @@
 use std::env;
 use std::fmt::{self, Display};
 use std::fs;
+use std::str::FromStr;
 
 use anyhow::{anyhow, Error};
 use clap::Args;
 use console::style;
 use gix::remote::Direction;
 use gix::Repository;
+use url::Url;
 
 /// Inspects the project.
 #[derive(Args)]
-pub struct Inspect;
+pub struct Inspect {
+    /// The remote GitHub repository owner/repo or URL.
+    #[clap(long)]
+    remote: Option<RepoOrUrl>,
+}
 
 impl Inspect {
     /// Executes the command.
     pub fn exec(self) -> Result<(), Error> {
-        let project = Project::load(gix::open(".")?)?;
+        let project = match self.remote {
+            Some(remote) => Project::remote(remote)?,
+            None => Project::local(gix::open(".")?)?,
+        };
 
         println!("{project}");
 
@@ -30,16 +39,42 @@ struct Project {
 }
 
 impl Project {
-    /// Loads the project information.
-    fn load(repository: Repository) -> Result<Self, Error> {
+    /// Loads the project information from the local repository.
+    fn local(repository: Repository) -> Result<Self, Error> {
         Ok(Self {
-            name: Self::query_project_name()?,
+            name: Self::query_local_project_name()?,
             repo: Self::query_repository_url(&repository)?,
         })
     }
 
-    /// Queries the project name.
-    fn query_project_name() -> Result<String, Error> {
+    /// Loads the project information from the remote repository.
+    fn remote(remote: RepoOrUrl) -> Result<Self, Error> {
+        let repo = match remote {
+            RepoOrUrl::Repo(repo) => repo,
+            RepoOrUrl::Url(url) => {
+                if url.domain() != Some("github.com") {
+                    return Err(anyhow!(
+                        "Unsupported remote repository: Only GitHub is supported"
+                    ));
+                }
+
+                url.path()
+                    .trim_start_matches("/")
+                    .trim_end_matches(".git")
+                    .parse::<Repo>()?
+            }
+        };
+
+        Self::query_remote_repository(&repo)?;
+
+        Ok(Self {
+            name: Self::query_remote_project_name(&repo),
+            repo: Some(format!("https://github.com/{}", repo)),
+        })
+    }
+
+    /// Queries the local project name.
+    fn query_local_project_name() -> Result<String, Error> {
         if let Ok(readme) = fs::read_to_string("README.md") {
             if let Some(title) = readme.lines().find(|line| line.starts_with("# ")) {
                 return Ok(title[2..].to_string());
@@ -51,6 +86,36 @@ impl Project {
         }
 
         Err(anyhow!("Invalid project information"))
+    }
+
+    /// Queries the remote repository to check that it exists.
+    fn query_remote_repository(repo: &Repo) -> Result<(), Error> {
+        let url = format!("https://api.github.com/repos/{}", repo);
+        let request = ureq::head(&url).set("User-Agent", "ploys/ploys");
+
+        match request.call() {
+            Ok(_) => Ok(()),
+            Err(ureq::Error::Status(404, _)) => Err(anyhow!("Repository not found")),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    /// Queries the remote repository name.
+    fn query_remote_project_name(repo: &Repo) -> String {
+        let url = format!("https://api.github.com/repos/{}/readme", repo);
+        let request = ureq::get(&url)
+            .set("User-Agent", "ploys/ploys")
+            .set("Accept", "application/vnd.github.raw");
+
+        if let Ok(response) = request.call() {
+            if let Ok(readme) = response.into_string() {
+                if let Some(title) = readme.lines().find(|line| line.starts_with("# ")) {
+                    return title[2..].to_string();
+                }
+            }
+        }
+
+        repo.repo.clone()
     }
 
     /// Queries the repository URL.
@@ -79,5 +144,56 @@ impl Display for Project {
         )?;
 
         Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct Repo {
+    owner: String,
+    repo: String,
+}
+
+impl Display for Repo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.owner, self.repo)?;
+
+        Ok(())
+    }
+}
+
+impl FromStr for Repo {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.split_once("/") {
+            Some((owner, repo)) => match repo.contains("/") {
+                true => Err(anyhow!("Expected owner/repo, found: {}", s)),
+                false => Ok(Self {
+                    owner: owner.to_string(),
+                    repo: repo.to_string(),
+                }),
+            },
+            None => Err(anyhow!("Expected owner/repo, found: {}", s)),
+        }
+    }
+}
+
+#[derive(Clone)]
+enum RepoOrUrl {
+    Repo(Repo),
+    Url(Url),
+}
+
+impl FromStr for RepoOrUrl {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.parse::<Repo>() {
+            Ok(repo) => Ok(Self::Repo(repo)),
+            Err(_) => match s.parse::<Url>() {
+                Ok(url) => Ok(Self::Url(url)),
+                Err(_) => Err(anyhow!("Expected owner/repo or URL, found: {}", s)),
+            },
+        }
     }
 }

--- a/packages/ploys-cli/tests/inspect.rs
+++ b/packages/ploys-cli/tests/inspect.rs
@@ -4,7 +4,7 @@ use assert_cmd::prelude::*;
 use predicates::prelude::*;
 
 #[test]
-fn test_inspect_command_output() {
+fn test_inspect_local_command_output() {
     Command::cargo_bin("ploys")
         .unwrap()
         .current_dir("../..")
@@ -13,4 +13,53 @@ fn test_inspect_command_output() {
         .success()
         .stdout(predicate::str::is_match(r#"Name:[ \t]*ploys"#).unwrap())
         .stdout(predicate::str::is_match(r#"Repository:.*github\.com/ploys/ploys"#).unwrap());
+}
+
+#[test]
+fn test_inspect_remote_command_output() {
+    Command::cargo_bin("ploys")
+        .unwrap()
+        .current_dir("../..")
+        .arg("inspect")
+        .arg("--remote")
+        .arg("ploys/ploys")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(r#"Name:[ \t]*ploys"#).unwrap())
+        .stdout(predicate::str::is_match(r#"Repository:.*github\.com/ploys/ploys"#).unwrap());
+}
+
+#[test]
+fn test_inspect_remote_url_command_output() {
+    Command::cargo_bin("ploys")
+        .unwrap()
+        .current_dir("../..")
+        .arg("inspect")
+        .arg("--remote")
+        .arg("https://github.com/ploys/ploys")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(r#"Name:[ \t]*ploys"#).unwrap())
+        .stdout(predicate::str::is_match(r#"Repository:.*github\.com/ploys/ploys"#).unwrap());
+
+    Command::cargo_bin("ploys")
+        .unwrap()
+        .current_dir("../..")
+        .arg("inspect")
+        .arg("--remote")
+        .arg("https://github.com/ploys/ploys.git")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(r#"Name:[ \t]*ploys"#).unwrap())
+        .stdout(predicate::str::is_match(r#"Repository:.*github\.com/ploys/ploys"#).unwrap());
+
+    Command::cargo_bin("ploys")
+        .unwrap()
+        .current_dir("../..")
+        .arg("inspect")
+        .arg("--remote")
+        .arg("https://github.com/ploys/repo-not-found")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Repository not found"));
 }


### PR DESCRIPTION
This adds basic support for inspecting remote GitHub repositories by using the GitHub API.

The aim of this project is to integrate with GitHub and other managed version control systems to automate project management, releases and deployments. The `inspect` command added in #2 was meant as the foundation for building out other features by providing a way to read the state of a project. The initial implementation of the command only supported local projects.

This updates the command to support an optional `remote` argument that can be used to specify a remote repository instead of the local one in the current working directory. This option supports either an `owner/repo` or a URL to query a GitHub repository.

Support for querying additional services such as GitLab should be added at a later date.