### PR TITLE
Remove project name readme lookup

### DIFF
--- a/packages/ploys/src/project/local/mod.rs
+++ b/packages/ploys/src/project/local/mod.rs
@@ -5,7 +5,6 @@
 
 mod error;
 
-use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -40,12 +39,6 @@ impl Local {
     /// Queries the project name.
     pub fn get_name(&self) -> Result<String, Error> {
         let path = self.repository.path().join("..").canonicalize()?;
-
-        if let Ok(readme) = fs::read_to_string(path.join("README.md")) {
-            if let Some(title) = readme.lines().find(|line| line.starts_with("# ")) {
-                return Ok(title[2..].to_string());
-            }
-        }
 
         if let Some(file_stem) = path.file_stem() {
             return Ok(file_stem.to_string_lossy().to_string());

--- a/packages/ploys/src/project/remote/mod.rs
+++ b/packages/ploys/src/project/remote/mod.rs
@@ -55,20 +55,7 @@ impl Remote {
 impl Remote {
     /// Queries the project name.
     pub fn get_name(&self) -> Result<String, Error> {
-        let request = self
-            .repository
-            .get("/readme", self.token.as_deref())
-            .set("Accept", "application/vnd.github.raw");
-
-        if let Ok(response) = request.call() {
-            if let Ok(readme) = response.into_string() {
-                if let Some(title) = readme.lines().find(|line| line.starts_with("# ")) {
-                    return Ok(title[2..].to_string());
-                }
-            }
-        }
-
-        Ok(self.repository.to_string())
+        Ok(self.repository.name().to_owned())
     }
 
     /// Queries the project URL.

--- a/packages/ploys/src/project/remote/repo.rs
+++ b/packages/ploys/src/project/remote/repo.rs
@@ -13,6 +13,11 @@ pub struct Repository {
 }
 
 impl Repository {
+    /// Gets the repository name.
+    pub fn name(&self) -> &str {
+        &self.repo
+    }
+
     /// Validates whether the remote repository exists.
     pub(super) fn validate(&self, token: Option<&str>) -> Result<(), Error> {
         self.head("", token).call()?;


### PR DESCRIPTION
This alters the logic for getting the project name by removing the use of the README file.

The initial implementation of the `Project::get_name` method used the `README.md` file to get a human-readable name instead of relying on the directory name which may not reflect the true name of the project. This unfortunately required a network request for remote projects to load the file and incorrectly used the file system instead of querying the repository for local projects. However, the biggest issue is that it is possible for the README title to be inaccurate, not represent the true name of the project, or include additional metadata such as badges as can be in several popular Rust crates.

This update removes the use of the `README.md` file entirely and simply updates the logic to use the directory name in local projects and repository name in remote projects. This does not alter the public API of the `Remote::get_name` method to remove the unnecessary result as a future update may introduce a configuration file with the name. However, it does introduce a new `Repository::name` method to get the repository name which is now returned for remote projects instead of the full organization/repo identifier.