### PR TITLE
Add GitHub webhook endpoint secret validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+Secrets*.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arc-swap"
@@ -613,6 +613,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1713,6 +1714,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,12 +2305,18 @@ dependencies = [
 name = "ploys-api"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "axum 0.7.5",
  "axum-extra",
+ "hex",
+ "hmac",
+ "mime",
  "serde_json",
+ "sha2",
  "shuttle-axum",
  "shuttle-runtime",
  "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2712,6 +2734,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,6 +2990,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3194,9 +3233,9 @@ checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/packages/ploys-api/Cargo.toml
+++ b/packages/ploys-api/Cargo.toml
@@ -10,9 +10,15 @@ edition = "2021"
 publish = false
 
 [dependencies]
+anyhow = "1.0.89"
 axum = "0.7.5"
 axum-extra = { version = "0.9.3", features = ["typed-header"] }
+hex = "0.4.3"
+hmac = "0.12.1"
+mime = "0.3.17"
 serde_json = "1.0.117"
+sha2 = "0.10.8"
 shuttle-axum = "0.47.0"
 shuttle-runtime = "0.47.0"
-tokio = "1.33.0"
+tokio = { version = "1.33.0", features = ["rt", "macros"] }
+tower-service = "0.3.3"

--- a/packages/ploys-api/src/github/webhook/header.rs
+++ b/packages/ploys-api/src/github/webhook/header.rs
@@ -4,6 +4,7 @@ use axum::http::{HeaderName, HeaderValue};
 use axum_extra::headers::{Error, Header};
 
 static X_GITHUB_EVENT: HeaderName = HeaderName::from_static("x-github-event");
+static X_HUB_SIGNATURE_256: HeaderName = HeaderName::from_static("x-hub-signature-256");
 
 pub struct XGitHubEvent {
     value: String,
@@ -34,6 +35,52 @@ impl Header for XGitHubEvent {
         Ok(Self {
             value: values
                 .next()
+                .ok_or_else(Error::invalid)?
+                .to_str()
+                .map_err(|_| Error::invalid())?
+                .to_owned(),
+        })
+    }
+
+    fn encode<E>(&self, values: &mut E)
+    where
+        E: Extend<HeaderValue>,
+    {
+        values.extend(std::iter::once(
+            HeaderValue::from_str(&self.value).expect("valid header"),
+        ));
+    }
+}
+
+pub struct XHubSignature256 {
+    value: String,
+}
+
+impl XHubSignature256 {
+    pub fn value(&self) -> &str {
+        &self.value["sha256=".len()..]
+    }
+}
+
+impl Display for XHubSignature256 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.value, f)
+    }
+}
+
+impl Header for XHubSignature256 {
+    fn name() -> &'static HeaderName {
+        &X_HUB_SIGNATURE_256
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = &'i HeaderValue>,
+        Self: Sized,
+    {
+        Ok(Self {
+            value: values
+                .find(|value| value.as_bytes().starts_with(b"sha256="))
                 .ok_or_else(Error::invalid)?
                 .to_str()
                 .map_err(|_| Error::invalid())?

--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -1,5 +1,6 @@
 mod header;
 mod payload;
+pub mod secret;
 
 use axum::http::StatusCode;
 
@@ -11,4 +12,99 @@ pub async fn receive(payload: Payload) -> StatusCode {
     println!("Payload: {:#}", payload.value);
 
     StatusCode::OK
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Method, Request, StatusCode};
+    use axum::routing::post;
+    use axum::{Extension, Router};
+    use hmac::{Hmac, Mac};
+    use serde_json::{json, Value};
+    use sha2::Sha256;
+    use tower_service::Service;
+
+    use super::secret::WebhookSecret;
+
+    fn router() -> Router {
+        Router::new().route(
+            "/github/webhook",
+            post(super::receive).layer(Extension(WebhookSecret {
+                value: String::from("super_secret"),
+            })),
+        )
+    }
+
+    fn payload() -> Value {
+        json!({
+            "action": "opened",
+            "issue": {
+              "url": "https://api.github.com/repos/octocat/Hello-World/issues/1347",
+              "number": 1347
+            },
+            "repository" : {
+              "id": 1296269,
+              "full_name": "octocat/Hello-World",
+              "owner": {
+                  "login": "octocat",
+                  "id": 1
+              }
+            },
+            "sender": {
+              "login": "octocat",
+              "id": 1
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn test_webhook_endpoint_valid_signature() {
+        let mut router = router();
+        let payload = serde_json::to_string(&payload()).unwrap();
+        let mut hmac = Hmac::<Sha256>::new_from_slice(b"super_secret").unwrap();
+
+        hmac.update(payload.as_bytes());
+
+        let digest = hmac.finalize().into_bytes();
+        let hex = hex::encode(digest);
+
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/github/webhook")
+            .header("Content-Type", "application/json")
+            .header("X-GitHub-Event", "issues")
+            .header("X-Hub-Signature-256", format!("sha256={hex}"))
+            .body(Body::from(payload))
+            .unwrap();
+
+        let response = router.call(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_webhook_endpoint_invalid_signature() {
+        let mut router = router();
+        let payload = serde_json::to_string(&payload()).unwrap();
+        let mut hmac = Hmac::<Sha256>::new_from_slice(b"not_super_secret").unwrap();
+
+        hmac.update(payload.as_bytes());
+
+        let digest = hmac.finalize().into_bytes();
+        let hex = hex::encode(digest);
+
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/github/webhook")
+            .header("Content-Type", "application/json")
+            .header("X-GitHub-Event", "issues")
+            .header("X-Hub-Signature-256", format!("sha256={hex}"))
+            .body(Body::from(payload))
+            .unwrap();
+
+        let response = router.call(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
 }

--- a/packages/ploys-api/src/github/webhook/secret.rs
+++ b/packages/ploys-api/src/github/webhook/secret.rs
@@ -1,0 +1,17 @@
+use anyhow::{anyhow, Error};
+use shuttle_runtime::SecretStore;
+
+#[derive(Clone)]
+pub struct WebhookSecret {
+    pub value: String,
+}
+
+impl WebhookSecret {
+    /// Gets the secret from the secret store.
+    pub fn from_store(store: &SecretStore, name: &str) -> Result<Self, Error> {
+        match store.get(name) {
+            Some(value) => Ok(Self { value }),
+            None => Err(anyhow!("Missing GitHub App webhook secret.")),
+        }
+    }
+}

--- a/packages/ploys-api/src/main.rs
+++ b/packages/ploys-api/src/main.rs
@@ -1,11 +1,20 @@
 mod github;
 
 use axum::routing::post;
-use axum::Router;
+use axum::{Extension, Router};
+use shuttle_runtime::SecretStore;
+
+use self::github::webhook::secret::WebhookSecret;
 
 #[shuttle_runtime::main]
-async fn axum() -> shuttle_axum::ShuttleAxum {
-    let router = Router::new().route("/github/webhook", post(self::github::webhook::receive));
+async fn axum(#[shuttle_runtime::Secrets] secret_store: SecretStore) -> shuttle_axum::ShuttleAxum {
+    let router = Router::new().route(
+        "/github/webhook",
+        post(self::github::webhook::receive).layer(Extension(WebhookSecret::from_store(
+            &secret_store,
+            "GITHUB_APP_WEBHOOK_SECRET",
+        )?)),
+    );
 
     Ok(router.into())
 }


### PR DESCRIPTION
This adds GitHub webhook endpoint secret validation to ensure that it only accepts payloads from GitHub.

The GitHub webhook payload request includes the `X-Hub-Signature-256` header to allow the receiver to validate the payload as originating from GitHub using a secret key configured in the GitHub App dashboard. This ensures that nobody else can craft a request to trigger the API without the secret key.

This change adds the ability to parse the header and validate the response using a secret stored in the shuttle runtime secret store. It also includes simple tests to validate that an incorrect key returns the correct response. This does not deal with security issues such as timing attacks but the plan is to eventually spin off this code into a separate crate where further development can happen.