### PR TITLE
Change git source to create branch on current reference

### DIFF
--- a/packages/ploys/src/project/source/git/git2/mod.rs
+++ b/packages/ploys/src/project/source/git/git2/mod.rs
@@ -41,7 +41,8 @@ impl Git2 {
 impl Git2 {
     /// Creates a new branch.
     pub(crate) fn create_branch(&self, branch_name: &str) -> Result<String, Error> {
-        let commit = self.repository.revparse_single("HEAD")?.peel_to_commit()?;
+        let spec = self.reference.to_string();
+        let commit = self.repository.revparse_single(&spec)?.peel_to_commit()?;
         let sha = commit.id().to_string();
         let remote_name = self
             .get_default_remote_name()?


### PR DESCRIPTION
This is a follow up to #50 that sets the `Git2` source to create a branch using the current reference.

The `Project` sources keep track of the current reference independently to the underlying implementations. For example, the currently checked out branch in a local git repository only affects the default `Head` reference but otherwise has no impact on loading a project from a different reference. The act of creating a branch is used for releasing a package but it is possible that a release may need to be made independently to the current `HEAD`. An example of this would be to create a hotfix for an older release.

This change continues the previous changes to unify the different sources by replacing the hard-coded usage of `HEAD` with the current reference.