### PR TITLE
Refactor inspect command to use library utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,9 +1433,8 @@ dependencies = [
  "assert_cmd",
  "clap",
  "console",
- "gix",
+ "ploys",
  "predicates",
- "ureq",
  "url",
 ]
 

--- a/packages/ploys-cli/Cargo.toml
+++ b/packages/ploys-cli/Cargo.toml
@@ -12,8 +12,7 @@ edition = "2021"
 anyhow = "1.0.72"
 clap = { version = "4.3.21", features = ["derive", "env"] }
 console = "0.15.7"
-gix = "0.51.0"
-ureq = "2.7.1"
+ploys = { path = "../ploys" }
 url = "2.4.0"
 
 [dev-dependencies]

--- a/packages/ploys-cli/src/command/inspect.rs
+++ b/packages/ploys-cli/src/command/inspect.rs
@@ -1,13 +1,10 @@
-use std::env;
-use std::fmt::{self, Display};
-use std::fs;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Error};
 use clap::Args;
 use console::style;
-use gix::remote::Direction;
-use gix::Repository;
+use ploys::project::remote::Repository;
+use ploys::project::Project;
 use url::Url;
 
 /// Inspects the project.
@@ -26,35 +23,56 @@ impl Inspect {
     /// Executes the command.
     pub fn exec(self) -> Result<(), Error> {
         let project = match self.remote {
-            Some(remote) => Project::remote(remote, self.token.as_deref())?,
-            None => Project::local(gix::open(".")?)?,
+            Some(remote) => match self.token {
+                Some(token) => Project::remote_with_authentication_token(
+                    remote.try_into_repo()?.to_string(),
+                    token,
+                )?,
+                None => Project::remote(remote.try_into_repo()?.to_string())?,
+            },
+            None => Project::local(".")?,
         };
 
-        println!("{project}");
+        println!("{}:\n", style("Project").underlined().bold());
+        println!("Name:       {}", project.get_name()?);
+        println!("Repository: {}", project.get_url()?);
 
         Ok(())
     }
 }
 
-/// The project information.
-struct Project {
-    name: String,
-    repo: Option<String>,
+#[derive(Clone)]
+enum RepoOrUrl {
+    Repo(Repository),
+    Url(Url),
 }
 
-impl Project {
-    /// Loads the project information from the local repository.
-    fn local(repository: Repository) -> Result<Self, Error> {
-        Ok(Self {
-            name: Self::query_local_project_name()?,
-            repo: Self::query_repository_url(&repository)?,
-        })
+impl RepoOrUrl {
+    fn try_into_repo(self) -> Result<Repository, Error> {
+        self.try_into()
     }
+}
 
-    /// Loads the project information from the remote repository.
-    fn remote(remote: RepoOrUrl, token: Option<&str>) -> Result<Self, Error> {
-        let repo = match remote {
-            RepoOrUrl::Repo(repo) => repo,
+impl FromStr for RepoOrUrl {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.parse::<Repository>() {
+            Ok(repo) => Ok(Self::Repo(repo)),
+            Err(_) => match s.parse::<Url>() {
+                Ok(url) => Ok(Self::Url(url)),
+                Err(_) => Err(anyhow!("Expected owner/repo or URL, found: {}", s)),
+            },
+        }
+    }
+}
+
+impl TryFrom<RepoOrUrl> for Repository {
+    type Error = Error;
+
+    fn try_from(value: RepoOrUrl) -> Result<Self, Self::Error> {
+        match value {
+            RepoOrUrl::Repo(repo) => Ok(repo),
             RepoOrUrl::Url(url) => {
                 if url.domain() != Some("github.com") {
                     return Err(anyhow!(
@@ -62,150 +80,12 @@ impl Project {
                     ));
                 }
 
-                url.path()
+                Ok(url
+                    .path()
                     .trim_start_matches('/')
                     .trim_end_matches(".git")
-                    .parse::<Repo>()?
+                    .parse::<Repository>()?)
             }
-        };
-
-        Self::query_remote_repository(&repo, token)?;
-
-        Ok(Self {
-            name: Self::query_remote_project_name(&repo, token),
-            repo: Some(format!("https://github.com/{}", repo)),
-        })
-    }
-
-    /// Queries the local project name.
-    fn query_local_project_name() -> Result<String, Error> {
-        if let Ok(readme) = fs::read_to_string("README.md") {
-            if let Some(title) = readme.lines().find(|line| line.starts_with("# ")) {
-                return Ok(title[2..].to_string());
-            }
-        }
-
-        if let Some(file_stem) = env::current_dir()?.canonicalize()?.file_stem() {
-            return Ok(file_stem.to_string_lossy().to_string());
-        }
-
-        Err(anyhow!("Invalid project information"))
-    }
-
-    /// Queries the remote repository to check that it exists.
-    fn query_remote_repository(repo: &Repo, token: Option<&str>) -> Result<(), Error> {
-        let url = format!("https://api.github.com/repos/{}", repo);
-        let mut request = ureq::head(&url).set("User-Agent", "ploys/ploys");
-
-        if let Some(token) = token {
-            request = request.set("Authorization", &format!("Bearer {token}"));
-        }
-
-        match request.call() {
-            Ok(_) => Ok(()),
-            Err(ureq::Error::Status(404, _)) => Err(anyhow!("Repository not found")),
-            Err(err) => Err(err.into()),
-        }
-    }
-
-    /// Queries the remote repository name.
-    fn query_remote_project_name(repo: &Repo, token: Option<&str>) -> String {
-        let url = format!("https://api.github.com/repos/{}/readme", repo);
-        let mut request = ureq::get(&url)
-            .set("User-Agent", "ploys/ploys")
-            .set("Accept", "application/vnd.github.raw");
-
-        if let Some(token) = token {
-            request = request.set("Authorization", &format!("Bearer {token}"));
-        }
-
-        if let Ok(response) = request.call() {
-            if let Ok(readme) = response.into_string() {
-                if let Some(title) = readme.lines().find(|line| line.starts_with("# ")) {
-                    return title[2..].to_string();
-                }
-            }
-        }
-
-        repo.repo.clone()
-    }
-
-    /// Queries the repository URL.
-    fn query_repository_url(repository: &Repository) -> Result<Option<String>, Error> {
-        if let Some(remote) = repository
-            .find_default_remote(Direction::Push)
-            .transpose()?
-        {
-            if let Some(url) = remote.url(Direction::Push) {
-                return Ok(Some(url.to_bstring().to_string()));
-            }
-        }
-
-        Ok(None)
-    }
-}
-
-impl Display for Project {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "{}:\n", style("Project").underlined().bold())?;
-        writeln!(f, "Name:       {}", self.name)?;
-        writeln!(
-            f,
-            "Repository: {}",
-            self.repo.as_deref().unwrap_or_default()
-        )?;
-
-        Ok(())
-    }
-}
-
-#[derive(Clone)]
-struct Repo {
-    owner: String,
-    repo: String,
-}
-
-impl Display for Repo {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}/{}", self.owner, self.repo)?;
-
-        Ok(())
-    }
-}
-
-impl FromStr for Repo {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.split_once('/') {
-            Some((owner, repo)) => match repo.contains('/') {
-                true => Err(anyhow!("Expected owner/repo, found: {}", s)),
-                false => Ok(Self {
-                    owner: owner.to_string(),
-                    repo: repo.to_string(),
-                }),
-            },
-            None => Err(anyhow!("Expected owner/repo, found: {}", s)),
-        }
-    }
-}
-
-#[derive(Clone)]
-enum RepoOrUrl {
-    Repo(Repo),
-    Url(Url),
-}
-
-impl FromStr for RepoOrUrl {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.parse::<Repo>() {
-            Ok(repo) => Ok(Self::Repo(repo)),
-            Err(_) => match s.parse::<Url>() {
-                Ok(url) => Ok(Self::Url(url)),
-                Err(_) => Err(anyhow!("Expected owner/repo or URL, found: {}", s)),
-            },
         }
     }
 }

--- a/packages/ploys-cli/tests/inspect.rs
+++ b/packages/ploys-cli/tests/inspect.rs
@@ -64,5 +64,5 @@ fn test_inspect_remote_url_command_output() {
         .arg("https://github.com/ploys/repo-not-found")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Repository not found"));
+        .stderr(predicate::str::contains("Not Found"));
 }


### PR DESCRIPTION
This refactors the inspect command to use the newly added library utility.

The utility added in #5 included the ability to get basic project information from both local and remote repositories. That update purposefully did not include changes made to the command line interface to reduce the scope of an already fairly large pull request.

This replaces the old code to inspect repositories such that the command line interface is a wrapper around the library.