### PR TITLE
Add project name cache

### DIFF
--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -43,7 +43,7 @@ impl Info {
         ploys::project::Error: From<T::Error>,
     {
         println!("{}:\n", style("Project").underlined().bold());
-        println!("Name:       {}", project.get_name()?);
+        println!("Name:       {}", project.name());
         println!("Repository: {}", project.get_url()?);
 
         println!("\n{}:\n", style("Packages").underlined().bold());

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -15,7 +15,7 @@
 //!
 //! let project = Project::git(".").unwrap();
 //!
-//! println!("Name:       {}", project.get_name().unwrap());
+//! println!("Name:       {}", project.name());
 //! println!("Repository: {}", project.get_url().unwrap());
 //! ```
 //!
@@ -30,7 +30,7 @@
 //!
 //! let project = Project::github("ploys/ploys").unwrap();
 //!
-//! println!("Name:       {}", project.get_name().unwrap());
+//! println!("Name:       {}", project.name());
 //! println!("Repository: {}", project.get_url().unwrap());
 //! ```
 
@@ -52,6 +52,7 @@ use self::source::Source;
 #[derive(Clone, Debug)]
 pub struct Project<T = Git> {
     source: T,
+    name: String,
     packages: Vec<Package>,
 }
 
@@ -66,17 +67,27 @@ where
         T::Config: Default,
     {
         let source = T::open()?;
+        let name = source.get_name()?;
         let packages = source.get_packages()?;
 
-        Ok(Self { source, packages })
+        Ok(Self {
+            source,
+            name,
+            packages,
+        })
     }
 
     /// Opens the project with the given source configuration.
     pub fn open_with(config: T::Config) -> Result<Self, Error> {
         let source = T::open_with(config)?;
+        let name = source.get_name()?;
         let packages = source.get_packages()?;
 
-        Ok(Self { source, packages })
+        Ok(Self {
+            source,
+            name,
+            packages,
+        })
     }
 }
 
@@ -87,9 +98,14 @@ impl Project<Git> {
         P: AsRef<Path>,
     {
         let source = Git::new(path)?;
+        let name = source.get_name()?;
         let packages = source.get_packages()?;
 
-        Ok(Self { source, packages })
+        Ok(Self {
+            source,
+            name,
+            packages,
+        })
     }
 }
 
@@ -100,9 +116,14 @@ impl Project<GitHub> {
         R: AsRef<str>,
     {
         let source = GitHub::new(repository)?.validated()?;
+        let name = source.get_name()?;
         let packages = source.get_packages()?;
 
-        Ok(Self { source, packages })
+        Ok(Self {
+            source,
+            name,
+            packages,
+        })
     }
 
     /// Opens a project with the GitHub source and authentication token.
@@ -114,9 +135,14 @@ impl Project<GitHub> {
         let source = GitHub::new(repository)?
             .with_authentication_token(token)
             .validated()?;
+        let name = source.get_name()?;
         let packages = source.get_packages()?;
 
-        Ok(Self { source, packages })
+        Ok(Self {
+            source,
+            name,
+            packages,
+        })
     }
 }
 
@@ -125,12 +151,9 @@ where
     T: Source,
     Error: From<T::Error>,
 {
-    /// Queries the project name.
-    ///
-    /// This method may perform file system operations or network requests to
-    /// query the latest project information.
-    pub fn get_name(&self) -> Result<String, Error> {
-        Ok(self.source.get_name()?)
+    /// Gets the project name.
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     /// Queries the project URL.

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -8,7 +8,7 @@ fn test_valid_local_project() -> Result<(), Error> {
     let project = Project::git("../..")?;
     let url = project.get_url()?;
 
-    assert_eq!(project.get_name()?, "ploys");
+    assert_eq!(project.name(), "ploys");
     assert_eq!(url.domain(), Some("github.com"));
     assert_eq!(url.path().trim_end_matches(".git"), "/ploys/ploys");
 
@@ -41,7 +41,7 @@ fn test_valid_remote_project() -> Result<(), Error> {
         None => Project::github("ploys/ploys")?,
     };
 
-    assert_eq!(project.get_name()?, "ploys");
+    assert_eq!(project.name(), "ploys");
     assert_eq!(
         project.get_url()?,
         "https://github.com/ploys/ploys".parse().unwrap()


### PR DESCRIPTION
This adds a cached name to the project type that is discovered during construction.

The project name will be potentially used multiple times when additional functionality is added to the library and command line interface. Each call to get the name could be expensive so code would need to be written to store this value in memory.

This reduces the overhead of multiple calls by getting the project name when the project type is constructed and storing it inside the state. There is a potential for this to cause the project state to become stale for long-running programs but that can be addressed by adding a way to sync the project information with the source after construction.