### PR TITLE
Refactor inconsistent error naming

### DIFF
--- a/packages/ploys/src/project/error.rs
+++ b/packages/ploys/src/project/error.rs
@@ -20,12 +20,12 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Git(git) => Display::fmt(git, f),
-            Error::GitHub(github) => Display::fmt(github, f),
-            Error::Package(err) => Display::fmt(err, f),
-            Error::Bump(err) => Display::fmt(err, f),
-            Error::LockFile(err) => Display::fmt(err, f),
-            Error::PackageNotFound(name) => write!(f, "Package not found: `{name}`."),
+            Self::Git(git) => Display::fmt(git, f),
+            Self::GitHub(github) => Display::fmt(github, f),
+            Self::Package(err) => Display::fmt(err, f),
+            Self::Bump(err) => Display::fmt(err, f),
+            Self::LockFile(err) => Display::fmt(err, f),
+            Self::PackageNotFound(name) => write!(f, "Package not found: `{name}`."),
         }
     }
 }
@@ -33,31 +33,31 @@ impl Display for Error {
 impl std::error::Error for Error {}
 
 impl From<crate::project::source::git::Error> for Error {
-    fn from(error: crate::project::source::git::Error) -> Self {
-        Self::Git(error)
+    fn from(err: crate::project::source::git::Error) -> Self {
+        Self::Git(err)
     }
 }
 
 impl From<crate::project::source::github::Error> for Error {
-    fn from(error: crate::project::source::github::Error) -> Self {
-        Self::GitHub(error)
+    fn from(err: crate::project::source::github::Error) -> Self {
+        Self::GitHub(err)
     }
 }
 
 impl From<crate::package::Error> for Error {
-    fn from(error: crate::package::Error) -> Self {
-        Self::Package(error)
+    fn from(err: crate::package::Error) -> Self {
+        Self::Package(err)
     }
 }
 
 impl From<crate::package::BumpError> for Error {
-    fn from(error: crate::package::BumpError) -> Self {
-        Self::Bump(error)
+    fn from(err: crate::package::BumpError) -> Self {
+        Self::Bump(err)
     }
 }
 
 impl From<crate::lockfile::Error> for Error {
-    fn from(error: crate::lockfile::Error) -> Self {
-        Self::LockFile(error)
+    fn from(err: crate::lockfile::Error) -> Self {
+        Self::LockFile(err)
     }
 }

--- a/packages/ploys/src/project/source/git/error.rs
+++ b/packages/ploys/src/project/source/git/error.rs
@@ -24,8 +24,8 @@ impl Error {
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Git(error) => Display::fmt(error, f),
-            Self::Io(error) => Display::fmt(error, f),
+            Self::Git(err) => Display::fmt(err, f),
+            Self::Io(err) => Display::fmt(err, f),
         }
     }
 }
@@ -33,44 +33,44 @@ impl Display for Error {
 impl std::error::Error for Error {}
 
 impl From<std::io::Error> for Error {
-    fn from(error: std::io::Error) -> Self {
-        Self::Io(error)
+    fn from(err: std::io::Error) -> Self {
+        Self::Io(err)
     }
 }
 
 impl From<gix::open::Error> for Error {
-    fn from(error: gix::open::Error) -> Self {
-        Self::Git(error.into())
+    fn from(err: gix::open::Error) -> Self {
+        Self::Git(err.into())
     }
 }
 
 impl From<gix::remote::find::existing::Error> for Error {
-    fn from(error: gix::remote::find::existing::Error) -> Self {
-        Self::Git(error.into())
+    fn from(err: gix::remote::find::existing::Error) -> Self {
+        Self::Git(err.into())
     }
 }
 
 impl From<gix::revision::spec::parse::single::Error> for Error {
-    fn from(error: gix::revision::spec::parse::single::Error) -> Self {
-        Self::Git(error.into())
+    fn from(err: gix::revision::spec::parse::single::Error) -> Self {
+        Self::Git(err.into())
     }
 }
 
 impl From<gix::odb::find::existing::Error<gix::odb::store::find::Error>> for Error {
-    fn from(error: gix::odb::find::existing::Error<gix::odb::store::find::Error>) -> Self {
-        Self::Git(error.into())
+    fn from(err: gix::odb::find::existing::Error<gix::odb::store::find::Error>) -> Self {
+        Self::Git(err.into())
     }
 }
 
 impl From<gix::object::peel::to_kind::Error> for Error {
-    fn from(error: gix::object::peel::to_kind::Error) -> Self {
-        Self::Git(error.into())
+    fn from(err: gix::object::peel::to_kind::Error) -> Self {
+        Self::Git(err.into())
     }
 }
 
 impl From<gix::traverse::tree::breadthfirst::Error> for Error {
-    fn from(error: gix::traverse::tree::breadthfirst::Error) -> Self {
-        Self::Git(error.into())
+    fn from(err: gix::traverse::tree::breadthfirst::Error) -> Self {
+        Self::Git(err.into())
     }
 }
 
@@ -107,37 +107,37 @@ impl Display for GitError {
 impl std::error::Error for GitError {}
 
 impl From<gix::open::Error> for GitError {
-    fn from(error: gix::open::Error) -> Self {
-        Self::Open(Box::new(error))
+    fn from(err: gix::open::Error) -> Self {
+        Self::Open(Box::new(err))
     }
 }
 
 impl From<gix::remote::find::existing::Error> for GitError {
-    fn from(error: gix::remote::find::existing::Error) -> Self {
-        Self::Remote(Box::new(error))
+    fn from(err: gix::remote::find::existing::Error) -> Self {
+        Self::Remote(Box::new(err))
     }
 }
 
 impl From<gix::revision::spec::parse::single::Error> for GitError {
-    fn from(error: gix::revision::spec::parse::single::Error) -> Self {
-        Self::Revision(Box::new(error))
+    fn from(err: gix::revision::spec::parse::single::Error) -> Self {
+        Self::Revision(Box::new(err))
     }
 }
 
 impl From<gix::odb::find::existing::Error<gix::odb::store::find::Error>> for GitError {
-    fn from(error: gix::odb::find::existing::Error<gix::odb::store::find::Error>) -> Self {
-        Self::ObjectFind(Box::new(error))
+    fn from(err: gix::odb::find::existing::Error<gix::odb::store::find::Error>) -> Self {
+        Self::ObjectFind(Box::new(err))
     }
 }
 
 impl From<gix::object::peel::to_kind::Error> for GitError {
-    fn from(error: gix::object::peel::to_kind::Error) -> Self {
-        Self::ObjectKind(Box::new(error))
+    fn from(err: gix::object::peel::to_kind::Error) -> Self {
+        Self::ObjectKind(Box::new(err))
     }
 }
 
 impl From<gix::traverse::tree::breadthfirst::Error> for GitError {
-    fn from(error: gix::traverse::tree::breadthfirst::Error) -> Self {
-        Self::Traverse(Box::new(error))
+    fn from(err: gix::traverse::tree::breadthfirst::Error) -> Self {
+        Self::Traverse(Box::new(err))
     }
 }

--- a/packages/ploys/src/project/source/github/error.rs
+++ b/packages/ploys/src/project/source/github/error.rs
@@ -17,16 +17,16 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Response(status_code) => match status_code {
+            Self::Response(status_code) => match status_code {
                 401 => write!(f, "401 Unauthorized"),
                 403 => write!(f, "403 Forbidden"),
                 404 => write!(f, "404 Not Found"),
                 429 => write!(f, "429 Too Many Requests"),
                 status_code => write!(f, "Response error: {status_code}"),
             },
-            Error::Transport(transport) => Display::fmt(transport, f),
-            Error::Parse(message) => write!(f, "Parse error: {message}"),
-            Error::Io(err) => Display::fmt(err, f),
+            Self::Transport(transport) => Display::fmt(transport, f),
+            Self::Parse(message) => write!(f, "Parse error: {message}"),
+            Self::Io(err) => Display::fmt(err, f),
         }
     }
 }
@@ -34,14 +34,14 @@ impl Display for Error {
 impl std::error::Error for Error {}
 
 impl From<io::Error> for Error {
-    fn from(error: io::Error) -> Self {
-        Self::Io(error)
+    fn from(err: io::Error) -> Self {
+        Self::Io(err)
     }
 }
 
 impl From<ureq::Error> for Error {
-    fn from(error: ureq::Error) -> Self {
-        match error {
+    fn from(err: ureq::Error) -> Self {
+        match err {
             ureq::Error::Status(status_code, _) => Self::Response(status_code),
             ureq::Error::Transport(transport) => Self::Transport(Box::new(transport)),
         }


### PR DESCRIPTION
This simply refactors the error code to be more consistent by using `err` instead of `error` for variable names and `Self` instead of `Error` for type names inside `Error` implementations.

These changes are minor nitpicks but help the error implementations to be more consistent across the various modules. The use of `Error` instead of `Self` appears to be due to the Rust Analyzer fill match arms quick fix getting confused.