### PR TITLE
Add GitHub webhook endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -172,7 +172,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -282,6 +282,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
+dependencies = [
+ "axum 0.7.5",
+ "axum-core 0.4.3",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +336,15 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -403,7 +435,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -465,6 +497,15 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -584,6 +625,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +658,16 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "doc-comment"
@@ -749,7 +810,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -777,6 +838,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1211,7 +1282,7 @@ checksum = "999ce923619f88194171a67fb3e6d613653b8d4d6078b529b15a765da0edcc17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1665,6 +1736,30 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http 1.1.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -2233,7 +2328,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2266,6 +2361,8 @@ name = "ploys-api"
 version = "0.0.0"
 dependencies = [
  "axum 0.7.5",
+ "axum-extra",
+ "serde_json",
  "shuttle-axum",
  "shuttle-runtime",
  "tokio",
@@ -2347,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -2384,7 +2481,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2398,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2624,29 +2721,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.185"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.185"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -2682,6 +2779,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2724,7 +2832,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2931,7 +3039,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.32",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2947,9 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.32"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3003,7 +3111,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3098,7 +3206,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3226,7 +3334,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3315,6 +3423,12 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uluru"
@@ -3483,7 +3597,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -3505,7 +3619,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3816,7 +3930,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/packages/ploys-api/Cargo.toml
+++ b/packages/ploys-api/Cargo.toml
@@ -11,6 +11,8 @@ publish = false
 
 [dependencies]
 axum = "0.7.5"
+axum-extra = { version = "0.9.3", features = ["typed-header"] }
+serde_json = "1.0.117"
 shuttle-axum = "0.45.0"
 shuttle-runtime = "0.45.0"
 tokio = "1.33.0"

--- a/packages/ploys-api/src/github/mod.rs
+++ b/packages/ploys-api/src/github/mod.rs
@@ -1,0 +1,1 @@
+pub mod webhook;

--- a/packages/ploys-api/src/github/webhook/header.rs
+++ b/packages/ploys-api/src/github/webhook/header.rs
@@ -1,0 +1,52 @@
+use std::fmt::{self, Display};
+
+use axum::http::{HeaderName, HeaderValue};
+use axum_extra::headers::{Error, Header};
+
+static X_GITHUB_EVENT: HeaderName = HeaderName::from_static("x-github-event");
+
+pub struct XGitHubEvent {
+    value: String,
+}
+
+impl XGitHubEvent {
+    pub fn into_inner(self) -> String {
+        self.value
+    }
+}
+
+impl Display for XGitHubEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.value, f)
+    }
+}
+
+impl Header for XGitHubEvent {
+    fn name() -> &'static HeaderName {
+        &X_GITHUB_EVENT
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = &'i HeaderValue>,
+        Self: Sized,
+    {
+        Ok(Self {
+            value: values
+                .next()
+                .ok_or_else(Error::invalid)?
+                .to_str()
+                .map_err(|_| Error::invalid())?
+                .to_owned(),
+        })
+    }
+
+    fn encode<E>(&self, values: &mut E)
+    where
+        E: Extend<HeaderValue>,
+    {
+        values.extend(std::iter::once(
+            HeaderValue::from_str(&self.value).expect("valid header"),
+        ));
+    }
+}

--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -1,0 +1,14 @@
+mod header;
+mod payload;
+
+use axum::http::StatusCode;
+
+use self::payload::Payload;
+
+/// Receives the GitHub webhook event payload.
+pub async fn receive(payload: Payload) -> StatusCode {
+    println!("Event: {}", payload.event);
+    println!("Payload: {:#}", payload.value);
+
+    StatusCode::OK
+}

--- a/packages/ploys-api/src/github/webhook/payload.rs
+++ b/packages/ploys-api/src/github/webhook/payload.rs
@@ -1,0 +1,77 @@
+use std::borrow::Cow;
+
+use axum::extract::rejection::JsonRejection;
+use axum::extract::{FromRequest, Json, Request};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::{async_trait, RequestExt};
+use axum_extra::typed_header::TypedHeaderRejection;
+use axum_extra::TypedHeader;
+use serde_json::Value;
+
+use super::header::XGitHubEvent;
+
+/// The GitHub event payload.
+pub struct Payload {
+    /// The event name.
+    pub event: String,
+    /// The payload value.
+    pub value: Value,
+}
+
+#[async_trait]
+impl<S> FromRequest<S> for Payload
+where
+    S: Send + Sync,
+{
+    type Rejection = PayloadRejection;
+
+    async fn from_request(mut req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let event = req.extract_parts::<TypedHeader<XGitHubEvent>>().await?;
+        let value = Json::from_request(req, state).await?;
+
+        Ok(Self {
+            event: event.0.into_inner(),
+            value: value.0,
+        })
+    }
+}
+
+pub enum PayloadRejection {
+    Header(TypedHeaderRejection),
+    Json(JsonRejection),
+}
+
+impl PayloadRejection {
+    pub fn status(&self) -> StatusCode {
+        match self {
+            Self::Header(_) => StatusCode::BAD_REQUEST,
+            Self::Json(rej) => rej.status(),
+        }
+    }
+
+    pub fn message(&self) -> Cow<'static, str> {
+        match self {
+            Self::Header(rej) => Cow::Owned(rej.to_string()),
+            Self::Json(rej) => Cow::Owned(rej.body_text()),
+        }
+    }
+}
+
+impl IntoResponse for PayloadRejection {
+    fn into_response(self) -> Response {
+        (self.status(), self.message()).into_response()
+    }
+}
+
+impl From<TypedHeaderRejection> for PayloadRejection {
+    fn from(value: TypedHeaderRejection) -> Self {
+        Self::Header(value)
+    }
+}
+
+impl From<JsonRejection> for PayloadRejection {
+    fn from(rejection: JsonRejection) -> Self {
+        Self::Json(rejection)
+    }
+}

--- a/packages/ploys-api/src/main.rs
+++ b/packages/ploys-api/src/main.rs
@@ -1,13 +1,11 @@
-use axum::routing::get;
-use axum::Router;
+mod github;
 
-async fn hello_world() -> &'static str {
-    "Hello, world!"
-}
+use axum::routing::post;
+use axum::Router;
 
 #[shuttle_runtime::main]
 async fn axum() -> shuttle_axum::ShuttleAxum {
-    let router = Router::new().route("/", get(hello_world));
+    let router = Router::new().route("/github/webhook", post(self::github::webhook::receive));
 
     Ok(router.into())
 }


### PR DESCRIPTION
This adds a GitHub webhook endpoint to receive GitHub event payloads.

The `ploys-api` crate is intended to function as a GitHub App and respond to GitHub events such as releases, pull requests and action runs. This adds an endpoint for the `Ploys` app that can receive event payloads. This is just the first step as the payloads need to be validated to ensure it only handles events from the app.

This change introduces the `axum-extra` crate for handling of typed headers and provides a custom `XGitHubEvent` header type to read the event header. The `serde_json` crate is used to store a generic event payload as it is not yet clear which payloads need to be supported. A custom extractor is used to combine these and get the payload from the request.