### PR TITLE
Add debug implementation for cargo dependencies

### DIFF
--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -1,3 +1,4 @@
+use std::fmt::{self, Debug};
 use std::path::PathBuf;
 
 use globset::{Glob, GlobSetBuilder};
@@ -219,10 +220,21 @@ impl<'a> IntoIterator for Dependencies<'a> {
     }
 }
 
+impl<'a> Debug for Dependencies<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(Self(self.0)).finish()
+    }
+}
+
 /// The dependency item.
 pub struct Dependency<'a>(&'a str, Option<&'a dyn TableLike>);
 
 impl<'a> Dependency<'a> {
+    /// Gets the dependency name.
+    pub fn name(&self) -> &'a str {
+        self.0
+    }
+
     /// Gets the dependency path if it has been set.
     pub fn path(&self) -> Option<&'a str> {
         match self.1 {
@@ -232,5 +244,14 @@ impl<'a> Dependency<'a> {
             },
             None => None,
         }
+    }
+}
+
+impl<'a> Debug for Dependency<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Dependency")
+            .field("name", &self.name())
+            .field("path", &self.path())
+            .finish()
     }
 }


### PR DESCRIPTION
This adds an implementation of `Debug` for the cargo manifest `Dependency` and `Dependencies` structs.

Although these types are not yet exported it is useful for development when types can be debugged. This initially targets the dependency types to resolve a lint warning about an unused field without removing it. This allows the project to continue development without the actions workflow failing.