### PR TITLE
Use toml_edit crate to preserve formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,16 +174,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
 
 [[package]]
-name = "cargo_toml"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a1f1117a8ff2f3547295da90f473c392d8d1107c90cea1ea82b1a544a97a4a"
-dependencies = [
- "serde",
- "toml",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,10 +1455,10 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 name = "ploys"
 version = "0.0.0"
 dependencies = [
- "cargo_toml",
  "gix",
  "globset",
  "serde",
+ "toml_edit",
  "ureq",
  "url",
 ]
@@ -1881,18 +1871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "toml"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c226a7bba6d859b63c92c4b4fe69c5b6b72d0cb897dbc8e6012298e6154cb56e"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,9 +1881,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff63e60a958cefbb518ae1fd6566af80d9d4be430a33f3723dfc47d1d411d95"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "serde",

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -9,9 +9,9 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
-cargo_toml = "0.16.2"
 gix = "0.51.0"
 globset = "0.4.13"
 serde = { version = "1.0.185", features = ["derive"] }
+toml_edit = { version = "0.20.2", features = ["serde"] }
 ureq = { version = "2.7.1", features = ["json"] }
 url = "2.4.0"

--- a/packages/ploys/src/package/cargo/error.rs
+++ b/packages/ploys/src/package/cargo/error.rs
@@ -6,7 +6,9 @@ pub enum Error {
     /// A glob error.
     Glob(globset::Error),
     /// A manifest error.
-    Manifest(cargo_toml::Error),
+    Manifest(toml_edit::TomlError),
+    /// A UTF-8 error.
+    Utf8(std::str::Utf8Error),
 }
 
 impl Display for Error {
@@ -14,6 +16,7 @@ impl Display for Error {
         match self {
             Self::Glob(err) => Display::fmt(err, f),
             Self::Manifest(err) => Display::fmt(err, f),
+            Self::Utf8(err) => Display::fmt(err, f),
         }
     }
 }
@@ -26,8 +29,14 @@ impl From<globset::Error> for Error {
     }
 }
 
-impl From<cargo_toml::Error> for Error {
-    fn from(err: cargo_toml::Error) -> Self {
+impl From<toml_edit::TomlError> for Error {
+    fn from(err: toml_edit::TomlError) -> Self {
         Self::Manifest(err)
+    }
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Self::Utf8(err)
     }
 }

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use cargo_toml::{Dependency, Manifest as CargoToml};
 use globset::{Glob, GlobSetBuilder};
+use toml_edit::{Array, Document, TableLike, Value};
 
 use crate::package::members::Members;
 
@@ -10,12 +10,47 @@ use super::Cargo;
 
 /// The cargo package manifest.
 #[derive(Debug)]
-pub struct Manifest(CargoToml);
+pub struct Manifest(Document);
 
 impl Manifest {
-    /// Gets the inner manifest.
-    pub fn inner(&self) -> &CargoToml {
-        &self.0
+    /// Gets the workspace table.
+    pub fn workspace(&self) -> Option<Workspace<'_>> {
+        match self.0.get("workspace") {
+            Some(item) => item.as_table_like().map(Workspace),
+            None => None,
+        }
+    }
+
+    /// Gets the package table.
+    pub fn package(&self) -> Option<Package<'_>> {
+        match self.0.get("package") {
+            Some(item) => item.as_table_like().map(Package),
+            None => None,
+        }
+    }
+
+    /// Gets the dependencies table.
+    pub fn dependencies(&self) -> Dependencies<'_> {
+        match self.0.get("dependencies") {
+            Some(item) => Dependencies(item.as_table_like()),
+            None => Dependencies(None),
+        }
+    }
+
+    /// Gets the dev dependencies table.
+    pub fn dev_dependencies(&self) -> Dependencies<'_> {
+        match self.0.get("dev-dependencies") {
+            Some(item) => Dependencies(item.as_table_like()),
+            None => Dependencies(None),
+        }
+    }
+
+    /// Gets the build dependencies table.
+    pub fn build_dependencies(&self) -> Dependencies<'_> {
+        match self.0.get("build-dependencies") {
+            Some(item) => Dependencies(item.as_table_like()),
+            None => Dependencies(None),
+        }
     }
 
     /// Gets the workspace members.
@@ -26,28 +61,25 @@ impl Manifest {
         let mut includes = GlobSetBuilder::new();
         let mut excludes = Vec::new();
 
-        if let Some(workspace) = &self.0.workspace {
-            for member in &workspace.members {
+        if let Some(workspace) = self.workspace() {
+            for member in workspace.members() {
                 includes.add(Glob::new(member.trim_start_matches("./"))?);
             }
 
-            for path in &workspace.exclude {
+            for path in workspace.exclude() {
                 excludes.push(PathBuf::from(path));
             }
         }
 
         let dependencies = self
-            .0
-            .dependencies
-            .values()
-            .chain(self.0.dev_dependencies.values())
-            .chain(self.0.build_dependencies.values());
+            .dependencies()
+            .into_iter()
+            .chain(self.dev_dependencies())
+            .chain(self.build_dependencies());
 
         for dependency in dependencies {
-            if let Dependency::Detailed(dependency) = dependency {
-                if let Some(path) = &dependency.path {
-                    includes.add(Glob::new(path.trim_start_matches("./"))?);
-                }
+            if let Some(path) = dependency.path() {
+                includes.add(Glob::new(path.trim_start_matches("./"))?);
             }
         }
 
@@ -56,14 +88,127 @@ impl Manifest {
 
     /// Creates a manifest from the given bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        Ok(Self(CargoToml::from_slice(bytes)?))
+        Ok(Self(std::str::from_utf8(bytes)?.parse()?))
     }
 
     /// Converts this manifest into a package with the given path.
     pub fn into_package(self, path: PathBuf) -> Option<Cargo> {
-        match self.0.package.is_some() {
+        match self.package().is_some() {
             true => Some(Cargo::new(self, path)),
             false => None,
+        }
+    }
+}
+
+/// The workspace table.
+pub struct Workspace<'a>(&'a dyn TableLike);
+
+impl<'a> Workspace<'a> {
+    /// Gets the workspace members.
+    pub fn members(&self) -> WorkspaceMembers<'a> {
+        match self.0.get("members") {
+            Some(item) => WorkspaceMembers(item.as_array()),
+            None => WorkspaceMembers(None),
+        }
+    }
+
+    /// Gets the workspace excludes.
+    pub fn exclude(&self) -> WorkspaceExclude<'a> {
+        match self.0.get("exclude") {
+            Some(item) => WorkspaceExclude(item.as_array()),
+            None => WorkspaceExclude(None),
+        }
+    }
+}
+
+/// The workspace members array.
+pub struct WorkspaceMembers<'a>(Option<&'a Array>);
+
+impl<'a> IntoIterator for WorkspaceMembers<'a> {
+    type Item = &'a str;
+    type IntoIter = Box<dyn Iterator<Item = &'a str> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self.0 {
+            Some(arr) => Box::new(arr.into_iter().flat_map(Value::as_str)),
+            None => Box::new(std::iter::empty()),
+        }
+    }
+}
+
+/// The workspace excludes array.
+pub struct WorkspaceExclude<'a>(Option<&'a Array>);
+
+impl<'a> IntoIterator for WorkspaceExclude<'a> {
+    type Item = &'a str;
+    type IntoIter = Box<dyn Iterator<Item = &'a str> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self.0 {
+            Some(arr) => Box::new(arr.into_iter().flat_map(Value::as_str)),
+            None => Box::new(std::iter::empty()),
+        }
+    }
+}
+
+/// The package table.
+pub struct Package<'a>(&'a dyn TableLike);
+
+impl<'a> Package<'a> {
+    /// Gets the package name.
+    pub fn name(&self) -> &'a str {
+        self.0.get("name").expect("name").as_str().expect("name")
+    }
+
+    /// Gets the package description.
+    pub fn description(&self) -> Option<&'a str> {
+        match self.0.get("description") {
+            Some(description) => Some(description.as_str().expect("description")),
+            None => None,
+        }
+    }
+
+    /// Gets the package version.
+    pub fn version(&self) -> &'a str {
+        self.0
+            .get("version")
+            .expect("version")
+            .as_str()
+            .expect("version")
+    }
+}
+
+/// The dependencies table.
+pub struct Dependencies<'a>(Option<&'a dyn TableLike>);
+
+impl<'a> IntoIterator for Dependencies<'a> {
+    type Item = Dependency<'a>;
+    type IntoIter = Box<dyn Iterator<Item = Dependency<'a>> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self.0 {
+            Some(table) => Box::new(
+                table
+                    .iter()
+                    .map(|(name, item)| Dependency(name, item.as_table_like())),
+            ),
+            None => Box::new(std::iter::empty()),
+        }
+    }
+}
+
+/// The dependency item.
+pub struct Dependency<'a>(&'a str, Option<&'a dyn TableLike>);
+
+impl<'a> Dependency<'a> {
+    /// Gets the dependency path if it has been set.
+    pub fn path(&self) -> Option<&'a str> {
+        match self.1 {
+            Some(table) => match table.get("path") {
+                Some(path) => path.as_str(),
+                None => None,
+            },
+            None => None,
         }
     }
 }

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -22,17 +22,17 @@ impl Cargo {
 
     /// Gets the package name.
     pub fn name(&self) -> &str {
-        self.manifest.inner().package().name()
+        self.manifest.package().expect("package").name()
     }
 
     /// Gets the package description.
     pub fn description(&self) -> Option<&str> {
-        self.manifest.inner().package().description()
+        self.manifest.package().expect("package").description()
     }
 
     /// Gets the package version.
     pub fn version(&self) -> &str {
-        self.manifest.inner().package().version()
+        self.manifest.package().expect("package").version()
     }
 
     /// Gets the package path.


### PR DESCRIPTION
This replaces the usage of the `cargo_toml` crate with `toml_edit` to preserve formatting.

The short-term goal of this project is to enable the ability to create GitHub releases through an automated Pull Request. This requires that both the `Cargo.toml` and `Cargo.lock` files be updated to bump the version number. The `cargo_toml` crate handled the `Cargo.toml` file but not the `Cargo.lock` and would not preserve formatting if the file were to be updated. This could result in a noisy Pull Request that does more than update the version number as lines are rearranged and important comments are lost.

The `toml_edit` crate, although not perfect, should preserve the formatting of the document and at the very least not strip out important comments.

This update includes the necessary changes to replicate the existing functionality with the new crate without altering the logic. However, it does not include the functionality to mutate the package metadata but this should be possible my creating mutable versions of the new structs.