### PR TITLE
Add release workflow with deploy job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     concurrency: production
     environment:
       name: production
-      url: https://ploys-1sdu.shuttle.app/
+      url: ${{ vars.APP_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,5 @@ jobs:
           shuttle-api-key: ${{ secrets.SHUTTLE_API_KEY }}
           secrets: |
             GITHUB_APP_CLIENT_ID = '${{ vars.APP_CLIENT_ID }}'
-            GITHUB_APP_PRIVATE_KEY = '${{ secrets.APP_PRIVATE_KEY }}'
+            GITHUB_APP_PRIVATE_KEY = '''${{ secrets.APP_PRIVATE_KEY }}'''
             GITHUB_APP_WEBHOOK_SECRET = '${{ secrets.APP_WEBHOOK_SECRET }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.release.tag_name, 'ploys-api') }}
+    concurrency: production
+    environment:
+      name: production
+      url: https://ploys-1sdu.shuttle.app/
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: shuttle-hq/deploy-action@v2
+        with:
+          project-id: ${{ vars.SHUTTLE_PROJECT_ID }}
+          shuttle-api-key: ${{ secrets.SHUTTLE_API_KEY }}
+          secrets: |
+            GITHUB_APP_CLIENT_ID = '${{ vars.APP_CLIENT_ID }}'
+            GITHUB_APP_PRIVATE_KEY = '${{ secrets.APP_PRIVATE_KEY }}'
+            GITHUB_APP_WEBHOOK_SECRET = '${{ secrets.APP_WEBHOOK_SECRET }}'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Secrets*.toml
+.shuttle*


### PR DESCRIPTION
This adds a new GitHub Actions workflow to deploy the Shuttle application on release.

This is the final step for #35 that will enable the local Shuttle application to be replaced with the deployed application. This will facilitate the release of the library, command-line interface, and future iterations to the application.