### PR TITLE
Combine local project Git error variants

### DIFF
--- a/packages/ploys/src/project/local/error.rs
+++ b/packages/ploys/src/project/local/error.rs
@@ -5,9 +5,7 @@ use std::io;
 #[derive(Debug)]
 pub enum Error {
     /// A Git error.
-    Git(Box<gix::open::Error>),
-    /// A remote error.
-    Remote(Box<gix::remote::find::existing::Error>),
+    Git(GitError),
     /// An I/O error.
     Io(io::Error),
 }
@@ -15,9 +13,11 @@ pub enum Error {
 impl Error {
     /// Creates a remote not found error.
     pub(super) fn remote_not_found() -> Self {
-        Self::Remote(Box::new(gix::remote::find::existing::Error::NotFound {
-            name: String::from("origin").into(),
-        }))
+        Self::Git(GitError::Remote(Box::new(
+            gix::remote::find::existing::Error::NotFound {
+                name: String::from("origin").into(),
+            },
+        )))
     }
 }
 
@@ -25,7 +25,6 @@ impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Git(error) => Display::fmt(error, f),
-            Self::Remote(error) => Display::fmt(error, f),
             Self::Io(error) => Display::fmt(error, f),
         }
     }
@@ -41,11 +40,43 @@ impl From<std::io::Error> for Error {
 
 impl From<gix::open::Error> for Error {
     fn from(error: gix::open::Error) -> Self {
-        Self::Git(Box::new(error))
+        Self::Git(error.into())
     }
 }
 
 impl From<gix::remote::find::existing::Error> for Error {
+    fn from(error: gix::remote::find::existing::Error) -> Self {
+        Self::Git(error.into())
+    }
+}
+
+/// A Git error.
+#[derive(Debug)]
+pub enum GitError {
+    /// An open error.
+    Open(Box<gix::open::Error>),
+    /// A remote lookup error.
+    Remote(Box<gix::remote::find::existing::Error>),
+}
+
+impl Display for GitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Open(err) => Display::fmt(err, f),
+            Self::Remote(err) => Display::fmt(err, f),
+        }
+    }
+}
+
+impl std::error::Error for GitError {}
+
+impl From<gix::open::Error> for GitError {
+    fn from(error: gix::open::Error) -> Self {
+        Self::Open(Box::new(error))
+    }
+}
+
+impl From<gix::remote::find::existing::Error> for GitError {
     fn from(error: gix::remote::find::existing::Error) -> Self {
         Self::Remote(Box::new(error))
     }

--- a/packages/ploys/src/project/local/mod.rs
+++ b/packages/ploys/src/project/local/mod.rs
@@ -13,7 +13,7 @@ use gix::remote::Direction;
 use gix::Repository;
 use url::Url;
 
-pub use self::error::Error;
+pub use self::error::{Error, GitError};
 
 /// A project on the local file system.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This combines the Git error variants for local projects under a new `GitError` type.

The local project uses the `gix` library to interact with the local Git repository. This crate exports a number of different errors for reasons why Git operations can fail. There does not appear to be a central error type that contains each of the other errors so the code had to treat each error as a separate variant. However, there is a need to support other Git errors which would significantly increase the number of error variants to handle.

This separates out the existing Git error variants into a new enum so that all Git operation errors can be contained in a single type. This simplifies code needing to handle errors without needing to know Git specifics.