### PR TITLE
Add inspect command discovered packages output

### DIFF
--- a/packages/ploys-cli/src/command/inspect.rs
+++ b/packages/ploys-cli/src/command/inspect.rs
@@ -37,6 +37,29 @@ impl Inspect {
         println!("Name:       {}", project.get_name()?);
         println!("Repository: {}", project.get_url()?);
 
+        println!("\n{}:\n", style("Packages").underlined().bold());
+
+        let packages = project.get_packages()?;
+        let max_name_len = packages
+            .iter()
+            .map(|pkg| pkg.name().len())
+            .max()
+            .unwrap_or_default();
+        let max_version_len = packages
+            .iter()
+            .map(|pkg| pkg.version().len())
+            .max()
+            .unwrap_or_default();
+
+        for package in packages {
+            println!(
+                "{:<max_name_len$}  {:>max_version_len$}  {}",
+                package.name(),
+                package.version(),
+                package.description().unwrap_or_default()
+            );
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
This updates the inspect command to show information about the discovered packages.

The purpose of the inspect command is to show information about the target project. It acts as a human-readable way to verify that the tool is correctly identifying and discovering the relevant information.

The #10 update included the ability to discover packages and this updates the command line to display that information. It currently includes only the package name, version and description but more information can be added later if needed.