### PR TITLE
Move package discovery from project source

### DIFF
--- a/packages/ploys/src/project/error.rs
+++ b/packages/ploys/src/project/error.rs
@@ -7,6 +7,8 @@ pub enum Error {
     Git(crate::project::source::git::Error),
     /// The GitHub source error.
     GitHub(crate::project::source::github::Error),
+    /// The package error.
+    Package(crate::package::Error),
     /// The package bump error.
     Bump(crate::package::BumpError),
     /// The package not found error.
@@ -18,6 +20,7 @@ impl Display for Error {
         match self {
             Error::Git(git) => Display::fmt(git, f),
             Error::GitHub(github) => Display::fmt(github, f),
+            Error::Package(err) => Display::fmt(err, f),
             Error::Bump(err) => Display::fmt(err, f),
             Error::PackageNotFound(name) => write!(f, "Package not found: `{name}`."),
         }
@@ -35,6 +38,12 @@ impl From<crate::project::source::git::Error> for Error {
 impl From<crate::project::source::github::Error> for Error {
     fn from(error: crate::project::source::github::Error) -> Self {
         Self::GitHub(error)
+    }
+}
+
+impl From<crate::package::Error> for Error {
+    fn from(error: crate::package::Error) -> Self {
+        Self::Package(error)
     }
 }
 

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -68,7 +68,7 @@ where
     {
         let source = T::open()?;
         let name = source.get_name()?;
-        let packages = source.get_packages()?;
+        let packages = Package::discover_packages(&source)?;
 
         Ok(Self {
             source,
@@ -81,7 +81,7 @@ where
     pub fn open_with(config: T::Config) -> Result<Self, Error> {
         let source = T::open_with(config)?;
         let name = source.get_name()?;
-        let packages = source.get_packages()?;
+        let packages = Package::discover_packages(&source)?;
 
         Ok(Self {
             source,
@@ -99,7 +99,7 @@ impl Project<Git> {
     {
         let source = Git::new(path)?;
         let name = source.get_name()?;
-        let packages = source.get_packages()?;
+        let packages = Package::discover_packages(&source)?;
 
         Ok(Self {
             source,
@@ -117,7 +117,7 @@ impl Project<GitHub> {
     {
         let source = GitHub::new(repository)?.validated()?;
         let name = source.get_name()?;
-        let packages = source.get_packages()?;
+        let packages = Package::discover_packages(&source)?;
 
         Ok(Self {
             source,
@@ -136,7 +136,7 @@ impl Project<GitHub> {
             .with_authentication_token(token)
             .validated()?;
         let name = source.get_name()?;
-        let packages = source.get_packages()?;
+        let packages = Package::discover_packages(&source)?;
 
         Ok(Self {
             source,

--- a/packages/ploys/src/project/source/git/error.rs
+++ b/packages/ploys/src/project/source/git/error.rs
@@ -8,8 +8,6 @@ pub enum Error {
     Git(GitError),
     /// An I/O error.
     Io(io::Error),
-    /// A package error.
-    Package(crate::package::Error),
 }
 
 impl Error {
@@ -28,18 +26,11 @@ impl Display for Error {
         match self {
             Self::Git(error) => Display::fmt(error, f),
             Self::Io(error) => Display::fmt(error, f),
-            Self::Package(error) => Display::fmt(error, f),
         }
     }
 }
 
 impl std::error::Error for Error {}
-
-impl From<crate::package::Error> for Error {
-    fn from(error: crate::package::Error) -> Self {
-        Self::Package(error)
-    }
-}
 
 impl From<std::io::Error> for Error {
     fn from(error: std::io::Error) -> Self {

--- a/packages/ploys/src/project/source/git/mod.rs
+++ b/packages/ploys/src/project/source/git/mod.rs
@@ -12,8 +12,6 @@ use gix::traverse::tree::Recorder;
 use gix::Repository;
 use url::Url;
 
-use crate::package::Package;
-
 pub use self::error::{Error, GitError};
 
 use super::Source;
@@ -76,12 +74,6 @@ impl Source for Git {
             },
             None => Err(Error::remote_not_found()),
         }
-    }
-
-    fn get_packages(&self) -> Result<Vec<Package>, Self::Error> {
-        let files = self.get_files()?;
-
-        Package::discover(&files, |path| self.get_file_contents(path))
     }
 
     fn get_files(&self) -> Result<Vec<PathBuf>, Self::Error> {

--- a/packages/ploys/src/project/source/github/error.rs
+++ b/packages/ploys/src/project/source/github/error.rs
@@ -12,8 +12,6 @@ pub enum Error {
     Parse(String),
     /// An I/O error.
     Io(io::Error),
-    /// A package error.
-    Package(crate::package::Error),
 }
 
 impl Display for Error {
@@ -29,18 +27,11 @@ impl Display for Error {
             Error::Transport(transport) => Display::fmt(transport, f),
             Error::Parse(message) => write!(f, "Parse error: {message}"),
             Error::Io(err) => Display::fmt(err, f),
-            Error::Package(err) => Display::fmt(err, f),
         }
     }
 }
 
 impl std::error::Error for Error {}
-
-impl From<crate::package::Error> for Error {
-    fn from(error: crate::package::Error) -> Self {
-        Self::Package(error)
-    }
-}
 
 impl From<io::Error> for Error {
     fn from(error: io::Error) -> Self {

--- a/packages/ploys/src/project/source/github/mod.rs
+++ b/packages/ploys/src/project/source/github/mod.rs
@@ -12,8 +12,6 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 use url::Url;
 
-use crate::package::Package;
-
 pub use self::error::Error;
 pub use self::repo::Repository;
 
@@ -76,12 +74,6 @@ impl Source for GitHub {
         Ok(format!("https://github.com/{}", self.repository)
             .parse()
             .unwrap())
-    }
-
-    fn get_packages(&self) -> Result<Vec<Package>, Self::Error> {
-        let files = self.get_files()?;
-
-        Package::discover(&files, |path| self.get_file_contents(path))
     }
 
     fn get_files(&self) -> Result<Vec<PathBuf>, Self::Error> {

--- a/packages/ploys/src/project/source/mod.rs
+++ b/packages/ploys/src/project/source/mod.rs
@@ -10,8 +10,6 @@ use std::path::{Path, PathBuf};
 
 use url::Url;
 
-use crate::package::Package;
-
 /// A project source.
 pub trait Source {
     /// The source configuration.
@@ -39,9 +37,6 @@ pub trait Source {
 
     /// Queries the source URL.
     fn get_url(&self) -> Result<Url, Self::Error>;
-
-    /// Queries the project packages.
-    fn get_packages(&self) -> Result<Vec<Package>, Self::Error>;
 
     /// Queries the project files.
     fn get_files(&self) -> Result<Vec<PathBuf>, Self::Error>;


### PR DESCRIPTION
This moves package discovery from the project source to the package module.

The initial implementation of package discovery required the use of a closure to support the differences between the Git and GitHub project variants. This was then migrated to the project source types with minimal changes. With the addition of the source trait the logic for this can now be separated from the source entirely.

This simply removes references to packages from the project source types and updates the existing private methods to use the source instead of a closure. The project error now also contains a new package variant for package errors.