### PR TITLE
Add inspect command authentication token option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Test (${{ matrix.label }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -43,7 +45,9 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Test
-      run: cargo test --target ${{ matrix.target }}
+      run: cargo test --target ${{ matrix.target }} -- --include-ignored
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lint:
     name: Lint

--- a/packages/ploys-cli/Cargo.toml
+++ b/packages/ploys-cli/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.72"
-clap = { version = "4.3.21", features = ["derive"] }
+clap = { version = "4.3.21", features = ["derive", "env"] }
 console = "0.15.7"
 gix = "0.51.0"
 ureq = "2.7.1"


### PR DESCRIPTION
This adds an option to provide a GitHub authentication token to the `inspect` command.

The update to support remote repositories in #3 included several tests that query the GitHub API but they needed to be disabled due to limitations in actions workflows. These tests need to use an authentication token for requests so that they do not run into the API limits.

This introduces a new `token` option in the `inspect` command to provide a valid GitHub authentication token. This option defaults to looking for the `GITHUB_TOKEN` environment variable when no token is given.

This also restores the ignored tests in the continuous integration workflow by providing the authentication token as an environment variable. The tests should still work without a token on developer machines as long as the API limit has not been reached but the tests remain ignored so that they are opt-in. Additional authentication options should be provided to bypass this limitation in the future.