### PR TITLE
Change project reference from commit to branch on release

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -460,9 +460,8 @@ impl Project<self::source::git::Git> {
             false => format!("release/{}-{version}", package.as_ref()),
         };
 
-        let sha = self.source.create_branch(&branch_name)?;
-
-        self.source.set_reference(Reference::Sha(sha));
+        self.source.create_branch(&branch_name)?;
+        self.source.set_reference(Reference::Branch(branch_name));
 
         Ok(())
     }
@@ -506,9 +505,8 @@ impl Project<self::source::github::GitHub> {
             false => format!("release/{}-{version}", package.as_ref()),
         };
 
-        let sha = self.source.create_branch(&branch_name)?;
-
-        self.source.set_reference(Reference::Sha(sha));
+        self.source.create_branch(&branch_name)?;
+        self.source.set_reference(Reference::Branch(branch_name));
 
         Ok(())
     }


### PR DESCRIPTION
This changes the project reference to track the new branch instead of commit on package release.

Changing the reference may limit the utility of the `Project` type for releasing multiple packages at once but the current implementation already sets it to the commit SHA. Instead, by setting it to the branch, it is possible to add more changes for that release while maintaining information about the current operation. For example, to push new commits and update the branch reference to the latest commit.

This change simply alters the `release_package` methods to use the branch as the new reference instead of the commit SHA.

In the future it may be beneficial to not update the existing reference but instead return a new project adaptor that allows additional operations to be created without updating the existing one.