### PR TITLE
Add project package bump method

### DIFF
--- a/packages/ploys/src/project/error.rs
+++ b/packages/ploys/src/project/error.rs
@@ -7,6 +7,10 @@ pub enum Error {
     Git(crate::project::source::git::Error),
     /// The GitHub source error.
     GitHub(crate::project::source::github::Error),
+    /// The package bump error.
+    Bump(crate::package::BumpError),
+    /// The package not found error.
+    PackageNotFound(String),
 }
 
 impl Display for Error {
@@ -14,6 +18,8 @@ impl Display for Error {
         match self {
             Error::Git(git) => Display::fmt(git, f),
             Error::GitHub(github) => Display::fmt(github, f),
+            Error::Bump(err) => Display::fmt(err, f),
+            Error::PackageNotFound(name) => write!(f, "Package not found: `{name}`."),
         }
     }
 }
@@ -29,5 +35,11 @@ impl From<crate::project::source::git::Error> for Error {
 impl From<crate::project::source::github::Error> for Error {
     fn from(error: crate::project::source::github::Error) -> Self {
         Self::GitHub(error)
+    }
+}
+
+impl From<crate::package::BumpError> for Error {
+    fn from(error: crate::package::BumpError) -> Self {
+        Self::Bump(error)
     }
 }

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -41,7 +41,7 @@ use std::path::{Path, PathBuf};
 
 use url::Url;
 
-use crate::package::Package;
+use crate::package::{Bump, Package};
 
 pub use self::error::Error;
 use self::source::git::Git;
@@ -186,5 +186,20 @@ where
         P: AsRef<Path>,
     {
         Ok(self.source.get_file_contents(path)?)
+    }
+
+    /// Bumps the version of the target package.
+    pub fn bump_package_version<S>(&mut self, package: S, bump: Bump) -> Result<(), Error>
+    where
+        S: AsRef<str>,
+    {
+        match self
+            .packages
+            .iter_mut()
+            .find(|pkg| pkg.name() == package.as_ref())
+        {
+            Some(package) => Ok(package.bump(bump)?),
+            None => Err(Error::PackageNotFound(package.as_ref().to_owned())),
+        }
     }
 }


### PR DESCRIPTION
This adds a method to the project type to bump the version of a discovered package.

In order to support project-level lock files the mutability of the package version number must be controlled via the project type instead of the individual package type. This allows the version to be updated simultaneously with the lock file. This will eliminate the need to check the version numbers of each package when the state is persisted back to the source. It also allows the future possibility of dealing with local dependencies that include the version number as those may also need to be updated.

The change also includes two new project error variants but a future update may want to move these to the more specific package error.