### PR TITLE
Add method to get project file content

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -160,4 +160,18 @@ impl Project {
             Self::Remote(remote) => Ok(remote.get_files()?),
         }
     }
+
+    /// Queries the contents of a project file.
+    ///
+    /// This method may perform file system operations or network requests to
+    /// query the latest project information.
+    pub fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Error>
+    where
+        P: AsRef<Path>,
+    {
+        match self {
+            Self::Local(local) => Ok(local.get_file_contents(path)?),
+            Self::Remote(remote) => Ok(remote.get_file_contents(path)?),
+        }
+    }
 }

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -18,6 +18,13 @@ fn test_valid_local_project() -> Result<(), Error> {
     assert!(files.contains(&PathBuf::from("packages/ploys/Cargo.toml")));
     assert!(files.contains(&PathBuf::from("packages/ploys-cli/Cargo.toml")));
 
+    let a = String::from_utf8(project.get_file_contents("Cargo.toml")?).unwrap();
+    let b = String::from_utf8(project.get_file_contents("packages/ploys/Cargo.toml")?).unwrap();
+
+    assert!(a.contains("[workspace]"));
+    assert!(b.contains("[package]"));
+    assert!(project.get_file_contents("packages/ploys").is_err());
+
     Ok(())
 }
 
@@ -40,6 +47,13 @@ fn test_valid_remote_project() -> Result<(), Error> {
     assert!(files.contains(&PathBuf::from("Cargo.toml")));
     assert!(files.contains(&PathBuf::from("packages/ploys/Cargo.toml")));
     assert!(files.contains(&PathBuf::from("packages/ploys-cli/Cargo.toml")));
+
+    let a = String::from_utf8(project.get_file_contents("Cargo.toml")?).unwrap();
+    let b = String::from_utf8(project.get_file_contents("packages/ploys/Cargo.toml")?).unwrap();
+
+    assert!(a.contains("[workspace]"));
+    assert!(b.contains("[package]"));
+    assert!(project.get_file_contents("packages/ploys").is_err());
 
     Ok(())
 }


### PR DESCRIPTION
This adds a new method to the various project types that gets the contents of a file.

A method to query file paths was introduced in #8 to facilitate the use of the `globset` crate to match files without traversing the directory structure. This change did not include any way to get file contents so the paths that it generates are not very helpful.

This adds a method to get the file contents for the given path by using the local repository or GitHub API. The logic and error handling has not yet been perfected but this provides the basic functionality of retrieving files. Directories have been excluded because both local and remote return different responses whereas the file contents should be the same.

The local repository is used instead of the local file system to ensure that only committed files can be retrieved and uncommitted changes are not reflected. This may pose a problem in the future but a separate project variant may be introduced for using the file system directly. Similarly an improvement may be made in the future to support querying directories in a common way.