### PR TITLE
Add `git2` integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,6 +2237,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.3.2+3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,6 +2253,7 @@ checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,11 +377,13 @@ checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
 
 [[package]]
 name = "cc"
-version = "1.0.82"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
+ "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -813,6 +815,21 @@ name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
 
 [[package]]
 name = "gix"
@@ -2006,6 +2023,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,6 +2060,46 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2165,6 +2231,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "opentelemetry"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,9 +2373,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
 name = "ploys"
 version = "0.0.0"
 dependencies = [
+ "git2",
  "gix",
  "globset",
  "semver",
@@ -2758,6 +2849,12 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shuttle-axum"
@@ -3458,6 +3555,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
-git2 = { version = "0.19.0", features = ["vendored-libgit2"] }
 gix = "0.66.0"
 globset = "0.4.13"
 semver = "1.0.19"
@@ -17,3 +16,7 @@ serde = { version = "1.0.185", features = ["derive"] }
 toml_edit = { version = "0.22.14", features = ["serde"] }
 ureq = { version = "2.7.1", features = ["json"] }
 url = "2.4.0"
+
+[dependencies.git2]
+version = "0.19.0"
+features = ["vendored-libgit2", "vendored-openssl"]

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
+git2 = { version = "0.19.0", features = ["vendored-libgit2"] }
 gix = "0.66.0"
 globset = "0.4.13"
 semver = "1.0.19"

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -116,6 +116,26 @@ impl Project<Git> {
             lockfiles,
         })
     }
+
+    #[doc(hidden)]
+    pub fn git2<P>(path: P) -> Result<Self, Error>
+    where
+        P: AsRef<Path>,
+    {
+        use self::source::git::Git2;
+
+        let source = Git::Git2(Git2::new(path)?);
+        let name = source.get_name()?;
+        let packages = Package::discover_packages(&source)?;
+        let lockfiles = LockFile::discover_lockfiles(&source)?;
+
+        Ok(Self {
+            source,
+            name,
+            packages,
+            lockfiles,
+        })
+    }
 }
 
 impl Project<GitHub> {

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -273,3 +273,35 @@ where
         }
     }
 }
+
+impl Project<Git> {
+    /// Upgrades the interior source in place to use advanced `git` operations.
+    ///
+    /// The `Git` source uses two internal implementations of `git`, one that is
+    /// pure Rust and another that uses C bindings. The former is not yet
+    /// feature complete and so this swaps to the other implementation to
+    /// support push operations.
+    pub fn upgrade(&mut self) -> Result<(), Error> {
+        use self::source::git::{Error, Git2};
+
+        if let Git::Gix(gix) = &self.source {
+            let path = gix
+                .repository
+                .path()
+                .join("..")
+                .canonicalize()
+                .map_err(Into::<Error>::into)?;
+
+            self.source = Git::Git2(Git2::new(path)?);
+        }
+
+        Ok(())
+    }
+
+    /// Upgrades the interior source to use advanced `git` operations.
+    pub fn upgraded(mut self) -> Result<Self, Error> {
+        self.upgrade()?;
+
+        Ok(self)
+    }
+}

--- a/packages/ploys/src/project/source/git/error.rs
+++ b/packages/ploys/src/project/source/git/error.rs
@@ -4,8 +4,10 @@ use std::io;
 /// The Git source error.
 #[derive(Debug)]
 pub enum Error {
-    /// A Git error.
-    Git(GitError),
+    /// A `gix` error.
+    Gix(GixError),
+    /// A `git2` error.
+    Git2(git2::Error),
     /// An I/O error.
     Io(io::Error),
 }
@@ -13,7 +15,7 @@ pub enum Error {
 impl Error {
     /// Creates a remote not found error.
     pub(super) fn remote_not_found() -> Self {
-        Self::Git(GitError::Remote(Box::new(
+        Self::Gix(GixError::Remote(Box::new(
             gix::remote::find::existing::Error::NotFound {
                 name: String::from("origin").into(),
             },
@@ -24,7 +26,8 @@ impl Error {
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Git(err) => Display::fmt(err, f),
+            Self::Gix(err) => Display::fmt(err, f),
+            Self::Git2(err) => Display::fmt(err, f),
             Self::Io(err) => Display::fmt(err, f),
         }
     }
@@ -40,43 +43,49 @@ impl From<std::io::Error> for Error {
 
 impl From<gix::open::Error> for Error {
     fn from(err: gix::open::Error) -> Self {
-        Self::Git(err.into())
+        Self::Gix(err.into())
     }
 }
 
 impl From<gix::remote::find::existing::Error> for Error {
     fn from(err: gix::remote::find::existing::Error) -> Self {
-        Self::Git(err.into())
+        Self::Gix(err.into())
     }
 }
 
 impl From<gix::revision::spec::parse::single::Error> for Error {
     fn from(err: gix::revision::spec::parse::single::Error) -> Self {
-        Self::Git(err.into())
+        Self::Gix(err.into())
     }
 }
 
 impl From<gix::object::find::existing::Error> for Error {
     fn from(err: gix::object::find::existing::Error) -> Self {
-        Self::Git(err.into())
+        Self::Gix(err.into())
     }
 }
 
 impl From<gix::object::peel::to_kind::Error> for Error {
     fn from(err: gix::object::peel::to_kind::Error) -> Self {
-        Self::Git(err.into())
+        Self::Gix(err.into())
     }
 }
 
 impl From<gix::traverse::tree::breadthfirst::Error> for Error {
     fn from(err: gix::traverse::tree::breadthfirst::Error) -> Self {
-        Self::Git(err.into())
+        Self::Gix(err.into())
+    }
+}
+
+impl From<git2::Error> for Error {
+    fn from(err: git2::Error) -> Self {
+        Self::Git2(err)
     }
 }
 
 /// A Git error.
 #[derive(Debug)]
-pub enum GitError {
+pub enum GixError {
     /// An open error.
     Open(Box<gix::open::Error>),
     /// A remote lookup error.
@@ -91,7 +100,7 @@ pub enum GitError {
     Traverse(Box<gix::traverse::tree::breadthfirst::Error>),
 }
 
-impl Display for GitError {
+impl Display for GixError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Open(err) => Display::fmt(err, f),
@@ -104,39 +113,39 @@ impl Display for GitError {
     }
 }
 
-impl std::error::Error for GitError {}
+impl std::error::Error for GixError {}
 
-impl From<gix::open::Error> for GitError {
+impl From<gix::open::Error> for GixError {
     fn from(err: gix::open::Error) -> Self {
         Self::Open(Box::new(err))
     }
 }
 
-impl From<gix::remote::find::existing::Error> for GitError {
+impl From<gix::remote::find::existing::Error> for GixError {
     fn from(err: gix::remote::find::existing::Error) -> Self {
         Self::Remote(Box::new(err))
     }
 }
 
-impl From<gix::revision::spec::parse::single::Error> for GitError {
+impl From<gix::revision::spec::parse::single::Error> for GixError {
     fn from(err: gix::revision::spec::parse::single::Error) -> Self {
         Self::Revision(Box::new(err))
     }
 }
 
-impl From<gix::object::find::existing::Error> for GitError {
+impl From<gix::object::find::existing::Error> for GixError {
     fn from(err: gix::object::find::existing::Error) -> Self {
         Self::ObjectFind(Box::new(err))
     }
 }
 
-impl From<gix::object::peel::to_kind::Error> for GitError {
+impl From<gix::object::peel::to_kind::Error> for GixError {
     fn from(err: gix::object::peel::to_kind::Error) -> Self {
         Self::ObjectKind(Box::new(err))
     }
 }
 
-impl From<gix::traverse::tree::breadthfirst::Error> for GitError {
+impl From<gix::traverse::tree::breadthfirst::Error> for GixError {
     fn from(err: gix::traverse::tree::breadthfirst::Error) -> Self {
         Self::Traverse(Box::new(err))
     }

--- a/packages/ploys/src/project/source/git/git2/mod.rs
+++ b/packages/ploys/src/project/source/git/git2/mod.rs
@@ -1,0 +1,123 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+use git2::{ObjectType, Repository, TreeWalkMode, TreeWalkResult};
+use url::Url;
+
+use super::{Error, GitConfig, Source};
+
+/// The local Git repository source using `git2`.
+pub struct Git2 {
+    repository: Repository,
+}
+
+impl Git2 {
+    /// Creates a Git2 source.
+    pub(crate) fn new<P>(path: P) -> Result<Self, Error>
+    where
+        P: AsRef<Path>,
+    {
+        Ok(Self {
+            repository: Repository::open(path.as_ref())?,
+        })
+    }
+
+    /// Gets the default remote name.
+    ///
+    /// This replicates the logic from `remote_default_name` in `gix`.
+    fn get_default_remote_name(&self) -> Result<Option<String>, Error> {
+        let remote_name = self
+            .repository
+            .config()?
+            .get_str("remote.pushDefault")
+            .map(ToOwned::to_owned)
+            .map(Some)
+            .or_else(|_| {
+                let remotes = self.repository.remotes()?;
+
+                Ok::<_, Error>(match remotes.len() {
+                    0 => None,
+                    1 => remotes.get(0).map(ToOwned::to_owned),
+                    _ => remotes
+                        .iter()
+                        .any(|remote| remote == Some("origin"))
+                        .then_some("origin")
+                        .map(ToOwned::to_owned),
+                })
+            })?;
+
+        Ok(remote_name)
+    }
+}
+
+impl Source for Git2 {
+    type Config = GitConfig;
+    type Error = Error;
+
+    fn open_with(config: Self::Config) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        Self::new(config.path)
+    }
+
+    fn get_name(&self) -> Result<String, Self::Error> {
+        let path = self.repository.path().join("..").canonicalize()?;
+
+        if let Some(file_stem) = path.file_stem() {
+            return Ok(file_stem.to_string_lossy().to_string());
+        }
+
+        Err(Error::Io(io::Error::new(
+            io::ErrorKind::Other,
+            "Invalid directory",
+        )))
+    }
+
+    fn get_url(&self) -> Result<Url, Self::Error> {
+        let remote_name = self
+            .get_default_remote_name()?
+            .ok_or_else(Error::remote_not_found)?;
+
+        let remote = self.repository.find_remote(&remote_name)?;
+
+        match remote.url() {
+            Some(url) => Ok(Url::parse(url).expect("url")),
+            None => Err(Error::remote_not_found()),
+        }
+    }
+
+    fn get_files(&self) -> Result<Vec<PathBuf>, Self::Error> {
+        let tree = self.repository.revparse_single("HEAD")?.peel_to_tree()?;
+        let mut entries = Vec::new();
+
+        tree.walk(TreeWalkMode::PreOrder, |path, entry| {
+            if let Some(ObjectType::Blob) = entry.kind() {
+                if let Some(name) = entry.name() {
+                    entries.push(Path::new(path).join(name));
+                }
+            }
+
+            TreeWalkResult::Ok
+        })?;
+
+        entries.sort();
+
+        Ok(entries)
+    }
+
+    fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Self::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let tree = self.repository.revparse_single("HEAD")?.peel_to_tree()?;
+        let entry = tree.get_path(path.as_ref())?;
+        let object = entry.to_object(&self.repository)?;
+
+        if let Some(blob) = object.as_blob() {
+            Ok(blob.content().to_vec())
+        } else {
+            Err(io::Error::from(io::ErrorKind::NotFound))?
+        }
+    }
+}

--- a/packages/ploys/src/project/source/git/gix/mod.rs
+++ b/packages/ploys/src/project/source/git/gix/mod.rs
@@ -9,7 +9,6 @@ use url::Url;
 use super::{Error, GitConfig, Source};
 
 /// The local Git repository source using `gix`.
-#[derive(Clone, Debug)]
 pub struct Gix {
     repository: Repository,
 }

--- a/packages/ploys/src/project/source/git/gix/mod.rs
+++ b/packages/ploys/src/project/source/git/gix/mod.rs
@@ -10,7 +10,7 @@ use super::{Error, GitConfig, Source};
 
 /// The local Git repository source using `gix`.
 pub struct Gix {
-    repository: Repository,
+    pub(crate) repository: Repository,
 }
 
 impl Gix {

--- a/packages/ploys/src/project/source/git/gix/mod.rs
+++ b/packages/ploys/src/project/source/git/gix/mod.rs
@@ -1,0 +1,114 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+use gix::remote::Direction;
+use gix::traverse::tree::Recorder;
+use gix::Repository;
+use url::Url;
+
+use super::{Error, GitConfig, Source};
+
+/// The local Git repository source using `gix`.
+#[derive(Clone, Debug)]
+pub struct Gix {
+    repository: Repository,
+}
+
+impl Gix {
+    /// Creates a Gix source.
+    pub(crate) fn new<P>(path: P) -> Result<Self, Error>
+    where
+        P: AsRef<Path>,
+    {
+        Ok(Self {
+            repository: gix::open(path.as_ref())?,
+        })
+    }
+}
+
+impl Source for Gix {
+    type Config = GitConfig;
+    type Error = Error;
+
+    fn open_with(config: Self::Config) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        Self::new(config.path)
+    }
+
+    fn get_name(&self) -> Result<String, Self::Error> {
+        let path = self.repository.path().join("..").canonicalize()?;
+
+        if let Some(file_stem) = path.file_stem() {
+            return Ok(file_stem.to_string_lossy().to_string());
+        }
+
+        Err(Error::Io(io::Error::new(
+            io::ErrorKind::Other,
+            "Invalid directory",
+        )))
+    }
+
+    fn get_url(&self) -> Result<Url, Self::Error> {
+        match self
+            .repository
+            .find_default_remote(Direction::Push)
+            .transpose()?
+        {
+            Some(remote) => match remote.url(Direction::Push) {
+                Some(url) => Ok(url
+                    .to_bstring()
+                    .to_string()
+                    .parse()
+                    .expect("A repository URL should be valid")),
+                None => Err(Error::remote_not_found()),
+            },
+            None => Err(Error::remote_not_found()),
+        }
+    }
+
+    fn get_files(&self) -> Result<Vec<PathBuf>, Self::Error> {
+        let tree = self
+            .repository
+            .rev_parse_single("HEAD")?
+            .object()?
+            .peel_to_tree()?;
+
+        let mut recorder = Recorder::default();
+
+        tree.traverse().breadthfirst(&mut recorder)?;
+
+        let mut entries = recorder
+            .records
+            .into_iter()
+            .filter(|entry| entry.mode.is_blob())
+            .map(|entry| PathBuf::from(entry.filepath.to_string()))
+            .collect::<Vec<_>>();
+
+        entries.sort();
+
+        Ok(entries)
+    }
+
+    fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Self::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let mut tree = self
+            .repository
+            .rev_parse_single("HEAD")?
+            .object()?
+            .peel_to_tree()?;
+
+        let entry = tree
+            .peel_to_entry_by_path(path)?
+            .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
+
+        if entry.mode().is_blob() {
+            Ok(entry.object()?.detached().data)
+        } else {
+            Err(io::Error::from(io::ErrorKind::NotFound))?
+        }
+    }
+}

--- a/packages/ploys/src/project/source/git/mod.rs
+++ b/packages/ploys/src/project/source/git/mod.rs
@@ -15,7 +15,6 @@ pub use self::gix::Gix;
 use super::Source;
 
 /// The local Git repository source.
-#[derive(Clone, Debug)]
 pub enum Git {
     /// The `gix` source for basic `git` operations.
     Gix(Gix),

--- a/packages/ploys/src/project/source/git/mod.rs
+++ b/packages/ploys/src/project/source/git/mod.rs
@@ -3,23 +3,22 @@
 //! This module contains the utilities related to local Git project management.
 
 mod error;
+mod gix;
 
-use std::io;
 use std::path::{Path, PathBuf};
 
-use gix::remote::Direction;
-use gix::traverse::tree::Recorder;
-use gix::Repository;
 use url::Url;
 
 pub use self::error::{Error, GitError};
+pub use self::gix::Gix;
 
 use super::Source;
 
 /// The local Git repository source.
 #[derive(Clone, Debug)]
-pub struct Git {
-    repository: Repository,
+pub enum Git {
+    /// The `gix` source for basic `git` operations.
+    Gix(Gix),
 }
 
 impl Git {
@@ -28,9 +27,7 @@ impl Git {
     where
         P: AsRef<Path>,
     {
-        Ok(Self {
-            repository: gix::open(path.as_ref())?,
-        })
+        Ok(Self::Gix(Gix::new(path)?))
     }
 }
 
@@ -46,77 +43,29 @@ impl Source for Git {
     }
 
     fn get_name(&self) -> Result<String, Self::Error> {
-        let path = self.repository.path().join("..").canonicalize()?;
-
-        if let Some(file_stem) = path.file_stem() {
-            return Ok(file_stem.to_string_lossy().to_string());
+        match self {
+            Self::Gix(gix) => gix.get_name(),
         }
-
-        Err(Error::Io(io::Error::new(
-            io::ErrorKind::Other,
-            "Invalid directory",
-        )))
     }
 
     fn get_url(&self) -> Result<Url, Self::Error> {
-        match self
-            .repository
-            .find_default_remote(Direction::Push)
-            .transpose()?
-        {
-            Some(remote) => match remote.url(Direction::Push) {
-                Some(url) => Ok(url
-                    .to_bstring()
-                    .to_string()
-                    .parse()
-                    .expect("A repository URL should be valid")),
-                None => Err(Error::remote_not_found()),
-            },
-            None => Err(Error::remote_not_found()),
+        match self {
+            Self::Gix(gix) => gix.get_url(),
         }
     }
 
     fn get_files(&self) -> Result<Vec<PathBuf>, Self::Error> {
-        let tree = self
-            .repository
-            .rev_parse_single("HEAD")?
-            .object()?
-            .peel_to_tree()?;
-
-        let mut recorder = Recorder::default();
-
-        tree.traverse().breadthfirst(&mut recorder)?;
-
-        let mut entries = recorder
-            .records
-            .into_iter()
-            .filter(|entry| entry.mode.is_blob())
-            .map(|entry| PathBuf::from(entry.filepath.to_string()))
-            .collect::<Vec<_>>();
-
-        entries.sort();
-
-        Ok(entries)
+        match self {
+            Self::Gix(gix) => gix.get_files(),
+        }
     }
 
     fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Self::Error>
     where
         P: AsRef<Path>,
     {
-        let mut tree = self
-            .repository
-            .rev_parse_single("HEAD")?
-            .object()?
-            .peel_to_tree()?;
-
-        let entry = tree
-            .peel_to_entry_by_path(path)?
-            .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
-
-        if entry.mode().is_blob() {
-            Ok(entry.object()?.detached().data)
-        } else {
-            Err(io::Error::from(io::ErrorKind::NotFound))?
+        match self {
+            Self::Gix(gix) => gix.get_file_contents(path),
         }
     }
 }

--- a/packages/ploys/src/project/source/git/mod.rs
+++ b/packages/ploys/src/project/source/git/mod.rs
@@ -3,13 +3,15 @@
 //! This module contains the utilities related to local Git project management.
 
 mod error;
+mod git2;
 mod gix;
 
 use std::path::{Path, PathBuf};
 
 use url::Url;
 
-pub use self::error::{Error, GitError};
+pub use self::error::{Error, GixError};
+pub use self::git2::Git2;
 pub use self::gix::Gix;
 
 use super::Source;
@@ -18,6 +20,8 @@ use super::Source;
 pub enum Git {
     /// The `gix` source for basic `git` operations.
     Gix(Gix),
+    /// The `git2` source for advanced `git` operations.
+    Git2(Git2),
 }
 
 impl Git {
@@ -44,18 +48,21 @@ impl Source for Git {
     fn get_name(&self) -> Result<String, Self::Error> {
         match self {
             Self::Gix(gix) => gix.get_name(),
+            Self::Git2(git2) => git2.get_name(),
         }
     }
 
     fn get_url(&self) -> Result<Url, Self::Error> {
         match self {
             Self::Gix(gix) => gix.get_url(),
+            Self::Git2(git2) => git2.get_url(),
         }
     }
 
     fn get_files(&self) -> Result<Vec<PathBuf>, Self::Error> {
         match self {
             Self::Gix(gix) => gix.get_files(),
+            Self::Git2(git2) => git2.get_files(),
         }
     }
 
@@ -65,6 +72,7 @@ impl Source for Git {
     {
         match self {
             Self::Gix(gix) => gix.get_file_contents(path),
+            Self::Git2(git2) => git2.get_file_contents(path),
         }
     }
 }

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -4,8 +4,42 @@ use ploys::project::{Error, Project};
 
 #[test]
 #[ignore]
-fn test_valid_local_project() -> Result<(), Error> {
+fn test_valid_local_project_gix() -> Result<(), Error> {
     let project = Project::git("../..")?;
+    let url = project.get_url()?;
+
+    assert_eq!(project.name(), "ploys");
+    assert_eq!(url.domain(), Some("github.com"));
+    assert_eq!(url.path().trim_end_matches(".git"), "/ploys/ploys");
+
+    let files = project.get_files()?;
+
+    assert!(files.contains(&PathBuf::from("Cargo.toml")));
+    assert!(files.contains(&PathBuf::from("packages/ploys/Cargo.toml")));
+    assert!(files.contains(&PathBuf::from("packages/ploys-cli/Cargo.toml")));
+
+    let a = String::from_utf8(project.get_file_contents("Cargo.toml")?).unwrap();
+    let b = String::from_utf8(project.get_file_contents("packages/ploys/Cargo.toml")?).unwrap();
+
+    assert!(a.contains("[workspace]"));
+    assert!(b.contains("[package]"));
+    assert!(project.get_file_contents("packages/ploys").is_err());
+
+    let packages = project.packages();
+
+    assert!(packages.iter().any(|pkg| pkg.name() == "ploys"));
+    assert!(packages.iter().any(|pkg| pkg.name() == "ploys-cli"));
+
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn test_valid_local_project_git2() -> Result<(), Error> {
+    let mut project = Project::git2("../..")?;
+
+    project.upgrade()?;
+
     let url = project.get_url()?;
 
     assert_eq!(project.name(), "ploys");


### PR DESCRIPTION
Closes #42.

This introduces integration with `git2` as an alternative `Git` project source. This is done by converting the existing `Git` source to an enumeration and moving the existing logic to a sub-source. A new sub-source for `Git2` is included as well as a couple of conversion methods to upgrade from one to the other. The idea is that `gix` is the primary source and future code can call `upgrade` as appropriate to get access to additional functionality such as pushing.

The code includes a hidden constructor to go directly to the `git2` source for the sake of the integration tests but otherwise it should not be called directly.