### PR TITLE
Add utility to load basic project information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,6 +1419,11 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 [[package]]
 name = "ploys"
 version = "0.0.0"
+dependencies = [
+ "gix",
+ "ureq",
+ "url",
+]
 
 [[package]]
 name = "ploys-cli"

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -7,3 +7,8 @@ homepage = "https://ploys.dev"
 repository = "https://github.com/ploys/ploys"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+
+[dependencies]
+gix = "0.51.0"
+ureq = "2.7.1"
+url = "2.4.0"

--- a/packages/ploys/src/lib.rs
+++ b/packages/ploys/src/lib.rs
@@ -1,1 +1,1 @@
-
+pub mod project;

--- a/packages/ploys/src/project/error.rs
+++ b/packages/ploys/src/project/error.rs
@@ -1,0 +1,33 @@
+use std::fmt::{self, Display};
+
+/// The project error.
+#[derive(Debug)]
+pub enum Error {
+    /// The local project error.
+    Local(super::local::Error),
+    /// The remote project error.
+    Remote(super::remote::Error),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Local(local) => Display::fmt(local, f),
+            Error::Remote(remote) => Display::fmt(remote, f),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<super::local::Error> for Error {
+    fn from(error: super::local::Error) -> Self {
+        Self::Local(error)
+    }
+}
+
+impl From<super::remote::Error> for Error {
+    fn from(error: super::remote::Error) -> Self {
+        Self::Remote(error)
+    }
+}

--- a/packages/ploys/src/project/local/error.rs
+++ b/packages/ploys/src/project/local/error.rs
@@ -1,0 +1,52 @@
+use std::fmt::{self, Display};
+use std::io;
+
+/// The local project error.
+#[derive(Debug)]
+pub enum Error {
+    /// A Git error.
+    Git(Box<gix::open::Error>),
+    /// A remote error.
+    Remote(Box<gix::remote::find::existing::Error>),
+    /// An I/O error.
+    Io(io::Error),
+}
+
+impl Error {
+    /// Creates a remote not found error.
+    pub(super) fn remote_not_found() -> Self {
+        Self::Remote(Box::new(gix::remote::find::existing::Error::NotFound {
+            name: String::from("origin").into(),
+        }))
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Git(error) => Display::fmt(error, f),
+            Self::Remote(error) => Display::fmt(error, f),
+            Self::Io(error) => Display::fmt(error, f),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<gix::open::Error> for Error {
+    fn from(error: gix::open::Error) -> Self {
+        Self::Git(Box::new(error))
+    }
+}
+
+impl From<gix::remote::find::existing::Error> for Error {
+    fn from(error: gix::remote::find::existing::Error) -> Self {
+        Self::Remote(Box::new(error))
+    }
+}

--- a/packages/ploys/src/project/local/mod.rs
+++ b/packages/ploys/src/project/local/mod.rs
@@ -1,0 +1,75 @@
+//! Local project inspection and management
+//!
+//! This module contains the utilities related to local project management. The
+//! [`Local`] type must be constructed via [`super::Project`].
+
+mod error;
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use gix::remote::Direction;
+use gix::Repository;
+use url::Url;
+
+pub use self::error::Error;
+
+/// A project on the local file system.
+#[derive(Clone, Debug)]
+pub struct Local {
+    repository: Repository,
+}
+
+impl Local {
+    /// Creates a local project.
+    pub(super) fn new<P>(path: P) -> Result<Self, Error>
+    where
+        P: AsRef<Path>,
+    {
+        Ok(Self {
+            repository: gix::open(path.as_ref())?,
+        })
+    }
+}
+
+impl Local {
+    /// Queries the project name.
+    pub fn get_name(&self) -> Result<String, Error> {
+        let path = self.repository.path().join("..").canonicalize()?;
+
+        if let Ok(readme) = fs::read_to_string(path.join("README.md")) {
+            if let Some(title) = readme.lines().find(|line| line.starts_with("# ")) {
+                return Ok(title[2..].to_string());
+            }
+        }
+
+        if let Some(file_stem) = path.file_stem() {
+            return Ok(file_stem.to_string_lossy().to_string());
+        }
+
+        Err(Error::Io(io::Error::new(
+            io::ErrorKind::Other,
+            "Invalid directory",
+        )))
+    }
+
+    /// Queries the project URL.
+    pub fn get_url(&self) -> Result<Url, Error> {
+        match self
+            .repository
+            .find_default_remote(Direction::Push)
+            .transpose()?
+        {
+            Some(remote) => match remote.url(Direction::Push) {
+                Some(url) => Ok(url
+                    .to_bstring()
+                    .to_string()
+                    .parse()
+                    .expect("A repository URL should be valid")),
+                None => Err(Error::remote_not_found()),
+            },
+            None => Err(Error::remote_not_found()),
+        }
+    }
+}

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -1,0 +1,152 @@
+//! Project inspection and management utilities
+//!
+//! This module includes utilities for inspecting and managing projects located
+//! on the local file system or in a remote version control system.
+//!
+//! ## Local
+//!
+//! To open a local project use the [`Project::local`] constructor and pass in
+//! a path to the project on the local file system. The target directory must be
+//! initialized as a Git repository.
+//!
+//! ```no_run
+//! use ploys::project::Project;
+//!
+//! let project = Project::local(".").unwrap();
+//!
+//! println!("Name:       {}", project.get_name().unwrap());
+//! println!("Repository: {}", project.get_url().unwrap());
+//! ```
+//!
+//! ## Remote
+//!
+//! To open a remote project use the [`Project::remote`] constructor and pass in
+//! a string in the `owner/repo` format. The target identifier must match an
+//! existing GitHub repository.
+//!
+//! ```no_run
+//! use ploys::project::Project;
+//!
+//! let project = Project::remote("ploys/ploys").unwrap();
+//!
+//! println!("Name:       {}", project.get_name().unwrap());
+//! println!("Repository: {}", project.get_url().unwrap());
+//! ```
+
+mod error;
+pub mod local;
+pub mod remote;
+
+use std::path::Path;
+
+use url::Url;
+
+pub use self::error::Error;
+use self::local::Local;
+use self::remote::Remote;
+
+/// A project that is either local or remote.
+#[derive(Clone, Debug)]
+pub enum Project {
+    /// A project on the local file system.
+    Local(Local),
+    /// A project in a remote version control system.
+    Remote(Remote),
+}
+
+impl Project {
+    /// Creates a local project.
+    pub fn local<P>(path: P) -> Result<Self, Error>
+    where
+        P: AsRef<Path>,
+    {
+        Ok(Self::Local(Local::new(path)?))
+    }
+
+    /// Checks if the project is local.
+    pub fn is_local(&self) -> bool {
+        match self {
+            Self::Local(_) => true,
+            Self::Remote(_) => false,
+        }
+    }
+
+    /// Gets the project as a local project.
+    pub fn as_local(&self) -> Option<&Local> {
+        match self {
+            Self::Local(local) => Some(local),
+            Self::Remote(_) => None,
+        }
+    }
+}
+
+impl Project {
+    /// Creates a remote project.
+    pub fn remote<R>(repository: R) -> Result<Self, Error>
+    where
+        R: AsRef<str>,
+    {
+        Ok(Self::Remote(Remote::new(repository)?.validated()?))
+    }
+
+    /// Creates a remote project with the given authentication token.
+    pub fn remote_with_authentication_token<R, T>(repository: R, token: T) -> Result<Self, Error>
+    where
+        R: AsRef<str>,
+        T: Into<String>,
+    {
+        Ok(Self::Remote(
+            Remote::new(repository)?
+                .with_authentication_token(token)
+                .validated()?,
+        ))
+    }
+
+    /// Checks if the project is remote.
+    pub fn is_remote(&self) -> bool {
+        match self {
+            Self::Local(_) => false,
+            Self::Remote(_) => true,
+        }
+    }
+
+    /// Gets the project as a remote project.
+    pub fn as_remote(&self) -> Option<&Remote> {
+        match self {
+            Self::Local(_) => None,
+            Self::Remote(remote) => Some(remote),
+        }
+    }
+
+    /// Converts the project into a remote.
+    pub fn try_into_remote(self) -> Result<Self, Error> {
+        match self {
+            Self::Local(local) => Ok(Self::Remote(local.try_into()?)),
+            Self::Remote(remote) => Ok(Self::Remote(remote)),
+        }
+    }
+}
+
+impl Project {
+    /// Queries the project name.
+    ///
+    /// This method may perform file system operations or network requests to
+    /// query the latest project information.
+    pub fn get_name(&self) -> Result<String, Error> {
+        match self {
+            Self::Local(local) => Ok(local.get_name()?),
+            Self::Remote(remote) => Ok(remote.get_name()?),
+        }
+    }
+
+    /// Queries the project URL.
+    ///
+    /// This method may perform file system operations or network requests to
+    /// query the latest project information.
+    pub fn get_url(&self) -> Result<Url, Error> {
+        match self {
+            Self::Local(local) => Ok(local.get_url()?),
+            Self::Remote(remote) => Ok(remote.get_url()?),
+        }
+    }
+}

--- a/packages/ploys/src/project/remote/error.rs
+++ b/packages/ploys/src/project/remote/error.rs
@@ -1,0 +1,39 @@
+use std::fmt::{self, Display};
+
+/// The remote project error.
+#[derive(Debug)]
+pub enum Error {
+    /// An HTTP status response.
+    Response(u16),
+    /// A transport error.
+    Transport(Box<ureq::Transport>),
+    /// A parse error.
+    Parse(String),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Response(status_code) => match status_code {
+                401 => write!(f, "401 Unauthorized"),
+                403 => write!(f, "403 Forbidden"),
+                404 => write!(f, "404 Not Found"),
+                429 => write!(f, "429 Too Many Requests"),
+                status_code => write!(f, "Response error: {status_code}"),
+            },
+            Error::Transport(transport) => Display::fmt(transport, f),
+            Error::Parse(message) => write!(f, "Parse error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<ureq::Error> for Error {
+    fn from(error: ureq::Error) -> Self {
+        match error {
+            ureq::Error::Status(status_code, _) => Self::Response(status_code),
+            ureq::Error::Transport(transport) => Self::Transport(Box::new(transport)),
+        }
+    }
+}

--- a/packages/ploys/src/project/remote/mod.rs
+++ b/packages/ploys/src/project/remote/mod.rs
@@ -1,0 +1,104 @@
+//! Remote project inspection and management
+//!
+//! This module contains the utilities related to remote project management. The
+//! [`Remote`] type must be constructed via [`super::Project`].
+
+mod error;
+mod repo;
+
+use url::Url;
+
+pub use self::error::Error;
+pub use self::repo::Repository;
+
+use super::local::Local;
+
+/// A project in a remote version control system.
+#[derive(Clone, Debug)]
+pub struct Remote {
+    repository: Repository,
+    token: Option<String>,
+}
+
+impl Remote {
+    /// Creates a remote project.
+    pub(super) fn new<R>(repository: R) -> Result<Self, Error>
+    where
+        R: AsRef<str>,
+    {
+        Ok(Self {
+            repository: repository.as_ref().parse::<Repository>()?,
+            token: None,
+        })
+    }
+
+    /// Builds the project with the given authentication token.
+    pub(super) fn with_authentication_token(mut self, token: impl Into<String>) -> Self {
+        self.token = Some(token.into());
+        self
+    }
+
+    /// Builds the project with validation to ensure it exists.
+    pub(super) fn validated(self) -> Result<Self, Error> {
+        self.repository.validate(self.token.as_deref())?;
+
+        Ok(self)
+    }
+}
+
+impl Remote {
+    /// Queries the project name.
+    pub fn get_name(&self) -> Result<String, Error> {
+        let request = self
+            .repository
+            .get("/readme", self.token.as_deref())
+            .set("Accept", "application/vnd.github.raw");
+
+        if let Ok(response) = request.call() {
+            if let Ok(readme) = response.into_string() {
+                if let Some(title) = readme.lines().find(|line| line.starts_with("# ")) {
+                    return Ok(title[2..].to_string());
+                }
+            }
+        }
+
+        Ok(self.repository.to_string())
+    }
+
+    /// Queries the project URL.
+    pub fn get_url(&self) -> Result<Url, Error> {
+        Ok(format!("https://github.com/{}", self.repository)
+            .parse()
+            .unwrap())
+    }
+}
+
+impl TryFrom<Local> for Remote {
+    type Error = super::Error;
+
+    fn try_from(local: Local) -> Result<Self, Self::Error> {
+        Ok(Self::new(local.get_url()?)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Error, Remote};
+
+    #[test]
+    fn test_remote_constructor() {
+        assert!(Remote::new("ploys/ploys").is_ok());
+        assert!(Remote::new("rust-lang/rust").is_ok());
+        assert!(Remote::new("one/two/three").is_err());
+    }
+
+    #[test]
+    fn test_remote_url() -> Result<(), Error> {
+        assert_eq!(
+            Remote::new("ploys/ploys")?.get_url()?,
+            "https://github.com/ploys/ploys".parse().unwrap()
+        );
+
+        Ok(())
+    }
+}

--- a/packages/ploys/src/project/remote/repo.rs
+++ b/packages/ploys/src/project/remote/repo.rs
@@ -1,0 +1,107 @@
+use std::fmt::{self, Display};
+use std::str::FromStr;
+
+use ureq::Request;
+
+use super::Error;
+
+/// The remote repository information.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Repository {
+    owner: String,
+    repo: String,
+}
+
+impl Repository {
+    /// Validates whether the remote repository exists.
+    pub(super) fn validate(&self, token: Option<&str>) -> Result<(), Error> {
+        self.head("", token).call()?;
+
+        Ok(())
+    }
+}
+
+impl Repository {
+    /// Gets the API endpoint.
+    pub(super) fn endpoint<P>(&self, path: P) -> String
+    where
+        P: AsRef<str>,
+    {
+        match path.as_ref() {
+            "" => format!("https://api.github.com/repos/{}", self),
+            path => format!(
+                "https://api.github.com/repos/{}/{}",
+                self,
+                path.trim_start_matches('/')
+            ),
+        }
+    }
+
+    /// Creates a HTTP request.
+    pub(super) fn request<P>(&self, method: &str, path: P, token: Option<&str>) -> Request
+    where
+        P: AsRef<str>,
+    {
+        let mut request =
+            ureq::request(method, &self.endpoint(path)).set("User-Agent", "ploys/ploys");
+
+        if let Some(token) = &token {
+            request = request.set("Authorization", &format!("Bearer {token}"));
+        }
+
+        request
+    }
+
+    /// Creates a HEAD request.
+    pub(super) fn head<P>(&self, path: P, token: Option<&str>) -> Request
+    where
+        P: AsRef<str>,
+    {
+        self.request("HEAD", path, token)
+    }
+
+    /// Creates a GET request.
+    pub(super) fn get<P>(&self, path: P, token: Option<&str>) -> Request
+    where
+        P: AsRef<str>,
+    {
+        self.request("GET", path, token)
+    }
+}
+
+impl Display for Repository {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.owner, self.repo)?;
+
+        Ok(())
+    }
+}
+
+impl FromStr for Repository {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.split_once('/') {
+            Some((owner, repo)) => match repo.contains('/') {
+                true => Err(Error::Parse(format!("Invalid repository format `{s}`"))),
+                false => Ok(Self {
+                    owner: owner.to_string(),
+                    repo: repo.to_string(),
+                }),
+            },
+            None => Err(Error::Parse(format!("Invalid repository format `{s}`"))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Repository;
+
+    #[test]
+    fn test_repository_parser() {
+        assert!("ploys/ploys".parse::<Repository>().is_ok());
+        assert!("rust-lang/rust".parse::<Repository>().is_ok());
+        assert!("one/two/three".parse::<Repository>().is_err());
+    }
+}

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -16,7 +16,10 @@ fn test_valid_local_project() -> Result<(), Error> {
 #[test]
 #[ignore]
 fn test_valid_remote_project() -> Result<(), Error> {
-    let project = Project::remote("ploys/ploys")?;
+    let project = match std::env::var("GITHUB_TOKEN").ok() {
+        Some(token) => Project::remote_with_authentication_token("ploys/ploys", token)?,
+        None => Project::remote("ploys/ploys")?
+    };
 
     assert_eq!(project.get_name()?, "ploys");
     assert_eq!(

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -1,0 +1,29 @@
+use ploys::project::{Error, Project};
+
+#[test]
+#[ignore]
+fn test_valid_local_project() -> Result<(), Error> {
+    let project = Project::local("../..")?;
+
+    assert_eq!(project.get_name()?, "ploys");
+    assert_eq!(
+        project.get_url()?,
+        "https://github.com/ploys/ploys.git".parse().unwrap()
+    );
+
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn test_valid_remote_project() -> Result<(), Error> {
+    let project = Project::remote("ploys/ploys")?;
+
+    assert_eq!(project.get_name()?, "ploys");
+    assert_eq!(
+        project.get_url()?,
+        "https://github.com/ploys/ploys".parse().unwrap()
+    );
+
+    Ok(())
+}

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -18,7 +18,7 @@ fn test_valid_local_project() -> Result<(), Error> {
 fn test_valid_remote_project() -> Result<(), Error> {
     let project = match std::env::var("GITHUB_TOKEN").ok() {
         Some(token) => Project::remote_with_authentication_token("ploys/ploys", token)?,
-        None => Project::remote("ploys/ploys")?
+        None => Project::remote("ploys/ploys")?,
     };
 
     assert_eq!(project.get_name()?, "ploys");

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -4,12 +4,11 @@ use ploys::project::{Error, Project};
 #[ignore]
 fn test_valid_local_project() -> Result<(), Error> {
     let project = Project::local("../..")?;
+    let url = project.get_url()?;
 
     assert_eq!(project.get_name()?, "ploys");
-    assert_eq!(
-        project.get_url()?,
-        "https://github.com/ploys/ploys.git".parse().unwrap()
-    );
+    assert_eq!(url.domain(), Some("github.com"));
+    assert_eq!(url.path().trim_end_matches(".git"), "/ploys/ploys");
 
     Ok(())
 }


### PR DESCRIPTION
This adds a utility to load basic information from both local and remote projects.

The command added in #2 was used to inspect basic project information for local repositories and that was expanded in #3 with the ability to inspect remote repositories. The logic to do so was included in the binary but it would be useful to extract it out into a library so that it can be used across multiple crates.

This extracts out the handling of local and remote projects to the library crate with documentation, tests and improved error handling. The logic has been divided into more manageable functions that can be used by future functionality without major refactoring. Some functions and methods have been kept private so that the library does not commit to a specific API.