### PR TITLE
Add CI test target `aarch64-apple-darwin`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: Test (${{ matrix.target }})
+    name: Test (${{ matrix.label }})
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -16,21 +16,25 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: aarch64-apple-darwin
-            toolchain: stable
-            os: macos-latest
-
-          - target: x86_64-apple-darwin
-            toolchain: stable
-            os: macos-latest
-
-          - target: x86_64-pc-windows-msvc
-            toolchain: stable
-            os: windows-latest
-
-          - target: x86_64-unknown-linux-gnu
+          - label: linux, x86_64
+            target: x86_64-unknown-linux-gnu
             toolchain: stable
             os: ubuntu-latest
+
+          - label: macos, aarch64
+            target: aarch64-apple-darwin
+            toolchain: stable
+            os: macos-latest
+
+          - label: macos, x86_64
+            target: x86_64-apple-darwin
+            toolchain: stable
+            os: macos-latest
+
+          - label: windows, x86_64
+            target: x86_64-pc-windows-msvc
+            toolchain: stable
+            os: windows-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: Test (${{ matrix.label }})
+    name: Test (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -16,20 +16,21 @@ jobs:
     strategy:
       matrix:
         include:
-          - label: linux
-            target: x86_64-unknown-linux-gnu
-            toolchain: stable
-            os: ubuntu-latest
-
-          - label: macos
-            target: x86_64-apple-darwin
+          - target: aarch64-apple-darwin
             toolchain: stable
             os: macos-latest
 
-          - label: windows
-            target: x86_64-pc-windows-msvc
+          - target: x86_64-apple-darwin
+            toolchain: stable
+            os: macos-latest
+
+          - target: x86_64-pc-windows-msvc
             toolchain: stable
             os: windows-latest
+
+          - target: x86_64-unknown-linux-gnu
+            toolchain: stable
+            os: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,21 +20,25 @@ jobs:
             target: x86_64-unknown-linux-gnu
             toolchain: stable
             os: ubuntu-latest
+            cache: linux-x86-64
 
           - label: macos, aarch64
             target: aarch64-apple-darwin
             toolchain: stable
             os: macos-latest
+            cache: macos-aarch64
 
           - label: macos, x86_64
             target: x86_64-apple-darwin
             toolchain: stable
             os: macos-latest
+            cache: macos-x86-64
 
           - label: windows, x86_64
             target: x86_64-pc-windows-msvc
             toolchain: stable
             os: windows-latest
+            cache: windows-x86-64
 
     steps:
       - name: Checkout
@@ -48,6 +52,8 @@ jobs:
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.cache }}
 
       - name: Test
         run: cargo test --target ${{ matrix.target }} -- --include-ignored


### PR DESCRIPTION
This adds `aarch64-apple-darwin` as a test target for the continuous integration workflow.

The `macos-latest` actions runner now uses the `aarch64` architecture but the CI workflow only tested `x86_64`. With modern macOS devices using this architecture and this project providing a command-line utility it is best that this is covered.

This change adds the new target to the job matrix and updates the labels to include the architecture. It also includes a new cache key because the job name does not include the label and the `Swatinem/rust-cache` action only considers the host architecture and not the target architecture. This meant that both macOS tests used the same cache and one would have to rebuild all dependencies every time.