### PR TITLE
Set `ploys` dependency version

### DIFF
--- a/packages/ploys-api/Cargo.toml
+++ b/packages/ploys-api/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1.33.0", features = ["rt", "macros"] }
 tower-service = "0.3.3"
 
 [dependencies.ploys]
+version = "0.1.0"
 path = "../ploys"
 features = ["github"]
 default-features = false

--- a/packages/ploys-cli/Cargo.toml
+++ b/packages/ploys-cli/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 anyhow = "1.0.72"
 clap = { version = "4.3.21", features = ["derive", "env"] }
 console = "0.15.7"
-ploys = { path = "../ploys" }
+ploys = { version = "0.1.0", path = "../ploys" }
 url = "2.4.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This manually sets the `ploys` dependency version in both `ploys-api` and `ploys-cli`.

In order to support publishing packages on crates.io, local path dependencies must also have a version specified that exists in the package manager. Cargo does not automatically retrieve the version number from the local package.

This change simply sets the version number according to the steps outlined in #72. This will allow the CLI to be published to crates.io.