### PR TITLE
Add method to query project files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,6 +1421,7 @@ name = "ploys"
 version = "0.0.0"
 dependencies = [
  "gix",
+ "serde",
  "ureq",
  "url",
 ]
@@ -1618,6 +1619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,9 +1651,34 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sha1_smol"
@@ -1852,6 +1884,8 @@ dependencies = [
  "once_cell",
  "rustls",
  "rustls-webpki 0.100.1",
+ "serde",
+ "serde_json",
  "url",
  "webpki-roots",
 ]

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -10,5 +10,6 @@ edition = "2021"
 
 [dependencies]
 gix = "0.51.0"
-ureq = "2.7.1"
+serde = { version = "1.0.185", features = ["derive"] }
+ureq = { version = "2.7.1", features = ["json"] }
 url = "2.4.0"

--- a/packages/ploys/src/project/local/error.rs
+++ b/packages/ploys/src/project/local/error.rs
@@ -50,6 +50,30 @@ impl From<gix::remote::find::existing::Error> for Error {
     }
 }
 
+impl From<gix::revision::spec::parse::single::Error> for Error {
+    fn from(error: gix::revision::spec::parse::single::Error) -> Self {
+        Self::Git(error.into())
+    }
+}
+
+impl From<gix::odb::find::existing::Error<gix::odb::store::find::Error>> for Error {
+    fn from(error: gix::odb::find::existing::Error<gix::odb::store::find::Error>) -> Self {
+        Self::Git(error.into())
+    }
+}
+
+impl From<gix::object::peel::to_kind::Error> for Error {
+    fn from(error: gix::object::peel::to_kind::Error) -> Self {
+        Self::Git(error.into())
+    }
+}
+
+impl From<gix::traverse::tree::breadthfirst::Error> for Error {
+    fn from(error: gix::traverse::tree::breadthfirst::Error) -> Self {
+        Self::Git(error.into())
+    }
+}
+
 /// A Git error.
 #[derive(Debug)]
 pub enum GitError {
@@ -57,6 +81,14 @@ pub enum GitError {
     Open(Box<gix::open::Error>),
     /// A remote lookup error.
     Remote(Box<gix::remote::find::existing::Error>),
+    /// A revision parse error.
+    Revision(Box<gix::revision::spec::parse::single::Error>),
+    /// An object find error.
+    ObjectFind(Box<gix::odb::find::existing::Error<gix::odb::store::find::Error>>),
+    /// An object kind error.
+    ObjectKind(Box<gix::object::peel::to_kind::Error>),
+    /// A tree traversal error.
+    Traverse(Box<gix::traverse::tree::breadthfirst::Error>),
 }
 
 impl Display for GitError {
@@ -64,6 +96,10 @@ impl Display for GitError {
         match self {
             Self::Open(err) => Display::fmt(err, f),
             Self::Remote(err) => Display::fmt(err, f),
+            Self::Revision(err) => Display::fmt(err, f),
+            Self::ObjectFind(err) => Display::fmt(err, f),
+            Self::ObjectKind(err) => Display::fmt(err, f),
+            Self::Traverse(err) => Display::fmt(err, f),
         }
     }
 }
@@ -79,5 +115,29 @@ impl From<gix::open::Error> for GitError {
 impl From<gix::remote::find::existing::Error> for GitError {
     fn from(error: gix::remote::find::existing::Error) -> Self {
         Self::Remote(Box::new(error))
+    }
+}
+
+impl From<gix::revision::spec::parse::single::Error> for GitError {
+    fn from(error: gix::revision::spec::parse::single::Error) -> Self {
+        Self::Revision(Box::new(error))
+    }
+}
+
+impl From<gix::odb::find::existing::Error<gix::odb::store::find::Error>> for GitError {
+    fn from(error: gix::odb::find::existing::Error<gix::odb::store::find::Error>) -> Self {
+        Self::ObjectFind(Box::new(error))
+    }
+}
+
+impl From<gix::object::peel::to_kind::Error> for GitError {
+    fn from(error: gix::object::peel::to_kind::Error) -> Self {
+        Self::ObjectKind(Box::new(error))
+    }
+}
+
+impl From<gix::traverse::tree::breadthfirst::Error> for GitError {
+    fn from(error: gix::traverse::tree::breadthfirst::Error) -> Self {
+        Self::Traverse(Box::new(error))
     }
 }

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -37,7 +37,7 @@ mod error;
 pub mod local;
 pub mod remote;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use url::Url;
 
@@ -147,6 +147,17 @@ impl Project {
         match self {
             Self::Local(local) => Ok(local.get_url()?),
             Self::Remote(remote) => Ok(remote.get_url()?),
+        }
+    }
+
+    /// Queries the project files.
+    ///
+    /// This method may perform file system operations or network requests to
+    /// query the latest project information.
+    pub fn get_files(&self) -> Result<Vec<PathBuf>, Error> {
+        match self {
+            Self::Local(local) => Ok(local.get_files()?),
+            Self::Remote(remote) => Ok(remote.get_files()?),
         }
     }
 }

--- a/packages/ploys/src/project/remote/error.rs
+++ b/packages/ploys/src/project/remote/error.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Display};
+use std::io;
 
 /// The remote project error.
 #[derive(Debug)]
@@ -9,6 +10,8 @@ pub enum Error {
     Transport(Box<ureq::Transport>),
     /// A parse error.
     Parse(String),
+    /// An I/O error.
+    Io(io::Error),
 }
 
 impl Display for Error {
@@ -23,11 +26,18 @@ impl Display for Error {
             },
             Error::Transport(transport) => Display::fmt(transport, f),
             Error::Parse(message) => write!(f, "Parse error: {message}"),
+            Error::Io(err) => Display::fmt(err, f),
         }
     }
 }
 
 impl std::error::Error for Error {}
+
+impl From<io::Error> for Error {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
 
 impl From<ureq::Error> for Error {
     fn from(error: ureq::Error) -> Self {

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use ploys::project::{Error, Project};
 
 #[test]
@@ -9,6 +11,12 @@ fn test_valid_local_project() -> Result<(), Error> {
     assert_eq!(project.get_name()?, "ploys");
     assert_eq!(url.domain(), Some("github.com"));
     assert_eq!(url.path().trim_end_matches(".git"), "/ploys/ploys");
+
+    let files = project.get_files()?;
+
+    assert!(files.contains(&PathBuf::from("Cargo.toml")));
+    assert!(files.contains(&PathBuf::from("packages/ploys/Cargo.toml")));
+    assert!(files.contains(&PathBuf::from("packages/ploys-cli/Cargo.toml")));
 
     Ok(())
 }
@@ -26,6 +34,12 @@ fn test_valid_remote_project() -> Result<(), Error> {
         project.get_url()?,
         "https://github.com/ploys/ploys".parse().unwrap()
     );
+
+    let files = project.get_files()?;
+
+    assert!(files.contains(&PathBuf::from("Cargo.toml")));
+    assert!(files.contains(&PathBuf::from("packages/ploys/Cargo.toml")));
+    assert!(files.contains(&PathBuf::from("packages/ploys-cli/Cargo.toml")));
 
     Ok(())
 }


### PR DESCRIPTION
This adds a new method to the various project types that queries the project files.

The short-term goal of this project is to be able to create releases of specific packages by triggering a GitHub Actions workflow. This will facilitate further development of the project by allowing itself and its dependencies to be released through an Actions workflow. However, there is a complication when it comes to remote projects as the existing tools to inspect packages only work with the local file system. For example, `cargo` uses the `glob` crate to expand workspace member paths from a pattern. This approach does not work for remote repositories without creating a bespoke glob implementation.

This adds a method that builds a list of project files so that a future update can use the alternative `globset` crate to expand workspace members using a known list of files instead of having to query the GitHub API for each directory. The implementation makes use of the git trees API that exists within the `gix` crate and as a GitHub API endpoint.