### PR TITLE
Add method to get project file changes

### DIFF
--- a/packages/ploys/src/lockfile/cargo/mod.rs
+++ b/packages/ploys/src/lockfile/cargo/mod.rs
@@ -10,6 +10,7 @@ pub use self::error::Error;
 #[derive(Clone, Debug)]
 pub struct CargoLockFile {
     manifest: DocumentMut,
+    changed: bool,
 }
 
 impl CargoLockFile {
@@ -21,13 +22,25 @@ impl CargoLockFile {
     {
         if let Some(mut package) = self.packages_mut().get_mut(package.as_ref()) {
             package.set_version(version);
+            self.changed = true;
         }
+    }
+
+    /// Gets the contents of the lockfile.
+    pub fn get_contents(&self) -> String {
+        self.manifest.to_string()
+    }
+
+    /// Checks if the lockfile has been changed.
+    pub fn is_changed(&self) -> bool {
+        self.changed
     }
 
     /// Creates a manifest from the given bytes.
     pub(super) fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         Ok(Self {
             manifest: std::str::from_utf8(bytes)?.parse()?,
+            changed: false,
         })
     }
 

--- a/packages/ploys/src/lockfile/mod.rs
+++ b/packages/ploys/src/lockfile/mod.rs
@@ -33,6 +33,20 @@ impl LockFile {
         }
     }
 
+    /// Gets the contents of the lockfile.
+    pub fn get_contents(&self) -> String {
+        match self {
+            Self::Cargo(cargo) => cargo.get_contents(),
+        }
+    }
+
+    /// Checks if the lockfile has been changed.
+    pub fn is_changed(&self) -> bool {
+        match self {
+            Self::Cargo(cargo) => cargo.is_changed(),
+        }
+    }
+
     /// Discovers project lockfiles.
     pub(super) fn discover_lockfiles<T>(
         source: &T,

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -11,7 +11,7 @@ use super::Cargo;
 
 /// The cargo package manifest.
 #[derive(Clone, Debug)]
-pub struct Manifest(DocumentMut);
+pub struct Manifest(pub(super) DocumentMut);
 
 impl Manifest {
     /// Gets the workspace table.

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -15,12 +15,17 @@ use super::{Bump, BumpError};
 pub struct Cargo {
     manifest: Manifest,
     path: PathBuf,
+    changed: bool,
 }
 
 impl Cargo {
     /// Creates a new cargo package.
     fn new(manifest: Manifest, path: PathBuf) -> Self {
-        Self { manifest, path }
+        Self {
+            manifest,
+            path,
+            changed: false,
+        }
     }
 
     /// Gets the package name.
@@ -47,6 +52,7 @@ impl Cargo {
             .package_mut()
             .expect("package")
             .set_version(version);
+        self.changed = true;
         self
     }
 
@@ -60,5 +66,15 @@ impl Cargo {
         self.set_version(bump.bump_str(self.version())?.to_string());
 
         Ok(())
+    }
+
+    /// Gets the package contents.
+    pub fn get_contents(&self) -> String {
+        self.manifest.0.to_string()
+    }
+
+    /// Checks if the package has been changed.
+    pub fn is_changed(&self) -> bool {
+        self.changed
     }
 }

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -76,6 +76,20 @@ impl Package {
             Self::Cargo(cargo) => Ok(cargo.bump(bump)?),
         }
     }
+
+    /// Gets the package contents.
+    pub fn get_contents(&self) -> String {
+        match self {
+            Self::Cargo(cargo) => cargo.get_contents(),
+        }
+    }
+
+    /// Checks if the package has been changed.
+    pub fn is_changed(&self) -> bool {
+        match self {
+            Self::Cargo(cargo) => cargo.is_changed(),
+        }
+    }
 }
 
 impl Package {

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -326,6 +326,23 @@ where
             None => Err(Error::PackageNotFound(package.as_ref().to_owned())),
         }
     }
+
+    /// Gets the changed files.
+    pub fn get_changed_files(&self) -> impl Iterator<Item = (PathBuf, String)> + '_ {
+        self.packages()
+            .iter()
+            .filter(|package| package.is_changed())
+            .map(|package| (package.path().to_owned(), package.get_contents()))
+            .chain(
+                self.lockfiles
+                    .iter()
+                    .filter(|(_, lockfile)| lockfile.is_changed())
+                    .filter_map(|(kind, lockfile)| {
+                        kind.lockfile_name()
+                            .map(|name| (name.to_owned(), lockfile.get_contents()))
+                    }),
+            )
+    }
 }
 
 #[cfg(feature = "git")]


### PR DESCRIPTION
This adds a method `Project::get_changed_files` to get the changed files in a project.

The `Project` type tracks the packages and lockfiles in a project and provides the ability to alter package versions. However, there is no way to get the updated file contents to commit the specific changes to the repository.

This change facilitates the implementation of #36 by adding the ability to get the changed files. Files are marked as changed whenever a package version is updated. It also includes the `get_contents` and `is_changed` methods on packages and lockfiles that is used internally by `get_changed_files`.