### PR TITLE
Add project package release methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "auth-git2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3810b5af212b013fe7302b12d86616c6c39a48e18f2e4b812a5a9e5710213791"
+dependencies = [
+ "dirs",
+ "git2",
+ "terminal-prompt",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +627,27 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2076,6 +2108,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
+]
+
+[[package]]
 name = "libssh2-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,6 +2349,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2392,6 +2440,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 name = "ploys"
 version = "0.0.0"
 dependencies = [
+ "auth-git2",
  "git2",
  "gix",
  "globset",
@@ -2597,6 +2646,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -3146,6 +3206,16 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "terminal-prompt"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "572818b3472910acbd5dff46a3413715c18e934b071ab2ba464a7b2c2af16376"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [features]
 default = ["git", "github"]
-git = ["dep:gix", "dep:git2"]
+git = ["dep:gix", "dep:git2", "dep:auth-git2"]
 github = ["dep:ureq"]
 
 [dependencies]
@@ -25,4 +25,8 @@ url = "2.4.0"
 [dependencies.git2]
 version = "0.19.0"
 features = ["vendored-libgit2", "vendored-openssl"]
+optional = true
+
+[dependencies.auth-git2]
+version = "0.5.5"
 optional = true

--- a/packages/ploys/src/package/bump.rs
+++ b/packages/ploys/src/package/bump.rs
@@ -159,6 +159,39 @@ impl FromStr for Bump {
     }
 }
 
+/// The bump level or version.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BumpOrVersion {
+    Bump(Bump),
+    Version(Version),
+}
+
+impl FromStr for BumpOrVersion {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.parse::<Bump>() {
+            Ok(bump) => Ok(Self::Bump(bump)),
+            Err(_) => match s.parse::<Version>() {
+                Ok(version) => Ok(Self::Version(version)),
+                Err(err) => Err(Error::Semver(err)),
+            },
+        }
+    }
+}
+
+impl From<Bump> for BumpOrVersion {
+    fn from(bump: Bump) -> Self {
+        Self::Bump(bump)
+    }
+}
+
+impl From<Version> for BumpOrVersion {
+    fn from(version: Version) -> Self {
+        Self::Version(version)
+    }
+}
+
 /// The bump error.
 #[derive(Debug)]
 pub enum Error {

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -38,6 +38,7 @@ impl Cargo {
         self.manifest.package().expect("package").version()
     }
 
+    /// Sets the package version.
     pub fn set_version<V>(&mut self, version: V) -> &mut Self
     where
         V: Into<String>,

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -11,9 +11,11 @@ mod members;
 
 use std::path::Path;
 
+use semver::Version;
+
 use crate::project::source::Source;
 
-pub use self::bump::{Bump, Error as BumpError};
+pub use self::bump::{Bump, BumpOrVersion, Error as BumpError};
 use self::cargo::Cargo;
 pub use self::error::Error;
 use self::manifest::Manifest;
@@ -59,6 +61,13 @@ impl Package {
         match self {
             Self::Cargo(_) => PackageKind::Cargo,
         }
+    }
+
+    /// Sets the package version.
+    pub fn set_version(&mut self, version: Version) {
+        match self {
+            Self::Cargo(cargo) => cargo.set_version(version.to_string()),
+        };
     }
 
     /// Bumps the package version.

--- a/packages/ploys/src/project/source/git/mod.rs
+++ b/packages/ploys/src/project/source/git/mod.rs
@@ -32,6 +32,14 @@ impl Git {
     {
         Ok(Self::Gix(Gix::new(path)?))
     }
+
+    /// Creates a new branch.
+    pub(crate) fn create_branch(&mut self, branch_name: &str) -> Result<String, Error> {
+        match self {
+            Self::Gix(_) => unreachable!("upgrade called first"),
+            Self::Git2(git2) => git2.create_branch(branch_name),
+        }
+    }
 }
 
 impl Source for Git {

--- a/packages/ploys/src/project/source/github/repo.rs
+++ b/packages/ploys/src/project/source/github/repo.rs
@@ -72,6 +72,14 @@ impl Repository {
     {
         self.request("GET", path, token)
     }
+
+    /// Creates a POST request.
+    pub(super) fn post<P>(&self, path: P, token: Option<&str>) -> Request
+    where
+        P: AsRef<str>,
+    {
+        self.request("POST", path, token)
+    }
 }
 
 impl Display for Repository {


### PR DESCRIPTION
This adds the package release implementation for #41 as part of the library crate.

This change introduces the `release_package` method for `Git` and `GitHub` projects, adds the `set_package_version` method to complement the `bump_package_version` method, and includes a new `BumpOrVersion` type to handle either a bump level or a version. This also includes the `auth-git2` crate as a dependency to handle local git authentication.