### PR TITLE
Add project source feature flags

### DIFF
--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -8,15 +8,21 @@ repository = "https://github.com/ploys/ploys"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 
+[features]
+default = ["git", "github"]
+git = ["dep:gix", "dep:git2"]
+github = ["dep:ureq"]
+
 [dependencies]
-gix = "0.66.0"
+gix = { version = "0.66.0", optional = true }
 globset = "0.4.13"
 semver = "1.0.19"
 serde = { version = "1.0.185", features = ["derive"] }
 toml_edit = { version = "0.22.14", features = ["serde"] }
-ureq = { version = "2.7.1", features = ["json"] }
+ureq = { version = "2.7.1", features = ["json"], optional = true }
 url = "2.4.0"
 
 [dependencies.git2]
 version = "0.19.0"
 features = ["vendored-libgit2", "vendored-openssl"]
+optional = true

--- a/packages/ploys/src/project/error.rs
+++ b/packages/ploys/src/project/error.rs
@@ -2,10 +2,13 @@ use std::fmt::{self, Display};
 
 /// The project error.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// The Git source error.
+    #[cfg(feature = "git")]
     Git(crate::project::source::git::Error),
     /// The GitHub source error.
+    #[cfg(feature = "github")]
     GitHub(crate::project::source::github::Error),
     /// The package error.
     Package(crate::package::Error),
@@ -20,7 +23,9 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(feature = "git")]
             Self::Git(git) => Display::fmt(git, f),
+            #[cfg(feature = "github")]
             Self::GitHub(github) => Display::fmt(github, f),
             Self::Package(err) => Display::fmt(err, f),
             Self::Bump(err) => Display::fmt(err, f),
@@ -32,12 +37,14 @@ impl Display for Error {
 
 impl std::error::Error for Error {}
 
+#[cfg(feature = "git")]
 impl From<crate::project::source::git::Error> for Error {
     fn from(err: crate::project::source::git::Error) -> Self {
         Self::Git(err)
     }
 }
 
+#[cfg(feature = "github")]
 impl From<crate::project::source::github::Error> for Error {
     fn from(err: crate::project::source::github::Error) -> Self {
         Self::GitHub(err)

--- a/packages/ploys/src/project/source/mod.rs
+++ b/packages/ploys/src/project/source/mod.rs
@@ -3,7 +3,10 @@
 //! This module contains the common functionality that is shared by different
 //! project sources.
 
+#[cfg(feature = "git")]
 pub mod git;
+
+#[cfg(feature = "github")]
 pub mod github;
 
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Closes #43.

This adds feature flags to the library to conditionally enable or disable project sources. At the moment this includes `git` and `github` features but more can be added as the project expands. This will allow the CLI crate to use both and the API crate to use only the GitHub source.

This does not include any additional changes around testing to handle different combinations of features so this is something that should be explored later.