### PR TITLE
Add ability to load Git project at a specific commit

### DIFF
--- a/packages/ploys/src/project/source/git/reference.rs
+++ b/packages/ploys/src/project/source/git/reference.rs
@@ -1,0 +1,44 @@
+use std::fmt::{self, Display};
+
+/// The git reference.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum Reference {
+    #[default]
+    Head,
+    Sha(String),
+    Branch(String),
+    Tag(String),
+}
+
+impl Reference {
+    /// Constructs a new head reference.
+    pub fn head() -> Self {
+        Self::Head
+    }
+
+    /// Constructs a new SHA reference.
+    pub fn sha(sha: impl Into<String>) -> Self {
+        Self::Sha(sha.into())
+    }
+
+    /// Constructs a new branch reference.
+    pub fn branch(branch: impl Into<String>) -> Self {
+        Self::Branch(branch.into())
+    }
+
+    /// Constructs a new tag reference.
+    pub fn tag(tag: impl Into<String>) -> Self {
+        Self::Tag(tag.into())
+    }
+}
+
+impl Display for Reference {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Head => write!(f, "HEAD"),
+            Self::Sha(sha) => write!(f, "{sha}"),
+            Self::Branch(branch) => write!(f, "refs/heads/{branch}"),
+            Self::Tag(tag) => write!(f, "refs/tags/{tag}"),
+        }
+    }
+}


### PR DESCRIPTION
This is a follow up to #34 that adds the ability to also load a Git project at a specific commit.

The aim for the different project sources is to provide feature parity and a previous change only extended the functionality of the `GitHub` project source. There is no reason why this functionality could not be extended to the `Git` project source.

This change adds a new `Reference` type specifically for `Git` projects and replicates the existing functionality by adding new constructor methods and updating the internal implementations to use the given reference.