### PR TITLE
Add release workflow publish for `ploys-cli` package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.release.tag_name, 'ploys') }}
+    if: ${{ !contains(github.event.release.tag_name, 'ploys') || contains(github.event.release.tag_name, 'ploys-cli') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,8 +19,13 @@ jobs:
           targets: x86_64-unknown-linux-gnu
           toolchain: stable
 
-      - name: Publish
+      - name: Publish (ploys)
+        if: ${{ !contains(github.event.release.tag_name, 'ploys') }}
         run: cargo publish --package ploys --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish (ploys-cli)
+        if: ${{ contains(github.event.release.tag_name, 'ploys-cli') }}
+        run: cargo publish --package ploys-cli --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   deploy:
     name: Deploy


### PR DESCRIPTION
This is a follow up to #73 to support publishing the `ploys-cli` package in addition to `ploys`.

This changes the release workflow to run the publish job on both `ploys` and `ploys-cli` packages with conditional steps to publish each package.