### PR TITLE
Add project commit methods

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -422,6 +422,25 @@ impl Project<self::source::git::Git> {
 
 #[cfg(feature = "git")]
 impl Project<self::source::git::Git> {
+    /// Commits the changes to the repository.
+    pub fn commit(&mut self, message: impl AsRef<str>) -> Result<String, Error> {
+        use self::source::revision::{Reference, Revision};
+
+        self.upgrade()?;
+
+        let files = self.get_changed_files();
+        let sha = self.source.commit(message, files)?;
+
+        if !matches!(
+            self.source.revision(),
+            Revision::Reference(Reference::Branch(_))
+        ) {
+            self.source.set_revision(Revision::sha(sha.clone()));
+        }
+
+        Ok(sha)
+    }
+
     /// Releases the specified package.
     ///
     /// This triggers the release flow by creating a new remote branch. This
@@ -469,6 +488,23 @@ impl Project<self::source::git::Git> {
 
 #[cfg(feature = "github")]
 impl Project<self::source::github::GitHub> {
+    /// Commits the changes to the repository.
+    pub fn commit(&mut self, message: impl AsRef<str>) -> Result<String, Error> {
+        use self::source::revision::{Reference, Revision};
+
+        let files = self.get_changed_files();
+        let sha = self.source.commit(message, files)?;
+
+        if !matches!(
+            self.source.revision(),
+            Revision::Reference(Reference::Branch(_))
+        ) {
+            self.source.set_revision(Revision::sha(sha.clone()));
+        }
+
+        Ok(sha)
+    }
+
     /// Releases the specified package.
     ///
     /// This triggers the release flow by creating a new remote branch. This

--- a/packages/ploys/src/project/source/git/git2/mod.rs
+++ b/packages/ploys/src/project/source/git/git2/mod.rs
@@ -2,10 +2,13 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use auth_git2::GitAuthenticator;
-use git2::{ObjectType, PushOptions, RemoteCallbacks, Repository, TreeWalkMode, TreeWalkResult};
+use git2::build::TreeUpdateBuilder;
+use git2::{
+    FileMode, ObjectType, PushOptions, RemoteCallbacks, Repository, TreeWalkMode, TreeWalkResult,
+};
 use url::Url;
 
-use crate::project::source::revision::Revision;
+use crate::project::source::revision::{Reference, Revision};
 
 use super::{Error, GitConfig, Source};
 
@@ -77,6 +80,67 @@ impl Git2 {
         remote.push(&[refspec], Some(&mut options))?;
 
         Ok(sha)
+    }
+
+    /// Commits the changes to the repository.
+    pub(crate) fn commit(
+        &self,
+        message: impl AsRef<str>,
+        files: impl Iterator<Item = (PathBuf, String)>,
+    ) -> Result<String, Error> {
+        let spec = self.revision.to_string();
+        let tree = self.repository.revparse_single(&spec)?.peel_to_tree()?;
+        let commit = self.repository.revparse_single(&spec)?.peel_to_commit()?;
+        let signature = self.repository.signature()?;
+        let mut tree_builder = TreeUpdateBuilder::new();
+
+        for (path, content) in files {
+            let blob = self.repository.blob(content.as_bytes())?;
+
+            tree_builder.upsert(path, blob, FileMode::Blob);
+        }
+
+        let tree_id = tree_builder.create_updated(&self.repository, &tree)?;
+        let tree = self.repository.find_tree(tree_id)?;
+        let update_ref = match &self.revision {
+            Revision::Head | Revision::Reference(Reference::Branch(_)) => {
+                Some(self.revision.to_string())
+            }
+            _ => None,
+        };
+
+        let sha = self.repository.commit(
+            update_ref.as_deref(),
+            &signature,
+            &signature,
+            message.as_ref(),
+            &tree,
+            &[&commit],
+        )?;
+
+        if let Revision::Reference(Reference::Branch(_)) = &self.revision {
+            let config = self.repository.config()?;
+            let auth = GitAuthenticator::new_empty()
+                .try_cred_helper(true)
+                .try_ssh_agent(true)
+                .add_default_ssh_keys();
+            let remote_name = self
+                .get_default_remote_name()?
+                .ok_or_else(Error::remote_not_found)?;
+
+            let mut remote = self.repository.find_remote(&remote_name)?;
+            let mut remote_callbacks = RemoteCallbacks::new();
+            let mut options = PushOptions::default();
+
+            remote_callbacks.credentials(auth.credentials(&config));
+            options.remote_callbacks(remote_callbacks);
+
+            let refspec = format!("{}:{}", self.revision, self.revision);
+
+            remote.push(&[refspec], Some(&mut options))?;
+        }
+
+        Ok(sha.to_string())
     }
 
     /// Gets the default remote name.

--- a/packages/ploys/src/project/source/git/mod.rs
+++ b/packages/ploys/src/project/source/git/mod.rs
@@ -67,6 +67,18 @@ impl Git {
             Self::Git2(git2) => git2.create_branch(branch_name),
         }
     }
+
+    /// Commits the changes to the repository.
+    pub(crate) fn commit(
+        &self,
+        message: impl AsRef<str>,
+        files: impl Iterator<Item = (PathBuf, String)>,
+    ) -> Result<String, Error> {
+        match self {
+            Self::Gix(_) => unreachable!("upgrade called first"),
+            Self::Git2(git2) => git2.commit(message, files),
+        }
+    }
 }
 
 impl Source for Git {

--- a/packages/ploys/src/project/source/github/repo.rs
+++ b/packages/ploys/src/project/source/github/repo.rs
@@ -80,6 +80,14 @@ impl Repository {
     {
         self.request("POST", path, token)
     }
+
+    /// Creates a PATCH request.
+    pub(super) fn patch<P>(&self, path: P, token: Option<&str>) -> Request
+    where
+        P: AsRef<str>,
+    {
+        self.request("PATCH", path, token)
+    }
 }
 
 impl Display for Repository {


### PR DESCRIPTION
This adds `commit` methods for both `Git` and `GitHub` projects to automate committing and pushing package changes.

The previous update #49 added the ability to detect which files had been changed when setting or bumping package versions. This extends that functionality to provide the ability to commit those changes. Both are prerequisite parts of #36 to automate the creation of release pull requests.

The `commit` methods create a single commit with all of the file changes and ensure that the branch, if set, is updated on the remote repository. This does not yet support commit signing but by omitting the committer information a GitHub App installation access token will allow GitHub to sign the commit. This does not apply to user access tokens using the API.