### PR TITLE
Rename local and remote project variants

### DIFF
--- a/packages/ploys-cli/src/command/inspect.rs
+++ b/packages/ploys-cli/src/command/inspect.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use anyhow::{anyhow, Error};
 use clap::Args;
 use console::style;
-use ploys::project::remote::Repository;
+use ploys::project::github::Repository;
 use ploys::project::Project;
 use url::Url;
 
@@ -24,13 +24,13 @@ impl Inspect {
     pub fn exec(self) -> Result<(), Error> {
         let project = match self.remote {
             Some(remote) => match self.token {
-                Some(token) => Project::remote_with_authentication_token(
+                Some(token) => Project::github_with_authentication_token(
                     remote.try_into_repo()?.to_string(),
                     token,
                 )?,
-                None => Project::remote(remote.try_into_repo()?.to_string())?,
+                None => Project::github(remote.try_into_repo()?.to_string())?,
             },
-            None => Project::local(".")?,
+            None => Project::git(".")?,
         };
 
         println!("{}:\n", style("Project").underlined().bold());

--- a/packages/ploys-cli/tests/inspect.rs
+++ b/packages/ploys-cli/tests/inspect.rs
@@ -5,7 +5,7 @@ use predicates::prelude::*;
 
 #[test]
 #[ignore]
-fn test_inspect_local_command_output() {
+fn test_inspect_command_git_output() {
     Command::cargo_bin("ploys")
         .unwrap()
         .current_dir("../..")
@@ -18,7 +18,7 @@ fn test_inspect_local_command_output() {
 
 #[test]
 #[ignore]
-fn test_inspect_remote_command_output() {
+fn test_inspect_command_github_output() {
     Command::cargo_bin("ploys")
         .unwrap()
         .current_dir("../..")
@@ -33,7 +33,7 @@ fn test_inspect_remote_command_output() {
 
 #[test]
 #[ignore]
-fn test_inspect_remote_url_command_output() {
+fn test_inspect_command_github_url_output() {
     Command::cargo_bin("ploys")
         .unwrap()
         .current_dir("../..")

--- a/packages/ploys/src/project/error.rs
+++ b/packages/ploys/src/project/error.rs
@@ -3,31 +3,31 @@ use std::fmt::{self, Display};
 /// The project error.
 #[derive(Debug)]
 pub enum Error {
-    /// The local project error.
-    Local(super::local::Error),
-    /// The remote project error.
-    Remote(super::remote::Error),
+    /// The Git project error.
+    Git(super::git::Error),
+    /// The GitHub project error.
+    GitHub(super::github::Error),
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Local(local) => Display::fmt(local, f),
-            Error::Remote(remote) => Display::fmt(remote, f),
+            Error::Git(git) => Display::fmt(git, f),
+            Error::GitHub(github) => Display::fmt(github, f),
         }
     }
 }
 
 impl std::error::Error for Error {}
 
-impl From<super::local::Error> for Error {
-    fn from(error: super::local::Error) -> Self {
-        Self::Local(error)
+impl From<super::git::Error> for Error {
+    fn from(error: super::git::Error) -> Self {
+        Self::Git(error)
     }
 }
 
-impl From<super::remote::Error> for Error {
-    fn from(error: super::remote::Error) -> Self {
-        Self::Remote(error)
+impl From<super::github::Error> for Error {
+    fn from(error: super::github::Error) -> Self {
+        Self::GitHub(error)
     }
 }

--- a/packages/ploys/src/project/git/error.rs
+++ b/packages/ploys/src/project/git/error.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
 use std::io;
 
-/// The local project error.
+/// The Git project error.
 #[derive(Debug)]
 pub enum Error {
     /// A Git error.

--- a/packages/ploys/src/project/git/mod.rs
+++ b/packages/ploys/src/project/git/mod.rs
@@ -1,7 +1,7 @@
-//! Local project inspection and management
+//! Git project inspection and management
 //!
-//! This module contains the utilities related to local project management. The
-//! [`Local`] type must be constructed via [`super::Project`].
+//! This module contains the utilities related to local Git project management.
+//! The [`Git`] type must be constructed via [`super::Project`].
 
 mod error;
 
@@ -17,14 +17,14 @@ use crate::package::Package;
 
 pub use self::error::{Error, GitError};
 
-/// A project on the local file system.
+/// A project in a local Git repository.
 #[derive(Clone, Debug)]
-pub struct Local {
+pub struct Git {
     repository: Repository,
 }
 
-impl Local {
-    /// Creates a local project.
+impl Git {
+    /// Creates a Git project.
     pub(super) fn new<P>(path: P) -> Result<Self, Error>
     where
         P: AsRef<Path>,
@@ -35,7 +35,7 @@ impl Local {
     }
 }
 
-impl Local {
+impl Git {
     /// Queries the project name.
     pub fn get_name(&self) -> Result<String, Error> {
         let path = self.repository.path().join("..").canonicalize()?;

--- a/packages/ploys/src/project/github/error.rs
+++ b/packages/ploys/src/project/github/error.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
 use std::io;
 
-/// The remote project error.
+/// The GitHub project error.
 #[derive(Debug)]
 pub enum Error {
     /// An HTTP status response.

--- a/packages/ploys/src/project/github/mod.rs
+++ b/packages/ploys/src/project/github/mod.rs
@@ -1,7 +1,7 @@
-//! Remote project inspection and management
+//! GitHub project inspection and management
 //!
-//! This module contains the utilities related to remote project management. The
-//! [`Remote`] type must be constructed via [`super::Project`].
+//! This module contains the utilities related to remote GitHub project
+//! management. The [`GitHub`] type must be constructed via [`super::Project`].
 
 mod error;
 mod repo;
@@ -17,17 +17,17 @@ use crate::package::Package;
 pub use self::error::Error;
 pub use self::repo::Repository;
 
-use super::local::Local;
+use super::git::Git;
 
-/// A project in a remote version control system.
+/// A project in a remote GitHub repository.
 #[derive(Clone, Debug)]
-pub struct Remote {
+pub struct GitHub {
     repository: Repository,
     token: Option<String>,
 }
 
-impl Remote {
-    /// Creates a remote project.
+impl GitHub {
+    /// Creates a GitHub project.
     pub(super) fn new<R>(repository: R) -> Result<Self, Error>
     where
         R: AsRef<str>,
@@ -52,7 +52,7 @@ impl Remote {
     }
 }
 
-impl Remote {
+impl GitHub {
     /// Queries the project name.
     pub fn get_name(&self) -> Result<String, Error> {
         Ok(self.repository.name().to_owned())
@@ -127,11 +127,11 @@ impl Remote {
     }
 }
 
-impl TryFrom<Local> for Remote {
+impl TryFrom<Git> for GitHub {
     type Error = super::Error;
 
-    fn try_from(local: Local) -> Result<Self, Self::Error> {
-        Ok(Self::new(local.get_url()?)?)
+    fn try_from(git: Git) -> Result<Self, Self::Error> {
+        Ok(Self::new(git.get_url()?)?)
     }
 }
 
@@ -148,19 +148,19 @@ struct TreeResponseEntry {
 
 #[cfg(test)]
 mod tests {
-    use super::{Error, Remote};
+    use super::{Error, GitHub};
 
     #[test]
-    fn test_remote_constructor() {
-        assert!(Remote::new("ploys/ploys").is_ok());
-        assert!(Remote::new("rust-lang/rust").is_ok());
-        assert!(Remote::new("one/two/three").is_err());
+    fn test_github_constructor() {
+        assert!(GitHub::new("ploys/ploys").is_ok());
+        assert!(GitHub::new("rust-lang/rust").is_ok());
+        assert!(GitHub::new("one/two/three").is_err());
     }
 
     #[test]
-    fn test_remote_url() -> Result<(), Error> {
+    fn test_github_url() -> Result<(), Error> {
         assert_eq!(
-            Remote::new("ploys/ploys")?.get_url()?,
+            GitHub::new("ploys/ploys")?.get_url()?,
             "https://github.com/ploys/ploys".parse().unwrap()
         );
 

--- a/packages/ploys/src/project/github/repo.rs
+++ b/packages/ploys/src/project/github/repo.rs
@@ -5,7 +5,7 @@ use ureq::Request;
 
 use super::Error;
 
-/// The remote repository information.
+/// The GitHub repository information.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Repository {
     owner: String,

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -5,7 +5,7 @@ use ploys::project::{Error, Project};
 #[test]
 #[ignore]
 fn test_valid_local_project() -> Result<(), Error> {
-    let project = Project::local("../..")?;
+    let project = Project::git("../..")?;
     let url = project.get_url()?;
 
     assert_eq!(project.get_name()?, "ploys");
@@ -37,8 +37,8 @@ fn test_valid_local_project() -> Result<(), Error> {
 #[ignore]
 fn test_valid_remote_project() -> Result<(), Error> {
     let project = match std::env::var("GITHUB_TOKEN").ok() {
-        Some(token) => Project::remote_with_authentication_token("ploys/ploys", token)?,
-        None => Project::remote("ploys/ploys")?,
+        Some(token) => Project::github_with_authentication_token("ploys/ploys", token)?,
+        None => Project::github("ploys/ploys")?,
     };
 
     assert_eq!(project.get_name()?, "ploys");


### PR DESCRIPTION
This renames the `Local` and `Remote` project variants to `Git` and `GitHub`.

The initial implementation of the `Project` type used the term _local_ to refer to a project on the local file system and the term _remote_ to refer to a project in a remote GitHub repository. These terms are too general for how they are currently used and do not represent the actual capabilities of the system.

The long-term goal of the project was to expand the `Remote` variant to support other providers such as GitLab. However, it is possible that the implementations could diverge enough that they do not neatly fit under the same type.

The `Local` variant could similarly be expanded to support other local version control systems but may suffer the same limitations if the implementations diverge. There was also some confusion where the variant would interchangeably use the local file system or the local Git repository. This could pose a problem if uncommitted changes were made as the state would differ depending on how the tool was used and which API was called.

This change makes it clear what each variant represents and enables the option to support other systems in a flat structure instead of nesting the integrations below either `Local` or `Remote`. Obviously there are some major differences as any continuous integration infrastructure would likely need a remote system. For this reason it may be necessary to alter the structure further and introduce traits representing these capabilities.