### PR TITLE
Add release command

### DIFF
--- a/packages/ploys-cli/src/main.rs
+++ b/packages/ploys-cli/src/main.rs
@@ -1,9 +1,12 @@
 mod project;
+mod release;
+mod util;
 
 use anyhow::Error;
 use clap::{Parser, Subcommand};
 
 use self::project::Project;
+use self::release::Release;
 
 /// Manage projects, packages, releases and deployments.
 #[derive(Parser)]
@@ -18,6 +21,7 @@ impl Args {
     fn exec(self) -> Result<(), Error> {
         match self.command {
             Command::Project(project) => project.exec(),
+            Command::Release(release) => release.exec(),
         }
     }
 }
@@ -27,6 +31,8 @@ impl Args {
 enum Command {
     /// Manages the project.
     Project(Project),
+    /// Manages releases.
+    Release(Release),
 }
 
 fn main() -> Result<(), Error> {

--- a/packages/ploys-cli/src/release/mod.rs
+++ b/packages/ploys-cli/src/release/mod.rs
@@ -1,0 +1,59 @@
+use anyhow::Error;
+use clap::Args;
+use ploys::package::BumpOrVersion;
+use ploys::project::source::github::GitHub;
+use ploys::project::Project;
+
+use crate::util::repo_or_url::RepoOrUrl;
+
+/// The release command.
+#[derive(Args)]
+pub struct Release {
+    /// The package identifier.
+    package: String,
+
+    /// The package version or level (major, minor, patch, rc, beta, alpha).
+    version: BumpOrVersion,
+
+    /// The remote GitHub repository owner/repo or URL.
+    #[clap(long)]
+    remote: Option<RepoOrUrl>,
+
+    /// The authentication token for GitHub API access.
+    #[clap(long, env = "GITHUB_TOKEN")]
+    token: Option<String>,
+}
+
+impl Release {
+    /// Executes the command.
+    pub fn exec(self) -> Result<(), Error> {
+        match &self.remote {
+            Some(remote) => match &self.token {
+                Some(token) => {
+                    let mut project = Project::<GitHub>::github_with_authentication_token(
+                        remote.clone().try_into_repo()?.to_string(),
+                        token,
+                    )?;
+
+                    project.release_package(self.package, self.version)?;
+
+                    Ok(())
+                }
+                None => {
+                    let mut project = Project::github(remote.clone().try_into_repo()?.to_string())?;
+
+                    project.release_package(self.package, self.version)?;
+
+                    Ok(())
+                }
+            },
+            None => {
+                let mut project = Project::git(".")?;
+
+                project.release_package(self.package, self.version)?;
+
+                Ok(())
+            }
+        }
+    }
+}

--- a/packages/ploys-cli/src/util/mod.rs
+++ b/packages/ploys-cli/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod repo_or_url;

--- a/packages/ploys-cli/src/util/repo_or_url.rs
+++ b/packages/ploys-cli/src/util/repo_or_url.rs
@@ -1,0 +1,56 @@
+use std::str::FromStr;
+
+use anyhow::{anyhow, Error};
+use ploys::project::source::github::Repository;
+use url::Url;
+
+/// The repository string or remote URL.
+#[derive(Clone)]
+pub enum RepoOrUrl {
+    Repo(Repository),
+    Url(Url),
+}
+
+impl RepoOrUrl {
+    /// Attempts to construct a repository from a URL.
+    pub fn try_into_repo(self) -> Result<Repository, Error> {
+        self.try_into()
+    }
+}
+
+impl FromStr for RepoOrUrl {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.parse::<Repository>() {
+            Ok(repo) => Ok(Self::Repo(repo)),
+            Err(_) => match s.parse::<Url>() {
+                Ok(url) => Ok(Self::Url(url)),
+                Err(_) => Err(anyhow!("Expected owner/repo or URL, found: {}", s)),
+            },
+        }
+    }
+}
+
+impl TryFrom<RepoOrUrl> for Repository {
+    type Error = Error;
+
+    fn try_from(value: RepoOrUrl) -> Result<Self, Self::Error> {
+        match value {
+            RepoOrUrl::Repo(repo) => Ok(repo),
+            RepoOrUrl::Url(url) => {
+                if url.domain() != Some("github.com") {
+                    return Err(anyhow!(
+                        "Unsupported remote repository: Only GitHub is supported"
+                    ));
+                }
+
+                Ok(url
+                    .path()
+                    .trim_start_matches('/')
+                    .trim_end_matches(".git")
+                    .parse::<Repository>()?)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #41.

This adds the release command using the release methods added in #46. It also moves the `RepoOrUrl` type to a shared module so that it can be accessed by multiple commands.

This does not include any checking to ensure that the repository is in a valid state for release but that can be added later.