### PR TITLE
Add package discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
 
 [[package]]
+name = "cargo_toml"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a1f1117a8ff2f3547295da90f473c392d8d1107c90cea1ea82b1a544a97a4a"
+dependencies = [
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +448,12 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -1136,6 +1158,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1233,16 @@ checksum = "e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8"
 dependencies = [
  "ahash",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -1420,7 +1465,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 name = "ploys"
 version = "0.0.0"
 dependencies = [
+ "cargo_toml",
  "gix",
+ "globset",
  "serde",
  "ureq",
  "url",
@@ -1681,6 +1728,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +1879,40 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c226a7bba6d859b63c92c4b4fe69c5b6b72d0cb897dbc8e6012298e6154cb56e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff63e60a958cefbb518ae1fd6566af80d9d4be430a33f3723dfc47d1d411d95"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
 
 [[package]]
 name = "uluru"

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -9,7 +9,9 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
+cargo_toml = "0.16.2"
 gix = "0.51.0"
+globset = "0.4.13"
 serde = { version = "1.0.185", features = ["derive"] }
 ureq = { version = "2.7.1", features = ["json"] }
 url = "2.4.0"

--- a/packages/ploys/src/lib.rs
+++ b/packages/ploys/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod package;
 pub mod project;

--- a/packages/ploys/src/package/cargo/error.rs
+++ b/packages/ploys/src/package/cargo/error.rs
@@ -1,0 +1,33 @@
+use std::fmt::{self, Display};
+
+/// A cargo package error.
+#[derive(Debug)]
+pub enum Error {
+    /// A glob error.
+    Glob(globset::Error),
+    /// A manifest error.
+    Manifest(cargo_toml::Error),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Glob(err) => Display::fmt(err, f),
+            Self::Manifest(err) => Display::fmt(err, f),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<globset::Error> for Error {
+    fn from(err: globset::Error) -> Self {
+        Self::Glob(err)
+    }
+}
+
+impl From<cargo_toml::Error> for Error {
+    fn from(err: cargo_toml::Error) -> Self {
+        Self::Manifest(err)
+    }
+}

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -1,0 +1,69 @@
+use std::path::PathBuf;
+
+use cargo_toml::{Dependency, Manifest as CargoToml};
+use globset::{Glob, GlobSetBuilder};
+
+use crate::package::members::Members;
+
+use super::error::Error;
+use super::Cargo;
+
+/// The cargo package manifest.
+#[derive(Debug)]
+pub struct Manifest(CargoToml);
+
+impl Manifest {
+    /// Gets the inner manifest.
+    pub fn inner(&self) -> &CargoToml {
+        &self.0
+    }
+
+    /// Gets the workspace members.
+    ///
+    /// This follows the [members and exclude fields](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-members-and-exclude-fields)
+    /// documentation to build a list of included and excluded members.
+    pub fn members(&self) -> Result<Members, Error> {
+        let mut includes = GlobSetBuilder::new();
+        let mut excludes = Vec::new();
+
+        if let Some(workspace) = &self.0.workspace {
+            for member in &workspace.members {
+                includes.add(Glob::new(member.trim_start_matches("./"))?);
+            }
+
+            for path in &workspace.exclude {
+                excludes.push(PathBuf::from(path));
+            }
+        }
+
+        let dependencies = self
+            .0
+            .dependencies
+            .values()
+            .chain(self.0.dev_dependencies.values())
+            .chain(self.0.build_dependencies.values());
+
+        for dependency in dependencies {
+            if let Dependency::Detailed(dependency) = dependency {
+                if let Some(path) = &dependency.path {
+                    includes.add(Glob::new(path.trim_start_matches("./"))?);
+                }
+            }
+        }
+
+        Ok(Members::new(includes.build()?, excludes))
+    }
+
+    /// Creates a manifest from the given bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        Ok(Self(CargoToml::from_slice(bytes)?))
+    }
+
+    /// Converts this manifest into a package with the given path.
+    pub fn into_package(self, path: PathBuf) -> Option<Cargo> {
+        match self.0.package.is_some() {
+            true => Some(Cargo::new(self, path)),
+            false => None,
+        }
+    }
+}

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -1,0 +1,42 @@
+//! The `Cargo.toml` package for Rust.
+
+mod error;
+pub(super) mod manifest;
+
+use std::path::{Path, PathBuf};
+
+pub use self::error::Error;
+use self::manifest::Manifest;
+
+/// A `Cargo.toml` package for Rust.
+pub struct Cargo {
+    manifest: Manifest,
+    path: PathBuf,
+}
+
+impl Cargo {
+    /// Creates a new cargo package.
+    fn new(manifest: Manifest, path: PathBuf) -> Self {
+        Self { manifest, path }
+    }
+
+    /// Gets the package name.
+    pub fn name(&self) -> &str {
+        self.manifest.inner().package().name()
+    }
+
+    /// Gets the package description.
+    pub fn description(&self) -> Option<&str> {
+        self.manifest.inner().package().description()
+    }
+
+    /// Gets the package version.
+    pub fn version(&self) -> &str {
+        self.manifest.inner().package().version()
+    }
+
+    /// Gets the package path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}

--- a/packages/ploys/src/package/error.rs
+++ b/packages/ploys/src/package/error.rs
@@ -1,0 +1,24 @@
+use std::fmt::{self, Display};
+
+/// The package error.
+#[derive(Debug)]
+pub enum Error {
+    /// A cargo package error.
+    Cargo(super::cargo::Error),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cargo(err) => Display::fmt(err, f),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<super::cargo::Error> for Error {
+    fn from(err: super::cargo::Error) -> Self {
+        Self::Cargo(err)
+    }
+}

--- a/packages/ploys/src/package/manifest.rs
+++ b/packages/ploys/src/package/manifest.rs
@@ -1,0 +1,90 @@
+use std::path::{Path, PathBuf};
+
+use super::cargo::manifest::Manifest as CargoManifest;
+use super::error::Error;
+use super::members::Members;
+use super::{Package, PackageKind};
+
+/// The package manifest.
+#[derive(Debug)]
+pub enum Manifest {
+    /// A cargo package manifest.
+    Cargo(CargoManifest),
+}
+
+impl Manifest {
+    /// Gets the package kind.
+    pub fn package_kind(&self) -> PackageKind {
+        match self {
+            Self::Cargo(_) => PackageKind::Cargo,
+        }
+    }
+
+    /// Gets the file name for the manifest.
+    pub fn file_name(&self) -> &'static Path {
+        self.package_kind().file_name()
+    }
+
+    /// Gets the workspace members.
+    pub fn members(&self) -> Result<Members, Error> {
+        match self {
+            Self::Cargo(cargo) => Ok(cargo.members()?),
+        }
+    }
+
+    /// Produces an iterator of paths to treat as package directories.
+    pub fn directories<'a>(&'a self, files: &'a [PathBuf]) -> impl Iterator<Item = &'a Path> {
+        files
+            .iter()
+            .filter(|path| path.file_name() == Some(self.file_name().as_os_str()))
+            .flat_map(|path| path.parent())
+    }
+
+    /// Finds member packages using the closure to query individual paths.
+    pub fn packages<F, E>(self, files: &[PathBuf], find: F) -> Result<Vec<Package>, E>
+    where
+        F: Fn(&Path) -> Result<Vec<u8>, E>,
+        E: From<Error>,
+    {
+        let members = self.members()?;
+        let file_name = self.file_name();
+
+        let mut packages = Vec::new();
+
+        if !members.is_empty() {
+            for directory in self.directories(files) {
+                if members.includes(directory) {
+                    let path = directory.join(file_name);
+                    let bytes = find(&path)?;
+                    let package = Self::from_bytes(self.package_kind(), &bytes)?.into_package(path);
+
+                    if let Some(package) = package {
+                        packages.push(package);
+                    }
+                }
+            }
+        }
+
+        if let Some(package) = self.into_package(file_name.to_owned()) {
+            packages.push(package);
+        }
+
+        packages.sort_by_key(|package| package.name().to_owned());
+
+        Ok(packages)
+    }
+
+    /// Creates a manifest from the given bytes.
+    pub fn from_bytes(kind: PackageKind, bytes: &[u8]) -> Result<Self, Error> {
+        match kind {
+            PackageKind::Cargo => Ok(Self::Cargo(CargoManifest::from_bytes(bytes)?)),
+        }
+    }
+
+    /// Converts this manifest into a package with the given path.
+    pub fn into_package(self, path: PathBuf) -> Option<Package> {
+        Some(match self {
+            Self::Cargo(manifest) => Package::Cargo(manifest.into_package(path)?),
+        })
+    }
+}

--- a/packages/ploys/src/package/members.rs
+++ b/packages/ploys/src/package/members.rs
@@ -1,0 +1,62 @@
+use std::path::{Path, PathBuf};
+
+use globset::GlobSet;
+
+/// The package members.
+pub struct Members {
+    includes: GlobSet,
+    excludes: Vec<PathBuf>,
+}
+
+impl Members {
+    /// Creates new members with the given includes and excludes.
+    pub fn new(includes: GlobSet, excludes: Vec<PathBuf>) -> Self {
+        Self { includes, excludes }
+    }
+
+    /// Checks whether the members includes the given path.
+    pub fn includes(&self, path: &Path) -> bool {
+        self.includes.is_match(path) && !self.excludes(path)
+    }
+
+    /// Checks whether the members excludes the given path.
+    pub fn excludes(&self, path: &Path) -> bool {
+        self.excludes
+            .iter()
+            .any(|exclude| path.starts_with(exclude))
+    }
+
+    /// Checks whether the members is empty.
+    pub fn is_empty(&self) -> bool {
+        self.includes.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use globset::{Glob, GlobSetBuilder};
+
+    use super::Members;
+
+    #[test]
+    fn test_member_includes() {
+        let mut includes = GlobSetBuilder::new();
+        let mut excludes = Vec::new();
+
+        includes.add(Glob::new("Cargo.toml").unwrap());
+        includes.add(Glob::new("crates/foo").unwrap());
+        includes.add(Glob::new("packages/foo").unwrap());
+        includes.add(Glob::new("packages/*").unwrap());
+        excludes.push(PathBuf::from("packages/baz"));
+
+        let members = Members::new(includes.build().unwrap(), excludes);
+
+        assert!(!members.is_empty());
+        assert!(members.includes(Path::new("crates/foo")));
+        assert!(members.includes(Path::new("packages/foo")));
+        assert!(members.includes(Path::new("packages/bar")));
+        assert!(members.excludes(Path::new("packages/baz")));
+    }
+}

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -1,0 +1,106 @@
+//! Package inspection and management utilities
+//!
+//! This module includes utilities for inspecting and managing packages located
+//! on the local file system or in a remote version control system.
+
+pub mod cargo;
+mod error;
+mod manifest;
+mod members;
+
+use std::path::{Path, PathBuf};
+
+use self::cargo::Cargo;
+pub use self::error::Error;
+use self::manifest::Manifest;
+
+/// A package in one of several supported formats.
+pub enum Package {
+    /// A `Cargo.toml` package for Rust.
+    Cargo(Cargo),
+}
+
+impl Package {
+    /// Gets the package name.
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Cargo(cargo) => cargo.name(),
+        }
+    }
+
+    /// Gets the package description, if it exists.
+    pub fn description(&self) -> Option<&str> {
+        match self {
+            Self::Cargo(cargo) => cargo.description(),
+        }
+    }
+
+    /// Gets the package version.
+    pub fn version(&self) -> &str {
+        match self {
+            Self::Cargo(cargo) => cargo.version(),
+        }
+    }
+
+    /// Gets the package manifest file path.
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Cargo(cargo) => cargo.path(),
+        }
+    }
+
+    /// Gets the package kind.
+    pub fn kind(&self) -> PackageKind {
+        match self {
+            Self::Cargo(_) => PackageKind::Cargo,
+        }
+    }
+}
+
+impl Package {
+    /// Discovers project packages.
+    pub(super) fn discover<F, E>(files: &[PathBuf], find: F) -> Result<Vec<Package>, E>
+    where
+        F: Fn(&Path) -> Result<Vec<u8>, E> + Copy,
+        E: From<Error>,
+    {
+        let mut packages = Vec::new();
+
+        for kind in PackageKind::variants() {
+            if let Ok(bytes) = find(kind.file_name()) {
+                let manifest = Manifest::from_bytes(*kind, &bytes)?;
+
+                packages.extend(manifest.packages(files, find)?);
+            }
+        }
+
+        Ok(packages)
+    }
+}
+
+impl From<Cargo> for Package {
+    fn from(value: Cargo) -> Self {
+        Self::Cargo(value)
+    }
+}
+
+/// The package kind.
+#[derive(Clone, Copy, Debug)]
+pub enum PackageKind {
+    /// The cargo package kind.
+    Cargo,
+}
+
+impl PackageKind {
+    /// Gets the package variants.
+    fn variants() -> &'static [Self] {
+        &[Self::Cargo]
+    }
+
+    /// Gets the package file name.
+    pub fn file_name(&self) -> &'static Path {
+        match self {
+            Self::Cargo => Path::new("Cargo.toml"),
+        }
+    }
+}

--- a/packages/ploys/src/project/local/error.rs
+++ b/packages/ploys/src/project/local/error.rs
@@ -8,6 +8,8 @@ pub enum Error {
     Git(GitError),
     /// An I/O error.
     Io(io::Error),
+    /// A package error.
+    Package(crate::package::Error),
 }
 
 impl Error {
@@ -26,11 +28,18 @@ impl Display for Error {
         match self {
             Self::Git(error) => Display::fmt(error, f),
             Self::Io(error) => Display::fmt(error, f),
+            Self::Package(error) => Display::fmt(error, f),
         }
     }
 }
 
 impl std::error::Error for Error {}
+
+impl From<crate::package::Error> for Error {
+    fn from(error: crate::package::Error) -> Self {
+        Self::Package(error)
+    }
+}
 
 impl From<std::io::Error> for Error {
     fn from(error: std::io::Error) -> Self {

--- a/packages/ploys/src/project/local/mod.rs
+++ b/packages/ploys/src/project/local/mod.rs
@@ -14,6 +14,8 @@ use gix::traverse::tree::Recorder;
 use gix::Repository;
 use url::Url;
 
+use crate::package::Package;
+
 pub use self::error::{Error, GitError};
 
 /// A project on the local file system.
@@ -72,6 +74,13 @@ impl Local {
             },
             None => Err(Error::remote_not_found()),
         }
+    }
+
+    /// Queries the project packages.
+    pub fn get_packages(&self) -> Result<Vec<Package>, Error> {
+        let files = self.get_files()?;
+
+        Package::discover(&files, |path| self.get_file_contents(path))
     }
 
     /// Queries the project files.

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -41,6 +41,8 @@ use std::path::{Path, PathBuf};
 
 use url::Url;
 
+use crate::package::Package;
+
 pub use self::error::Error;
 use self::local::Local;
 use self::remote::Remote;
@@ -147,6 +149,17 @@ impl Project {
         match self {
             Self::Local(local) => Ok(local.get_url()?),
             Self::Remote(remote) => Ok(remote.get_url()?),
+        }
+    }
+
+    /// Queries the project packages.
+    ///
+    /// This method may perform file system operations or network requests to
+    /// query the latest project information.
+    pub fn get_packages(&self) -> Result<Vec<Package>, Error> {
+        match self {
+            Self::Local(local) => Ok(local.get_packages()?),
+            Self::Remote(remote) => Ok(remote.get_packages()?),
         }
     }
 

--- a/packages/ploys/src/project/remote/error.rs
+++ b/packages/ploys/src/project/remote/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     Parse(String),
     /// An I/O error.
     Io(io::Error),
+    /// A package error.
+    Package(crate::package::Error),
 }
 
 impl Display for Error {
@@ -27,11 +29,18 @@ impl Display for Error {
             Error::Transport(transport) => Display::fmt(transport, f),
             Error::Parse(message) => write!(f, "Parse error: {message}"),
             Error::Io(err) => Display::fmt(err, f),
+            Error::Package(err) => Display::fmt(err, f),
         }
     }
 }
 
 impl std::error::Error for Error {}
+
+impl From<crate::package::Error> for Error {
+    fn from(error: crate::package::Error) -> Self {
+        Self::Package(error)
+    }
+}
 
 impl From<io::Error> for Error {
     fn from(error: io::Error) -> Self {

--- a/packages/ploys/src/project/remote/mod.rs
+++ b/packages/ploys/src/project/remote/mod.rs
@@ -12,6 +12,8 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 use url::Url;
 
+use crate::package::Package;
+
 pub use self::error::Error;
 pub use self::repo::Repository;
 
@@ -74,6 +76,13 @@ impl Remote {
         Ok(format!("https://github.com/{}", self.repository)
             .parse()
             .unwrap())
+    }
+
+    /// Queries the project packages.
+    pub fn get_packages(&self) -> Result<Vec<Package>, Error> {
+        let files = self.get_files()?;
+
+        Package::discover(&files, |path| self.get_file_contents(path))
     }
 
     /// Queries the project files.

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -25,6 +25,11 @@ fn test_valid_local_project() -> Result<(), Error> {
     assert!(b.contains("[package]"));
     assert!(project.get_file_contents("packages/ploys").is_err());
 
+    let packages = project.get_packages()?;
+
+    assert!(packages.iter().any(|pkg| pkg.name() == "ploys"));
+    assert!(packages.iter().any(|pkg| pkg.name() == "ploys-cli"));
+
     Ok(())
 }
 
@@ -54,6 +59,11 @@ fn test_valid_remote_project() -> Result<(), Error> {
     assert!(a.contains("[workspace]"));
     assert!(b.contains("[package]"));
     assert!(project.get_file_contents("packages/ploys").is_err());
+
+    let packages = project.get_packages()?;
+
+    assert!(packages.iter().any(|pkg| pkg.name() == "ploys"));
+    assert!(packages.iter().any(|pkg| pkg.name() == "ploys-cli"));
 
     Ok(())
 }


### PR DESCRIPTION
This adds the initial implementation of package discovery with support for Cargo packages in Rust projects.

The short-term goal of this project is to support creating releases so that it can be used to release itself. This consists of publishing packages to [crates.io](https://crates.io) and uploading GitHub release assets. This requires that the tool knows about the existence of the packages in a project.

This introduces the ability to locate `Cargo.toml` packages by first reading a top-level `Cargo.toml` package and then discovering any workspace members. The API has been written such that support for other package types from other languages can be introduced.