### PR TITLE
Add release workflow publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,23 @@ on:
     types: [created]
 
 jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.release.tag_name, 'ploys') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: dtolnay/rust-toolchain@master
+        with:
+          targets: x86_64-unknown-linux-gnu
+          toolchain: stable
+
+      - name: Publish
+        run: cargo publish --package ploys --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a follow up to #69 to publish the library to crates.io on release.

This simply adds a new `publish` job to the release workflow that is configured to run `cargo publish` with the secret credentials. This does not include a cache step as it is unlikely to run very often and caches are limited.