### PR TITLE
Set workspace resolver version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "packages/*",
 ]


### PR DESCRIPTION
This simply sets the workspace resolver version to "2".

The GitHub Actions workflow was reporting the following warning that the default resolver for a virtual workspace without a root-level package was version "1" instead of "2" despite the default for 2021 edition packages being "2".

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

This simply sets the value in the root `Cargo.toml` file to the newer version but does not make any attempt to update the `Cargo.lock` file with newly resolved versions.