### PR TITLE
Add package bump method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,6 +1457,7 @@ version = "0.0.0"
 dependencies = [
  "gix",
  "globset",
+ "semver",
  "serde",
  "toml_edit",
  "ureq",
@@ -1685,6 +1686,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
 
 [[package]]
 name = "serde"

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 [dependencies]
 gix = "0.51.0"
 globset = "0.4.13"
+semver = "1.0.19"
 serde = { version = "1.0.185", features = ["derive"] }
 toml_edit = { version = "0.20.2", features = ["serde"] }
 ureq = { version = "2.7.1", features = ["json"] }

--- a/packages/ploys/src/package/bump.rs
+++ b/packages/ploys/src/package/bump.rs
@@ -1,0 +1,317 @@
+use std::fmt::{self, Display};
+use std::str::FromStr;
+
+use semver::{BuildMetadata, Prerelease, Version};
+
+/// The package semver bump target.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Bump {
+    Major,
+    Minor,
+    Patch,
+    Rc,
+    Beta,
+    Alpha,
+}
+
+impl Bump {
+    /// Updates the given version.
+    pub fn bump(self, version: &mut Version) -> Result<(), Error> {
+        match self {
+            Self::Major => {
+                version.major += 1;
+                version.minor = 0;
+                version.patch = 0;
+                version.pre = Prerelease::EMPTY;
+                version.build = BuildMetadata::EMPTY;
+            }
+            Self::Minor => {
+                version.minor += 1;
+                version.patch = 0;
+                version.pre = Prerelease::EMPTY;
+                version.build = BuildMetadata::EMPTY;
+            }
+            Self::Patch => match version.pre.is_empty() {
+                true => {
+                    version.patch += 1;
+                    version.pre = Prerelease::EMPTY;
+                    version.build = BuildMetadata::EMPTY;
+                }
+                false => {
+                    version.pre = Prerelease::EMPTY;
+                }
+            },
+            Self::Rc => match parse_prelease(&version.pre) {
+                Some((Tag::Rc, ver)) => {
+                    version.pre = Prerelease::new(&format!("rc.{}", ver.unwrap_or(0) + 1))?;
+                    version.build = BuildMetadata::EMPTY;
+                }
+                Some(_) => {
+                    version.pre = Prerelease::new("rc.1")?;
+                    version.build = BuildMetadata::EMPTY;
+                }
+                None => match version.major {
+                    0 => {
+                        version.minor += 1;
+                        version.patch = 0;
+                        version.pre = Prerelease::new("rc.1")?;
+                        version.build = BuildMetadata::EMPTY;
+                    }
+                    _ => {
+                        version.major += 1;
+                        version.minor = 0;
+                        version.patch = 0;
+                        version.pre = Prerelease::new("rc.1")?;
+                        version.build = BuildMetadata::EMPTY;
+                    }
+                },
+            },
+            Self::Beta => match parse_prelease(&version.pre) {
+                Some((Tag::Rc, _)) => return Err(Error::Unsupported(self)),
+                Some((Tag::Beta, ver)) => {
+                    version.pre = Prerelease::new(&format!("beta.{}", ver.unwrap_or(0) + 1))?;
+                    version.build = BuildMetadata::EMPTY;
+                }
+                Some(_) => {
+                    version.pre = Prerelease::new("beta.1")?;
+                    version.build = BuildMetadata::EMPTY;
+                }
+                None => match version.major {
+                    0 => {
+                        version.minor += 1;
+                        version.patch = 0;
+                        version.pre = Prerelease::new("beta.1")?;
+                        version.build = BuildMetadata::EMPTY;
+                    }
+                    _ => {
+                        version.major += 1;
+                        version.minor = 0;
+                        version.patch = 0;
+                        version.pre = Prerelease::new("beta.1")?;
+                        version.build = BuildMetadata::EMPTY;
+                    }
+                },
+            },
+            Self::Alpha => match parse_prelease(&version.pre) {
+                Some((Tag::Rc, _)) => return Err(Error::Unsupported(self)),
+                Some((Tag::Beta, _)) => return Err(Error::Unsupported(self)),
+                Some((Tag::Alpha, ver)) => {
+                    version.pre = Prerelease::new(&format!("alpha.{}", ver.unwrap_or(0) + 1))?;
+                    version.build = BuildMetadata::EMPTY;
+                }
+                None => match version.major {
+                    0 => {
+                        version.minor += 1;
+                        version.patch = 0;
+                        version.pre = Prerelease::new("alpha.1")?;
+                        version.build = BuildMetadata::EMPTY;
+                    }
+                    _ => {
+                        version.major += 1;
+                        version.minor = 0;
+                        version.patch = 0;
+                        version.pre = Prerelease::new("alpha.1")?;
+                        version.build = BuildMetadata::EMPTY;
+                    }
+                },
+            },
+        }
+
+        Ok(())
+    }
+
+    /// Updates the given version string slice.
+    pub fn bump_str(self, version: &str) -> Result<Version, Error> {
+        let mut version = version.parse::<Version>()?;
+
+        self.bump(&mut version)?;
+
+        Ok(version)
+    }
+}
+
+impl Display for Bump {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Bump::Major => write!(f, "major"),
+            Bump::Minor => write!(f, "minor"),
+            Bump::Patch => write!(f, "patch"),
+            Bump::Rc => write!(f, "rc"),
+            Bump::Beta => write!(f, "beta"),
+            Bump::Alpha => write!(f, "alpha"),
+        }
+    }
+}
+
+impl FromStr for Bump {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "major" => Ok(Self::Major),
+            "minor" => Ok(Self::Minor),
+            "patch" => Ok(Self::Patch),
+            "rc" => Ok(Self::Rc),
+            "beta" => Ok(Self::Beta),
+            "alpha" => Ok(Self::Alpha),
+            _ => Err(Error::Invalid(s.to_string())),
+        }
+    }
+}
+
+/// The bump error.
+#[derive(Debug)]
+pub enum Error {
+    /// A semver error.
+    Semver(semver::Error),
+    /// An invalid bump error.
+    Invalid(String),
+    /// An unsupported bump error.
+    Unsupported(Bump),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Semver(err) => Display::fmt(err, f),
+            Self::Invalid(bump) => write!(f, "Invalid bump: `{bump}`"),
+            Self::Unsupported(bump) => write!(f, "Unsupported bump: `{bump}`"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<semver::Error> for Error {
+    fn from(err: semver::Error) -> Self {
+        Self::Semver(err)
+    }
+}
+
+enum Tag {
+    Rc,
+    Beta,
+    Alpha,
+}
+
+impl FromStr for Tag {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "rc" => Ok(Self::Rc),
+            "beta" => Ok(Self::Beta),
+            "alpha" => Ok(Self::Alpha),
+            _ => Err(()),
+        }
+    }
+}
+
+fn parse_prelease(prerelease: &Prerelease) -> Option<(Tag, Option<u64>)> {
+    match prerelease.is_empty() {
+        true => None,
+        false => match prerelease.as_str().split_once('.') {
+            Some((lhs, rhs)) => Some((lhs.parse::<Tag>().ok()?, rhs.parse::<u64>().ok())),
+            None => Some((prerelease.as_str().parse::<Tag>().ok()?, None)),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Bump, Error};
+
+    #[test]
+    fn test_bump_major() -> Result<(), Error> {
+        let a = Bump::Major.bump_str("0.0.0")?;
+        let b = Bump::Major.bump_str("1.0.0")?;
+        let c = Bump::Major.bump_str("1.2.3")?;
+
+        assert_eq!(a, "1.0.0".parse().unwrap());
+        assert_eq!(b, "2.0.0".parse().unwrap());
+        assert_eq!(c, "2.0.0".parse().unwrap());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bump_minor() -> Result<(), Error> {
+        let a = Bump::Minor.bump_str("0.0.0")?;
+        let b = Bump::Minor.bump_str("0.1.0")?;
+        let c = Bump::Minor.bump_str("1.2.3")?;
+
+        assert_eq!(a, "0.1.0".parse().unwrap());
+        assert_eq!(b, "0.2.0".parse().unwrap());
+        assert_eq!(c, "1.3.0".parse().unwrap());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bump_patch() -> Result<(), Error> {
+        let a = Bump::Patch.bump_str("0.0.0")?;
+        let b = Bump::Patch.bump_str("1.0.0")?;
+        let c = Bump::Patch.bump_str("1.2.3")?;
+
+        assert_eq!(a, "0.0.1".parse().unwrap());
+        assert_eq!(b, "1.0.1".parse().unwrap());
+        assert_eq!(c, "1.2.4".parse().unwrap());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bump_rc() -> Result<(), Error> {
+        let a = Bump::Rc.bump_str("0.1.0")?;
+        let b = Bump::Rc.bump_str("1.0.0")?;
+        let c = Bump::Rc.bump_str("1.0.0-alpha.1")?;
+        let d = Bump::Rc.bump_str("1.0.0-beta.1")?;
+        let e = Bump::Rc.bump_str("1.0.0-rc.1")?;
+
+        assert_eq!(a, "0.2.0-rc.1".parse().unwrap());
+        assert_eq!(b, "2.0.0-rc.1".parse().unwrap());
+        assert_eq!(c, "1.0.0-rc.1".parse().unwrap());
+        assert_eq!(d, "1.0.0-rc.1".parse().unwrap());
+        assert_eq!(e, "1.0.0-rc.2".parse().unwrap());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bump_beta() -> Result<(), Error> {
+        let a = Bump::Beta.bump_str("0.1.0")?;
+        let b = Bump::Beta.bump_str("1.0.0")?;
+        let c = Bump::Beta.bump_str("1.0.0-alpha.1")?;
+        let d = Bump::Beta.bump_str("1.0.0-beta.1")?;
+        let e = Bump::Beta.bump_str("1.0.0-rc.1");
+
+        assert_eq!(a, "0.2.0-beta.1".parse().unwrap());
+        assert_eq!(b, "2.0.0-beta.1".parse().unwrap());
+        assert_eq!(c, "1.0.0-beta.1".parse().unwrap());
+        assert_eq!(d, "1.0.0-beta.2".parse().unwrap());
+
+        assert!(e.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bump_alpha() -> Result<(), Error> {
+        let a = Bump::Alpha.bump_str("0.1.0")?;
+        let b = Bump::Alpha.bump_str("1.0.0")?;
+        let c = Bump::Alpha.bump_str("0.1.0-alpha.1")?;
+        let d = Bump::Alpha.bump_str("1.0.0-alpha.1")?;
+        let e = Bump::Alpha.bump_str("1.0.0-beta.1");
+        let f = Bump::Alpha.bump_str("1.0.0-rc.1");
+
+        assert_eq!(a, "0.2.0-alpha.1".parse().unwrap());
+        assert_eq!(b, "2.0.0-alpha.1".parse().unwrap());
+        assert_eq!(c, "0.1.0-alpha.2".parse().unwrap());
+        assert_eq!(d, "1.0.0-alpha.2".parse().unwrap());
+
+        assert!(e.is_err());
+        assert!(f.is_err());
+
+        Ok(())
+    }
+}

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use globset::{Glob, GlobSetBuilder};
-use toml_edit::{Array, Document, TableLike, Value};
+use toml_edit::{Array, Document, Item, TableLike, Value};
 
 use crate::package::members::Members;
 
@@ -25,6 +25,14 @@ impl Manifest {
     pub fn package(&self) -> Option<Package<'_>> {
         match self.0.get("package") {
             Some(item) => item.as_table_like().map(Package),
+            None => None,
+        }
+    }
+
+    /// Gets the mutable package table.
+    pub fn package_mut(&mut self) -> Option<PackageMut<'_>> {
+        match self.0.get_mut("package") {
+            Some(item) => item.as_table_like_mut().map(PackageMut),
             None => None,
         }
     }
@@ -175,6 +183,20 @@ impl<'a> Package<'a> {
             .expect("version")
             .as_str()
             .expect("version")
+    }
+}
+
+/// The mutable package table.
+pub struct PackageMut<'a>(&'a mut dyn TableLike);
+
+impl<'a> PackageMut<'a> {
+    /// Sets the package version.
+    pub fn set_version<V>(&mut self, version: V) -> &mut Self
+    where
+        V: Into<String>,
+    {
+        *self.0.get_mut("version").expect("version") = Item::Value(Value::from(version.into()));
+        self
     }
 }
 

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -8,6 +8,8 @@ use std::path::{Path, PathBuf};
 pub use self::error::Error;
 use self::manifest::Manifest;
 
+use super::{Bump, BumpError};
+
 /// A `Cargo.toml` package for Rust.
 pub struct Cargo {
     manifest: Manifest,
@@ -35,8 +37,26 @@ impl Cargo {
         self.manifest.package().expect("package").version()
     }
 
+    pub fn set_version<V>(&mut self, version: V) -> &mut Self
+    where
+        V: Into<String>,
+    {
+        self.manifest
+            .package_mut()
+            .expect("package")
+            .set_version(version);
+        self
+    }
+
     /// Gets the package path.
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    /// Bumps the package version.
+    pub fn bump(&mut self, bump: Bump) -> Result<(), BumpError> {
+        self.set_version(bump.bump_str(self.version())?.to_string());
+
+        Ok(())
     }
 }

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -3,6 +3,7 @@
 //! This module includes utilities for inspecting and managing packages located
 //! on the local file system or in a remote version control system.
 
+mod bump;
 pub mod cargo;
 mod error;
 mod manifest;
@@ -10,6 +11,7 @@ mod members;
 
 use std::path::{Path, PathBuf};
 
+pub use self::bump::{Bump, Error as BumpError};
 use self::cargo::Cargo;
 pub use self::error::Error;
 use self::manifest::Manifest;
@@ -53,6 +55,13 @@ impl Package {
     pub fn kind(&self) -> PackageKind {
         match self {
             Self::Cargo(_) => PackageKind::Cargo,
+        }
+    }
+
+    /// Bumps the package version.
+    pub fn bump(&mut self, bump: Bump) -> Result<(), BumpError> {
+        match self {
+            Self::Cargo(cargo) => Ok(cargo.bump(bump)?),
         }
     }
 }


### PR DESCRIPTION
This adds a method to the `Package` type to bump the specified version component.

The short-term goal of this project is to support creating GitHub releases via an automated Pull Request. This requires that the package version number be updated for the new release.

This adds the ability to update the package version not with a specific version number but instead to increment the major, minor, patch, or prerelease component. This currently only supports the three major Rust prerelease targets rc, beta and alpha but the design may need to be adapted when support for other languages is added.