### PR TITLE
Add project package cache

### DIFF
--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -48,7 +48,7 @@ impl Info {
 
         println!("\n{}:\n", style("Packages").underlined().bold());
 
-        let packages = project.get_packages()?;
+        let packages = project.packages();
         let max_name_len = packages
             .iter()
             .map(|pkg| pkg.name().len())

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -9,7 +9,7 @@ use super::error::Error;
 use super::Cargo;
 
 /// The cargo package manifest.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Manifest(Document);
 
 impl Manifest {

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -11,6 +11,7 @@ use self::manifest::Manifest;
 use super::{Bump, BumpError};
 
 /// A `Cargo.toml` package for Rust.
+#[derive(Clone, Debug)]
 pub struct Cargo {
     manifest: Manifest,
     path: PathBuf,

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -17,6 +17,7 @@ pub use self::error::Error;
 use self::manifest::Manifest;
 
 /// A package in one of several supported formats.
+#[derive(Clone, Debug)]
 pub enum Package {
     /// A `Cargo.toml` package for Rust.
     Cargo(Cargo),

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -25,7 +25,7 @@ fn test_valid_local_project() -> Result<(), Error> {
     assert!(b.contains("[package]"));
     assert!(project.get_file_contents("packages/ploys").is_err());
 
-    let packages = project.get_packages()?;
+    let packages = project.packages();
 
     assert!(packages.iter().any(|pkg| pkg.name() == "ploys"));
     assert!(packages.iter().any(|pkg| pkg.name() == "ploys-cli"));
@@ -60,7 +60,7 @@ fn test_valid_remote_project() -> Result<(), Error> {
     assert!(b.contains("[package]"));
     assert!(project.get_file_contents("packages/ploys").is_err());
 
-    let packages = project.get_packages()?;
+    let packages = project.packages();
 
     assert!(packages.iter().any(|pkg| pkg.name() == "ploys"));
     assert!(packages.iter().any(|pkg| pkg.name() == "ploys-cli"));


### PR DESCRIPTION
This adds a package cache to the project type that is generated during construction.

The short-term goal of this project is to create GitHub releases via an automated Pull Request. This requires that package versions be updated but the previous design only supported updating the package manifest in-memory. Cargo and other package managers make use of lock files that also need to be updated with the corresponding versions. Both the package manifest and lock file need to be updated in tandem and this can only be done through the project type.

This introduces a local package cache inside the project type that will eventually be used to store the altered state of packages so that a bump can update both the package and lock file before being persisted to the source.