### PR TITLE
Add initial lockfile support

### DIFF
--- a/packages/ploys/src/lib.rs
+++ b/packages/ploys/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod lockfile;
 pub mod package;
 pub mod project;

--- a/packages/ploys/src/lockfile/cargo/error.rs
+++ b/packages/ploys/src/lockfile/cargo/error.rs
@@ -1,0 +1,33 @@
+use std::fmt::{self, Display};
+
+/// A cargo lockfile error.
+#[derive(Debug)]
+pub enum Error {
+    /// A manifest error.
+    Manifest(toml_edit::TomlError),
+    /// A UTF-8 error.
+    Utf8(std::str::Utf8Error),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Manifest(err) => Display::fmt(err, f),
+            Self::Utf8(err) => Display::fmt(err, f),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<toml_edit::TomlError> for Error {
+    fn from(err: toml_edit::TomlError) -> Self {
+        Self::Manifest(err)
+    }
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Self::Utf8(err)
+    }
+}

--- a/packages/ploys/src/lockfile/cargo/mod.rs
+++ b/packages/ploys/src/lockfile/cargo/mod.rs
@@ -1,0 +1,70 @@
+//! The `Cargo.lock` lockfile for Rust.
+
+mod error;
+
+use toml_edit::{ArrayOfTables, Document, Item, TableLike, Value};
+
+pub use self::error::Error;
+
+/// A `Cargo.lock` lockfile for Rust.
+#[derive(Clone, Debug)]
+pub struct CargoLockFile {
+    manifest: Document,
+}
+
+impl CargoLockFile {
+    /// Sets the package version.
+    pub fn set_package_version<P, V>(&mut self, package: P, version: V)
+    where
+        P: AsRef<str>,
+        V: Into<String>,
+    {
+        if let Some(mut package) = self.packages_mut().get_mut(package.as_ref()) {
+            package.set_version(version);
+        }
+    }
+
+    /// Creates a manifest from the given bytes.
+    pub(super) fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        Ok(Self {
+            manifest: std::str::from_utf8(bytes)?.parse()?,
+        })
+    }
+
+    fn packages_mut(&mut self) -> PackagesMut<'_> {
+        PackagesMut(
+            self.manifest
+                .get_mut("package")
+                .and_then(Item::as_array_of_tables_mut),
+        )
+    }
+}
+
+/// The mutable packages table.
+struct PackagesMut<'a>(Option<&'a mut ArrayOfTables>);
+
+impl<'a> PackagesMut<'a> {
+    fn get_mut(&'a mut self, package: &'a str) -> Option<PackageMut<'a>> {
+        match &mut self.0 {
+            Some(arr) => arr
+                .iter_mut()
+                .find(|table| table.get("name").and_then(Item::as_str) == Some(package))
+                .map(|table| PackageMut(table)),
+            None => None,
+        }
+    }
+}
+
+/// The mutable package table.
+struct PackageMut<'a>(&'a mut dyn TableLike);
+
+impl<'a> PackageMut<'a> {
+    /// Sets the package version.
+    fn set_version<V>(&mut self, version: V) -> &mut Self
+    where
+        V: Into<String>,
+    {
+        *self.0.get_mut("version").expect("version") = Item::Value(Value::from(version.into()));
+        self
+    }
+}

--- a/packages/ploys/src/lockfile/error.rs
+++ b/packages/ploys/src/lockfile/error.rs
@@ -1,0 +1,24 @@
+use std::fmt::{self, Display};
+
+/// The lockfile error.
+#[derive(Debug)]
+pub enum Error {
+    /// A cargo lockfile error.
+    Cargo(super::cargo::Error),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cargo(err) => Display::fmt(err, f),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<super::cargo::Error> for Error {
+    fn from(err: super::cargo::Error) -> Self {
+        Self::Cargo(err)
+    }
+}

--- a/packages/ploys/src/lockfile/mod.rs
+++ b/packages/ploys/src/lockfile/mod.rs
@@ -1,0 +1,65 @@
+//! Lockfile inspection and management utilities
+//!
+//! This module includes utilities for inspecting and managing lockfiles across
+//! different package managers.
+
+pub mod cargo;
+mod error;
+
+use std::collections::HashMap;
+
+use crate::package::PackageKind;
+use crate::project::source::Source;
+
+use self::cargo::CargoLockFile;
+pub use self::error::Error;
+
+/// A lockfile in one of several supported formats.
+#[derive(Clone, Debug)]
+pub enum LockFile {
+    /// A `Cargo.lock` lockfile for Rust.
+    Cargo(CargoLockFile),
+}
+
+impl LockFile {
+    /// Sets the package version.
+    pub fn set_package_version<P, V>(&mut self, package: P, version: V)
+    where
+        P: AsRef<str>,
+        V: Into<String>,
+    {
+        match self {
+            Self::Cargo(cargo) => cargo.set_package_version(package, version),
+        }
+    }
+
+    /// Discovers project lockfiles.
+    pub(super) fn discover_lockfiles<T>(
+        source: &T,
+    ) -> Result<HashMap<PackageKind, Self>, crate::project::Error>
+    where
+        T: Source,
+        crate::project::Error: From<T::Error>,
+    {
+        let mut lockfiles = HashMap::new();
+
+        for kind in PackageKind::variants() {
+            if let Some(lockfile_name) = kind.lockfile_name() {
+                if let Ok(bytes) = source.get_file_contents(lockfile_name) {
+                    let lockfile = LockFile::from_bytes(*kind, &bytes)?;
+
+                    lockfiles.insert(*kind, lockfile);
+                }
+            }
+        }
+
+        Ok(lockfiles)
+    }
+
+    /// Creates a lockfile from the given bytes.
+    fn from_bytes(kind: PackageKind, bytes: &[u8]) -> Result<Self, Error> {
+        match kind {
+            PackageKind::Cargo => Ok(Self::Cargo(CargoLockFile::from_bytes(bytes)?)),
+        }
+    }
+}

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -98,7 +98,7 @@ impl From<Cargo> for Package {
 }
 
 /// The package kind.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum PackageKind {
     /// The cargo package kind.
     Cargo,
@@ -106,7 +106,7 @@ pub enum PackageKind {
 
 impl PackageKind {
     /// Gets the package variants.
-    fn variants() -> &'static [Self] {
+    pub(super) fn variants() -> &'static [Self] {
         &[Self::Cargo]
     }
 
@@ -114,6 +114,13 @@ impl PackageKind {
     pub fn file_name(&self) -> &'static Path {
         match self {
             Self::Cargo => Path::new("Cargo.toml"),
+        }
+    }
+
+    /// Gets the lockfile name.
+    pub(super) fn lockfile_name(&self) -> Option<&'static Path> {
+        match self {
+            Self::Cargo => Some(Path::new("Cargo.lock")),
         }
     }
 }

--- a/packages/ploys/src/project/error.rs
+++ b/packages/ploys/src/project/error.rs
@@ -11,6 +11,8 @@ pub enum Error {
     Package(crate::package::Error),
     /// The package bump error.
     Bump(crate::package::BumpError),
+    /// The lockfile error.
+    LockFile(crate::lockfile::Error),
     /// The package not found error.
     PackageNotFound(String),
 }
@@ -22,6 +24,7 @@ impl Display for Error {
             Error::GitHub(github) => Display::fmt(github, f),
             Error::Package(err) => Display::fmt(err, f),
             Error::Bump(err) => Display::fmt(err, f),
+            Error::LockFile(err) => Display::fmt(err, f),
             Error::PackageNotFound(name) => write!(f, "Package not found: `{name}`."),
         }
     }
@@ -50,5 +53,11 @@ impl From<crate::package::Error> for Error {
 impl From<crate::package::BumpError> for Error {
     fn from(error: crate::package::BumpError) -> Self {
         Self::Bump(error)
+    }
+}
+
+impl From<crate::lockfile::Error> for Error {
+    fn from(error: crate::lockfile::Error) -> Self {
+        Self::LockFile(error)
     }
 }


### PR DESCRIPTION
This adds the initial lockfile support for use in package version bumping.

The inclusion of package version bumping in #20 only handled the package file but not the corresponding lockfile. The only currently supported package manager _Cargo_ stores the version number of local packages in the `Cargo.lock` file. This should be kept in sync to avoid issues such as _Cargo_ automatically updating the lockfile and the changes being included in a subsequent unrelated pull request.

This adds automatic lockfile discovery on construction of the project type but does not yet expose a way to read this information through the project. Instead it simply bumps the internal manifest whenever a package version is bumped.