### PR TITLE
Bump toml_edit to 0.22.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "unicode-bom",
- "winnow",
+ "winnow 0.5.4",
 ]
 
 [[package]]
@@ -2768,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
@@ -3281,24 +3281,24 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.11",
 ]
 
 [[package]]
@@ -3904,6 +3904,15 @@ name = "winnow"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acaaa1190073b2b101e15083c38ee8ec891b5e05cbee516521e94ec008f61e64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c52728401e1dc672a56e81e593e912aa54c78f40246869f78359a2bf24d29d"
 dependencies = [
  "memchr",
 ]

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -13,6 +13,6 @@ gix = "0.51.0"
 globset = "0.4.13"
 semver = "1.0.19"
 serde = { version = "1.0.185", features = ["derive"] }
-toml_edit = { version = "0.20.2", features = ["serde"] }
+toml_edit = { version = "0.22.14", features = ["serde"] }
 ureq = { version = "2.7.1", features = ["json"] }
 url = "2.4.0"

--- a/packages/ploys/src/lockfile/cargo/mod.rs
+++ b/packages/ploys/src/lockfile/cargo/mod.rs
@@ -2,14 +2,14 @@
 
 mod error;
 
-use toml_edit::{ArrayOfTables, Document, Item, TableLike, Value};
+use toml_edit::{ArrayOfTables, DocumentMut, Item, TableLike, Value};
 
 pub use self::error::Error;
 
 /// A `Cargo.lock` lockfile for Rust.
 #[derive(Clone, Debug)]
 pub struct CargoLockFile {
-    manifest: Document,
+    manifest: DocumentMut,
 }
 
 impl CargoLockFile {

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Debug};
 use std::path::PathBuf;
 
 use globset::{Glob, GlobSetBuilder};
-use toml_edit::{Array, Document, Item, TableLike, Value};
+use toml_edit::{Array, DocumentMut, Item, TableLike, Value};
 
 use crate::package::members::Members;
 
@@ -11,7 +11,7 @@ use super::Cargo;
 
 /// The cargo package manifest.
 #[derive(Clone, Debug)]
-pub struct Manifest(Document);
+pub struct Manifest(DocumentMut);
 
 impl Manifest {
     /// Gets the workspace table.


### PR DESCRIPTION
This bumps `toml_edit` from `0.20.2` to `0.22.14`.

This change replaces the deprecated `Document` type alias with the `DocumentMut` struct but otherwise contains no other significant changes.