### PR TITLE
Add ability to load GitHub project at a specific commit

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -47,7 +47,7 @@ use crate::package::{Bump, Package, PackageKind};
 
 pub use self::error::Error;
 use self::source::git::Git;
-use self::source::github::GitHub;
+use self::source::github::{GitHub, Reference};
 use self::source::Source;
 
 /// A project from one of several supported sources.
@@ -137,6 +137,27 @@ impl Project<GitHub> {
         })
     }
 
+    /// Opens a project with the GitHub source and reference.
+    pub fn github_with_reference<R, F>(repository: R, reference: F) -> Result<Self, Error>
+    where
+        R: AsRef<str>,
+        F: Into<Reference>,
+    {
+        let source = GitHub::new(repository)?
+            .with_reference(reference)
+            .validated()?;
+        let name = source.get_name()?;
+        let packages = Package::discover_packages(&source)?;
+        let lockfiles = LockFile::discover_lockfiles(&source)?;
+
+        Ok(Self {
+            source,
+            name,
+            packages,
+            lockfiles,
+        })
+    }
+
     /// Opens a project with the GitHub source and authentication token.
     pub fn github_with_authentication_token<R, T>(repository: R, token: T) -> Result<Self, Error>
     where
@@ -144,6 +165,34 @@ impl Project<GitHub> {
         T: Into<String>,
     {
         let source = GitHub::new(repository)?
+            .with_authentication_token(token)
+            .validated()?;
+        let name = source.get_name()?;
+        let packages = Package::discover_packages(&source)?;
+        let lockfiles = LockFile::discover_lockfiles(&source)?;
+
+        Ok(Self {
+            source,
+            name,
+            packages,
+            lockfiles,
+        })
+    }
+
+    /// Opens a project with the GitHub source, reference, and authentication
+    /// token.
+    pub fn github_with_reference_and_authentication_token<R, F, T>(
+        repository: R,
+        reference: F,
+        token: T,
+    ) -> Result<Self, Error>
+    where
+        R: AsRef<str>,
+        F: Into<Reference>,
+        T: Into<String>,
+    {
+        let source = GitHub::new(repository)?
+            .with_reference(reference)
             .with_authentication_token(token)
             .validated()?;
         let name = source.get_name()?;

--- a/packages/ploys/src/project/source/github/mod.rs
+++ b/packages/ploys/src/project/source/github/mod.rs
@@ -4,6 +4,7 @@
 //! management.
 
 mod error;
+mod reference;
 mod repo;
 
 use std::io;
@@ -13,6 +14,7 @@ use serde::Deserialize;
 use url::Url;
 
 pub use self::error::Error;
+pub use self::reference::Reference;
 pub use self::repo::Repository;
 
 use super::Source;
@@ -21,6 +23,7 @@ use super::Source;
 #[derive(Clone, Debug)]
 pub struct GitHub {
     repository: Repository,
+    reference: Reference,
     token: Option<String>,
 }
 
@@ -32,8 +35,15 @@ impl GitHub {
     {
         Ok(Self {
             repository: repository.as_ref().parse::<Repository>()?,
+            reference: Reference::head(),
             token: None,
         })
+    }
+
+    /// Builds the source with the given reference.
+    pub(crate) fn with_reference(mut self, reference: impl Into<Reference>) -> Self {
+        self.reference = reference.into();
+        self
     }
 
     /// Builds the source with the given authentication token.
@@ -79,7 +89,10 @@ impl Source for GitHub {
     fn get_files(&self) -> Result<Vec<PathBuf>, Self::Error> {
         let request = self
             .repository
-            .get("git/trees/HEAD", self.token.as_deref())
+            .get(
+                format!("git/trees/{}", self.reference),
+                self.token.as_deref(),
+            )
             .set("Accept", "application/vnd.github+json")
             .set("X-GitHub-Api-Version", "2022-11-28")
             .query("recursive", "true");
@@ -105,7 +118,11 @@ impl Source for GitHub {
         let request = self
             .repository
             .get(
-                format!("contents/{}", path.as_ref().display()),
+                format!(
+                    "contents/{}?ref={}",
+                    path.as_ref().display(),
+                    self.reference
+                ),
                 self.token.as_deref(),
             )
             .set("Accept", "application/vnd.github.raw")

--- a/packages/ploys/src/project/source/github/mod.rs
+++ b/packages/ploys/src/project/source/github/mod.rs
@@ -70,9 +70,10 @@ impl Source for GitHub {
     {
         match config.token {
             Some(token) => Ok(Self::new(config.repo)?
+                .with_reference(config.reference)
                 .with_authentication_token(token)
                 .validated()?),
-            None => Self::new(config.repo),
+            None => Ok(Self::new(config.repo)?.with_reference(config.reference)),
         }
     }
 
@@ -146,6 +147,7 @@ impl Source for GitHub {
 /// The GitHub source configuration.
 pub struct GitHubConfig {
     repo: String,
+    reference: Reference,
     token: Option<String>,
 }
 
@@ -157,8 +159,15 @@ impl GitHubConfig {
     {
         Self {
             repo: repo.into(),
+            reference: Reference::head(),
             token: None,
         }
+    }
+
+    /// Builds the configuration with the given reference.
+    pub fn with_reference(mut self, reference: impl Into<Reference>) -> Self {
+        self.reference = reference.into();
+        self
     }
 
     /// Builds the configuration with the given authentication token.

--- a/packages/ploys/src/project/source/github/reference.rs
+++ b/packages/ploys/src/project/source/github/reference.rs
@@ -1,0 +1,43 @@
+use std::fmt::{self, Display};
+
+/// The git reference.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Reference {
+    Head,
+    Sha(String),
+    Branch(String),
+    Tag(String),
+}
+
+impl Reference {
+    /// Constructs a new head reference.
+    pub fn head() -> Self {
+        Self::Head
+    }
+
+    /// Constructs a new SHA reference.
+    pub fn sha(sha: impl Into<String>) -> Self {
+        Self::Sha(sha.into())
+    }
+
+    /// Constructs a new branch reference.
+    pub fn branch(branch: impl Into<String>) -> Self {
+        Self::Branch(branch.into())
+    }
+
+    /// Constructs a new tag reference.
+    pub fn tag(tag: impl Into<String>) -> Self {
+        Self::Tag(tag.into())
+    }
+}
+
+impl Display for Reference {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Head => write!(f, "HEAD"),
+            Self::Sha(sha) => Display::fmt(sha, f),
+            Self::Branch(branch) => Display::fmt(branch, f),
+            Self::Tag(tag) => Display::fmt(tag, f),
+        }
+    }
+}

--- a/packages/ploys/src/project/source/github/reference.rs
+++ b/packages/ploys/src/project/source/github/reference.rs
@@ -1,8 +1,9 @@
 use std::fmt::{self, Display};
 
 /// The git reference.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum Reference {
+    #[default]
     Head,
     Sha(String),
     Branch(String),


### PR DESCRIPTION
This adds the ability to load a GitHub project with a specific commit SHA, branch, or tag name.

The current implementation of the GitHub project source hard-codes the `HEAD` reference, enabling it to load the latest project information from the main branch. However, it does not provide a way to get project information from another point in time or from another branch. This would be useful to compare two commits to detect any changes. For example, it would be possible to determine which packages had been updated.

This change introduces a new `Reference` type under the GitHub project source, updates the source implementation to use this reference, and exposes new methods to configure which reference to use.