### PR TITLE
Add support for package dependencies

### DIFF
--- a/packages/ploys/src/package/cargo/dependency.rs
+++ b/packages/ploys/src/package/cargo/dependency.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Debug};
 
-use toml_edit::{Item, TableLike};
+use toml_edit::{Item, KeyMut, TableLike};
 
 /// The cargo package dependency.
 #[derive(Clone)]
@@ -99,6 +99,118 @@ impl<'a> From<&'a Item> for Dependencies<'a> {
     fn from(item: &'a Item) -> Self {
         Self {
             table: item.as_table_like(),
+        }
+    }
+}
+
+/// The mutable cargo package dependency.
+pub struct DependencyMut<'a> {
+    name: KeyMut<'a>,
+    item: &'a mut Item,
+}
+
+impl<'a> DependencyMut<'a> {
+    /// Gets the dependency name.
+    pub fn name(&self) -> &str {
+        self.name.get()
+    }
+
+    /// Gets the dependency version if it has been set.
+    pub fn version(&self) -> Option<&str> {
+        match self.item.as_str() {
+            Some(version) => Some(version),
+            None => match self.item.as_table()?.get("version") {
+                Some(version) => version.as_str(),
+                None => None,
+            },
+        }
+    }
+
+    /// Sets the dependency version.
+    pub fn set_version(&mut self, version: impl Into<String>) {
+        if let Some(value) = self.item.as_value_mut() {
+            *value = version.into().into();
+        } else if let Some(table) = self.item.as_table_like_mut() {
+            if let Some(item) = table.get_mut("version") {
+                if let Some(value) = item.as_value_mut() {
+                    *value = version.into().into();
+                }
+            }
+        }
+    }
+
+    /// Gets the dependency path if it has been set.
+    pub fn path(&self) -> Option<&str> {
+        match self.item.as_table()?.get("path") {
+            Some(path) => path.as_str(),
+            None => None,
+        }
+    }
+}
+
+impl<'a> Debug for DependencyMut<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DependencyMut")
+            .field("name", &self.name())
+            .field("version", &self.version())
+            .field("path", &self.path())
+            .finish()
+    }
+}
+
+impl<'a> From<(KeyMut<'a>, &'a mut Item)> for DependencyMut<'a> {
+    fn from((name, item): (KeyMut<'a>, &'a mut Item)) -> Self {
+        Self { name, item }
+    }
+}
+
+/// The mutable cargo package dependencies.
+#[derive(Default)]
+pub struct DependenciesMut<'a> {
+    pub(super) table: Option<&'a mut dyn TableLike>,
+}
+
+impl<'a> DependenciesMut<'a> {
+    /// Gets the mutable dependency with the given name.
+    pub fn get_mut(&mut self, name: impl AsRef<str>) -> Option<DependencyMut<'_>> {
+        self.table
+            .as_mut()?
+            .iter_mut()
+            .map(Into::<DependencyMut>::into)
+            .find(|dependency| dependency.name() == name.as_ref())
+    }
+}
+
+impl<'a> IntoIterator for DependenciesMut<'a> {
+    type Item = DependencyMut<'a>;
+    type IntoIter = Box<dyn Iterator<Item = DependencyMut<'a>> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self.table {
+            Some(table) => Box::new(table.iter_mut().map(Into::into)),
+            None => Box::new(std::iter::empty()),
+        }
+    }
+}
+
+impl<'a> Debug for DependenciesMut<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.table {
+            Some(table) => f
+                .debug_list()
+                .entries(Dependencies {
+                    table: Some(&**table),
+                })
+                .finish(),
+            None => f.debug_list().finish(),
+        }
+    }
+}
+
+impl<'a> From<&'a mut Item> for DependenciesMut<'a> {
+    fn from(item: &'a mut Item) -> Self {
+        Self {
+            table: item.as_table_like_mut(),
         }
     }
 }

--- a/packages/ploys/src/package/cargo/dependency.rs
+++ b/packages/ploys/src/package/cargo/dependency.rs
@@ -1,0 +1,58 @@
+use std::fmt::{self, Debug};
+
+use toml_edit::TableLike;
+
+/// The dependency item.
+pub struct Dependency<'a>(&'a str, Option<&'a dyn TableLike>);
+
+impl<'a> Dependency<'a> {
+    /// Gets the dependency name.
+    pub fn name(&self) -> &'a str {
+        self.0
+    }
+
+    /// Gets the dependency path if it has been set.
+    pub fn path(&self) -> Option<&'a str> {
+        match self.1 {
+            Some(table) => match table.get("path") {
+                Some(path) => path.as_str(),
+                None => None,
+            },
+            None => None,
+        }
+    }
+}
+
+impl<'a> Debug for Dependency<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Dependency")
+            .field("name", &self.name())
+            .field("path", &self.path())
+            .finish()
+    }
+}
+
+/// The dependencies table.
+pub struct Dependencies<'a>(pub(super) Option<&'a dyn TableLike>);
+
+impl<'a> IntoIterator for Dependencies<'a> {
+    type Item = Dependency<'a>;
+    type IntoIter = Box<dyn Iterator<Item = Dependency<'a>> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self.0 {
+            Some(table) => Box::new(
+                table
+                    .iter()
+                    .map(|(name, item)| Dependency(name, item.as_table_like())),
+            ),
+            None => Box::new(std::iter::empty()),
+        }
+    }
+}
+
+impl<'a> Debug for Dependencies<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(Self(self.0)).finish()
+    }
+}

--- a/packages/ploys/src/package/cargo/dependency.rs
+++ b/packages/ploys/src/package/cargo/dependency.rs
@@ -128,12 +128,6 @@ impl<'a> DependencyMut<'a> {
 
     /// Sets the dependency version.
     pub fn set_version(&mut self, version: impl Into<String>) {
-        if let Some(value) = self.item.as_value_mut() {
-            *value = version.into().into();
-
-            return;
-        }
-
         if let Some(table) = self.item.as_table_like_mut() {
             if let Some(item) = table.get_mut("version") {
                 if let Some(value) = item.as_value_mut() {
@@ -144,6 +138,12 @@ impl<'a> DependencyMut<'a> {
             }
 
             table.insert("version", Item::Value(version.into().into()));
+
+            return;
+        }
+
+        if let Some(value) = self.item.as_value_mut() {
+            *value = version.into().into();
         }
     }
 

--- a/packages/ploys/src/package/cargo/dependency.rs
+++ b/packages/ploys/src/package/cargo/dependency.rs
@@ -6,6 +6,7 @@ use toml_edit::{Item, TableLike};
 #[derive(Clone)]
 pub struct Dependency<'a> {
     name: &'a str,
+    version: Option<&'a str>,
     table: Option<&'a dyn TableLike>,
 }
 
@@ -13,6 +14,20 @@ impl<'a> Dependency<'a> {
     /// Gets the dependency name.
     pub fn name(&self) -> &'a str {
         self.name
+    }
+
+    /// Gets the dependency version if it has been set.
+    pub fn version(&self) -> Option<&'a str> {
+        match self.version {
+            Some(version) => Some(version),
+            None => match self.table {
+                Some(table) => match table.get("version") {
+                    Some(version) => version.as_str(),
+                    None => None,
+                },
+                None => None,
+            },
+        }
     }
 
     /// Gets the dependency path if it has been set.
@@ -31,6 +46,7 @@ impl<'a> Debug for Dependency<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Dependency")
             .field("name", &self.name())
+            .field("version", &self.version())
             .field("path", &self.path())
             .finish()
     }
@@ -40,6 +56,7 @@ impl<'a> From<(&'a str, &'a Item)> for Dependency<'a> {
     fn from((name, item): (&'a str, &'a Item)) -> Self {
         Self {
             name,
+            version: item.as_str(),
             table: item.as_table_like(),
         }
     }

--- a/packages/ploys/src/package/cargo/dependency.rs
+++ b/packages/ploys/src/package/cargo/dependency.rs
@@ -130,12 +130,20 @@ impl<'a> DependencyMut<'a> {
     pub fn set_version(&mut self, version: impl Into<String>) {
         if let Some(value) = self.item.as_value_mut() {
             *value = version.into().into();
-        } else if let Some(table) = self.item.as_table_like_mut() {
+
+            return;
+        }
+
+        if let Some(table) = self.item.as_table_like_mut() {
             if let Some(item) = table.get_mut("version") {
                 if let Some(value) = item.as_value_mut() {
                     *value = version.into().into();
+
+                    return;
                 }
             }
+
+            table.insert("version", Item::Value(version.into().into()));
         }
     }
 

--- a/packages/ploys/src/package/cargo/dependency.rs
+++ b/packages/ploys/src/package/cargo/dependency.rs
@@ -33,7 +33,17 @@ impl<'a> Debug for Dependency<'a> {
 }
 
 /// The dependencies table.
+#[derive(Clone)]
 pub struct Dependencies<'a>(pub(super) Option<&'a dyn TableLike>);
+
+impl<'a> Dependencies<'a> {
+    /// Gets the dependency with the given name.
+    pub fn get(&self, name: impl AsRef<str>) -> Option<Dependency<'a>> {
+        self.clone()
+            .into_iter()
+            .find(|dependency| dependency.name() == name.as_ref())
+    }
+}
 
 impl<'a> IntoIterator for Dependencies<'a> {
     type Item = Dependency<'a>;

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -40,26 +40,26 @@ impl Manifest {
 
     /// Gets the dependencies table.
     pub fn dependencies(&self) -> Dependencies<'_> {
-        match self.0.get("dependencies") {
-            Some(item) => Dependencies(item.as_table_like()),
-            None => Dependencies(None),
-        }
+        self.0
+            .get("dependencies")
+            .map(Into::into)
+            .unwrap_or_default()
     }
 
     /// Gets the dev dependencies table.
     pub fn dev_dependencies(&self) -> Dependencies<'_> {
-        match self.0.get("dev-dependencies") {
-            Some(item) => Dependencies(item.as_table_like()),
-            None => Dependencies(None),
-        }
+        self.0
+            .get("dev-dependencies")
+            .map(Into::into)
+            .unwrap_or_default()
     }
 
     /// Gets the build dependencies table.
     pub fn build_dependencies(&self) -> Dependencies<'_> {
-        match self.0.get("build-dependencies") {
-            Some(item) => Dependencies(item.as_table_like()),
-            None => Dependencies(None),
-        }
+        self.0
+            .get("build-dependencies")
+            .map(Into::into)
+            .unwrap_or_default()
     }
 
     /// Gets the workspace members.

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -62,10 +62,26 @@ impl Manifest {
             .unwrap_or_default()
     }
 
+    /// Gets the mutable dev dependencies table.
+    pub fn dev_dependencies_mut(&mut self) -> DependenciesMut<'_> {
+        self.0
+            .get_mut("dev-dependencies")
+            .map(Into::into)
+            .unwrap_or_default()
+    }
+
     /// Gets the build dependencies table.
     pub fn build_dependencies(&self) -> Dependencies<'_> {
         self.0
             .get("build-dependencies")
+            .map(Into::into)
+            .unwrap_or_default()
+    }
+
+    /// Gets the mutable build dependencies table.
+    pub fn build_dependencies_mut(&mut self) -> DependenciesMut<'_> {
+        self.0
+            .get_mut("build-dependencies")
             .map(Into::into)
             .unwrap_or_default()
     }

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -5,7 +5,7 @@ use toml_edit::{Array, DocumentMut, Item, TableLike, Value};
 
 use crate::package::members::Members;
 
-use super::dependency::Dependencies;
+use super::dependency::{Dependencies, DependenciesMut};
 use super::error::Error;
 use super::Cargo;
 
@@ -42,6 +42,14 @@ impl Manifest {
     pub fn dependencies(&self) -> Dependencies<'_> {
         self.0
             .get("dependencies")
+            .map(Into::into)
+            .unwrap_or_default()
+    }
+
+    /// Gets the mutable dependencies table.
+    pub fn dependencies_mut(&mut self) -> DependenciesMut<'_> {
+        self.0
+            .get_mut("dependencies")
             .map(Into::into)
             .unwrap_or_default()
     }

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -1,4 +1,3 @@
-use std::fmt::{self, Debug};
 use std::path::PathBuf;
 
 use globset::{Glob, GlobSetBuilder};
@@ -6,6 +5,7 @@ use toml_edit::{Array, DocumentMut, Item, TableLike, Value};
 
 use crate::package::members::Members;
 
+use super::dependency::Dependencies;
 use super::error::Error;
 use super::Cargo;
 
@@ -198,60 +198,5 @@ impl<'a> PackageMut<'a> {
     {
         *self.0.get_mut("version").expect("version") = Item::Value(Value::from(version.into()));
         self
-    }
-}
-
-/// The dependencies table.
-pub struct Dependencies<'a>(Option<&'a dyn TableLike>);
-
-impl<'a> IntoIterator for Dependencies<'a> {
-    type Item = Dependency<'a>;
-    type IntoIter = Box<dyn Iterator<Item = Dependency<'a>> + 'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        match self.0 {
-            Some(table) => Box::new(
-                table
-                    .iter()
-                    .map(|(name, item)| Dependency(name, item.as_table_like())),
-            ),
-            None => Box::new(std::iter::empty()),
-        }
-    }
-}
-
-impl<'a> Debug for Dependencies<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_list().entries(Self(self.0)).finish()
-    }
-}
-
-/// The dependency item.
-pub struct Dependency<'a>(&'a str, Option<&'a dyn TableLike>);
-
-impl<'a> Dependency<'a> {
-    /// Gets the dependency name.
-    pub fn name(&self) -> &'a str {
-        self.0
-    }
-
-    /// Gets the dependency path if it has been set.
-    pub fn path(&self) -> Option<&'a str> {
-        match self.1 {
-            Some(table) => match table.get("path") {
-                Some(path) => path.as_str(),
-                None => None,
-            },
-            None => None,
-        }
-    }
-}
-
-impl<'a> Debug for Dependency<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Dependency")
-            .field("name", &self.name())
-            .field("path", &self.path())
-            .finish()
     }
 }

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -1,5 +1,6 @@
 //! The `Cargo.toml` package for Rust.
 
+mod dependency;
 mod error;
 pub(super) mod manifest;
 

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -6,7 +6,7 @@ pub(super) mod manifest;
 
 use std::path::{Path, PathBuf};
 
-pub use self::dependency::{Dependencies, Dependency};
+pub use self::dependency::{Dependencies, DependenciesMut, Dependency, DependencyMut};
 pub use self::error::Error;
 use self::manifest::Manifest;
 
@@ -75,9 +75,21 @@ impl Cargo {
         self.dependencies().get(name)
     }
 
+    /// Gets the mutable dependency with the given name.
+    pub fn get_dependency_mut(&mut self, name: impl AsRef<str>) -> Option<DependencyMut<'_>> {
+        self.dependencies_mut()
+            .into_iter()
+            .find(|dependency| dependency.name() == name.as_ref())
+    }
+
     /// Gets the dependencies.
     pub fn dependencies(&self) -> Dependencies<'_> {
         self.manifest.dependencies()
+    }
+
+    // Gets the mutable dependencies.
+    pub fn dependencies_mut(&mut self) -> DependenciesMut<'_> {
+        self.manifest.dependencies_mut()
     }
 
     /// Gets the package contents.

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -6,6 +6,7 @@ pub(super) mod manifest;
 
 use std::path::{Path, PathBuf};
 
+pub use self::dependency::Dependency;
 pub use self::error::Error;
 use self::manifest::Manifest;
 
@@ -67,6 +68,11 @@ impl Cargo {
         self.set_version(bump.bump_str(self.version())?.to_string());
 
         Ok(())
+    }
+
+    /// Gets the dependency with the given name.
+    pub fn get_dependency(&self, name: impl AsRef<str>) -> Option<Dependency<'_>> {
+        self.manifest.dependencies().get(name)
     }
 
     /// Gets the package contents.

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -145,4 +145,9 @@ impl Cargo {
     pub fn is_changed(&self) -> bool {
         self.changed
     }
+
+    /// Sets the package as changed.
+    pub(crate) fn set_changed(&mut self, changed: bool) {
+        self.changed = changed;
+    }
 }

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -6,7 +6,7 @@ pub(super) mod manifest;
 
 use std::path::{Path, PathBuf};
 
-pub use self::dependency::Dependency;
+pub use self::dependency::{Dependencies, Dependency};
 pub use self::error::Error;
 use self::manifest::Manifest;
 
@@ -72,7 +72,12 @@ impl Cargo {
 
     /// Gets the dependency with the given name.
     pub fn get_dependency(&self, name: impl AsRef<str>) -> Option<Dependency<'_>> {
-        self.manifest.dependencies().get(name)
+        self.dependencies().get(name)
+    }
+
+    /// Gets the dependencies.
+    pub fn dependencies(&self) -> Dependencies<'_> {
+        self.manifest.dependencies()
     }
 
     /// Gets the package contents.

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -92,6 +92,50 @@ impl Cargo {
         self.manifest.dependencies_mut()
     }
 
+    /// Gets the dev dependency with the given name.
+    pub fn get_dev_dependency(&self, name: impl AsRef<str>) -> Option<Dependency<'_>> {
+        self.dev_dependencies().get(name)
+    }
+
+    /// Gets the mutable dev dependency with the given name.
+    pub fn get_dev_dependency_mut(&mut self, name: impl AsRef<str>) -> Option<DependencyMut<'_>> {
+        self.dev_dependencies_mut()
+            .into_iter()
+            .find(|dependency| dependency.name() == name.as_ref())
+    }
+
+    /// Gets the dev dependencies.
+    pub fn dev_dependencies(&self) -> Dependencies<'_> {
+        self.manifest.dev_dependencies()
+    }
+
+    // Gets the mutable dev dependencies.
+    pub fn dev_dependencies_mut(&mut self) -> DependenciesMut<'_> {
+        self.manifest.dev_dependencies_mut()
+    }
+
+    /// Gets the build dependency with the given name.
+    pub fn get_build_dependency(&self, name: impl AsRef<str>) -> Option<Dependency<'_>> {
+        self.build_dependencies().get(name)
+    }
+
+    /// Gets the mutable build dependency with the given name.
+    pub fn get_build_dependency_mut(&mut self, name: impl AsRef<str>) -> Option<DependencyMut<'_>> {
+        self.build_dependencies_mut()
+            .into_iter()
+            .find(|dependency| dependency.name() == name.as_ref())
+    }
+
+    /// Gets the build dependencies.
+    pub fn build_dependencies(&self) -> Dependencies<'_> {
+        self.manifest.build_dependencies()
+    }
+
+    // Gets the mutable build dependencies.
+    pub fn build_dependencies_mut(&mut self) -> DependenciesMut<'_> {
+        self.manifest.build_dependencies_mut()
+    }
+
     /// Gets the package contents.
     pub fn get_contents(&self) -> String {
         self.manifest.0.to_string()

--- a/packages/ploys/src/package/dependency.rs
+++ b/packages/ploys/src/package/dependency.rs
@@ -1,4 +1,7 @@
-use super::cargo::{Dependencies as CargoDependencies, Dependency as CargoDependency};
+use super::cargo::{
+    Dependencies as CargoDependencies, DependenciesMut as CargoDependenciesMut,
+    Dependency as CargoDependency, DependencyMut as CargoDependencyMut,
+};
 
 /// The package dependency.
 #[derive(Clone, Debug)]
@@ -52,6 +55,71 @@ impl<'a> IntoIterator for Dependencies<'a> {
     fn into_iter(self) -> Self::IntoIter {
         match self {
             Self::Cargo(dependencies) => Box::new(dependencies.into_iter().map(Dependency::Cargo)),
+        }
+    }
+}
+
+/// The mutable package dependency.
+#[derive(Debug)]
+pub enum DependencyMut<'a> {
+    /// A cargo package dependency.
+    Cargo(CargoDependencyMut<'a>),
+}
+
+impl<'a> DependencyMut<'a> {
+    /// Gets the dependency name.
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Cargo(dependency) => dependency.name(),
+        }
+    }
+
+    /// Gets the dependency version if it has been set.
+    pub fn version(&self) -> Option<&str> {
+        match self {
+            Self::Cargo(dependency) => dependency.version(),
+        }
+    }
+
+    /// Sets the dependency version.
+    pub fn set_version(&mut self, version: impl Into<String>) {
+        match self {
+            Self::Cargo(dependency) => dependency.set_version(version),
+        }
+    }
+
+    /// Gets the dependency path if it has been set.
+    pub fn path(&self) -> Option<&str> {
+        match self {
+            Self::Cargo(dependency) => dependency.path(),
+        }
+    }
+}
+
+/// The mutable package dependencies.
+#[derive(Debug)]
+pub enum DependenciesMut<'a> {
+    Cargo(CargoDependenciesMut<'a>),
+}
+
+impl<'a> DependenciesMut<'a> {
+    /// Gets the mutable dependency with the given name.
+    pub fn get_mut(&mut self, name: impl AsRef<str>) -> Option<DependencyMut<'_>> {
+        match self {
+            Self::Cargo(dependencies) => dependencies.get_mut(name).map(DependencyMut::Cargo),
+        }
+    }
+}
+
+impl<'a> IntoIterator for DependenciesMut<'a> {
+    type Item = DependencyMut<'a>;
+    type IntoIter = Box<dyn Iterator<Item = DependencyMut<'a>> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Self::Cargo(dependencies) => {
+                Box::new(dependencies.into_iter().map(DependencyMut::Cargo))
+            }
         }
     }
 }

--- a/packages/ploys/src/package/dependency.rs
+++ b/packages/ploys/src/package/dependency.rs
@@ -15,6 +15,13 @@ impl<'a> Dependency<'a> {
         }
     }
 
+    /// Gets the dependency version if it has been set.
+    pub fn version(&self) -> Option<&'a str> {
+        match self {
+            Self::Cargo(dependency) => dependency.version(),
+        }
+    }
+
     /// Gets the dependency path if it has been set.
     pub fn path(&self) -> Option<&'a str> {
         match self {

--- a/packages/ploys/src/package/dependency.rs
+++ b/packages/ploys/src/package/dependency.rs
@@ -1,0 +1,24 @@
+use super::cargo::Dependency as CargoDependency;
+
+/// The package dependency.
+#[derive(Debug)]
+pub enum Dependency<'a> {
+    /// A cargo package dependency.
+    Cargo(CargoDependency<'a>),
+}
+
+impl<'a> Dependency<'a> {
+    /// Gets the dependency name.
+    pub fn name(&self) -> &'a str {
+        match self {
+            Self::Cargo(dependency) => dependency.name(),
+        }
+    }
+
+    /// Gets the dependency path if it has been set.
+    pub fn path(&self) -> Option<&'a str> {
+        match self {
+            Self::Cargo(dependency) => dependency.path(),
+        }
+    }
+}

--- a/packages/ploys/src/package/dependency.rs
+++ b/packages/ploys/src/package/dependency.rs
@@ -1,7 +1,7 @@
-use super::cargo::Dependency as CargoDependency;
+use super::cargo::{Dependencies as CargoDependencies, Dependency as CargoDependency};
 
 /// The package dependency.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Dependency<'a> {
     /// A cargo package dependency.
     Cargo(CargoDependency<'a>),
@@ -26,6 +26,32 @@ impl<'a> Dependency<'a> {
     pub fn path(&self) -> Option<&'a str> {
         match self {
             Self::Cargo(dependency) => dependency.path(),
+        }
+    }
+}
+
+/// The package dependencies.
+#[derive(Clone, Debug)]
+pub enum Dependencies<'a> {
+    Cargo(CargoDependencies<'a>),
+}
+
+impl<'a> Dependencies<'a> {
+    /// Gets the dependency with the given name.
+    pub fn get(&self, name: impl AsRef<str>) -> Option<Dependency<'a>> {
+        match self {
+            Self::Cargo(dependencies) => dependencies.get(name).map(Dependency::Cargo),
+        }
+    }
+}
+
+impl<'a> IntoIterator for Dependencies<'a> {
+    type Item = Dependency<'a>;
+    type IntoIter = Box<dyn Iterator<Item = Dependency<'a>> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Self::Cargo(dependencies) => Box::new(dependencies.into_iter().map(Dependency::Cargo)),
         }
     }
 }

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -5,6 +5,7 @@
 
 mod bump;
 pub mod cargo;
+mod dependency;
 mod error;
 mod manifest;
 mod members;
@@ -17,6 +18,7 @@ use crate::project::source::Source;
 
 pub use self::bump::{Bump, BumpOrVersion, Error as BumpError};
 use self::cargo::Cargo;
+pub use self::dependency::Dependency;
 pub use self::error::Error;
 use self::manifest::Manifest;
 
@@ -74,6 +76,13 @@ impl Package {
     pub fn bump(&mut self, bump: Bump) -> Result<(), BumpError> {
         match self {
             Self::Cargo(cargo) => Ok(cargo.bump(bump)?),
+        }
+    }
+
+    /// Gets the dependency with the given name.
+    pub fn get_dependency(&self, name: impl AsRef<str>) -> Option<Dependency<'_>> {
+        match self {
+            Self::Cargo(cargo) => cargo.get_dependency(name).map(Dependency::Cargo),
         }
     }
 

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -178,6 +178,13 @@ impl Package {
             Self::Cargo(cargo) => cargo.is_changed(),
         }
     }
+
+    /// Sets the package as changed.
+    pub(crate) fn set_changed(&mut self, changed: bool) {
+        match self {
+            Self::Cargo(cargo) => cargo.set_changed(changed),
+        }
+    }
 }
 
 impl Package {

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -18,7 +18,7 @@ use crate::project::source::Source;
 
 pub use self::bump::{Bump, BumpOrVersion, Error as BumpError};
 use self::cargo::Cargo;
-pub use self::dependency::{Dependencies, Dependency};
+pub use self::dependency::{Dependencies, DependenciesMut, Dependency, DependencyMut};
 pub use self::error::Error;
 use self::manifest::Manifest;
 
@@ -86,10 +86,24 @@ impl Package {
         }
     }
 
+    /// Gets the mutable dependency with the given name.
+    pub fn get_dependency_mut(&mut self, name: impl AsRef<str>) -> Option<DependencyMut<'_>> {
+        match self {
+            Self::Cargo(cargo) => cargo.get_dependency_mut(name).map(DependencyMut::Cargo),
+        }
+    }
+
     /// Gets the dependencies.
     pub fn dependencies(&self) -> Dependencies<'_> {
         match self {
             Self::Cargo(cargo) => Dependencies::Cargo(cargo.dependencies()),
+        }
+    }
+
+    /// Gets the mutable dependencies.
+    pub fn dependencies_mut(&mut self) -> DependenciesMut<'_> {
+        match self {
+            Self::Cargo(cargo) => DependenciesMut::Cargo(cargo.dependencies_mut()),
         }
     }
 

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -18,7 +18,7 @@ use crate::project::source::Source;
 
 pub use self::bump::{Bump, BumpOrVersion, Error as BumpError};
 use self::cargo::Cargo;
-pub use self::dependency::Dependency;
+pub use self::dependency::{Dependencies, Dependency};
 pub use self::error::Error;
 use self::manifest::Manifest;
 
@@ -83,6 +83,13 @@ impl Package {
     pub fn get_dependency(&self, name: impl AsRef<str>) -> Option<Dependency<'_>> {
         match self {
             Self::Cargo(cargo) => cargo.get_dependency(name).map(Dependency::Cargo),
+        }
+    }
+
+    /// Gets the dependencies.
+    pub fn dependencies(&self) -> Dependencies<'_> {
+        match self {
+            Self::Cargo(cargo) => Dependencies::Cargo(cargo.dependencies()),
         }
     }
 

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -107,6 +107,64 @@ impl Package {
         }
     }
 
+    /// Gets the dev dependency with the given name.
+    pub fn get_dev_dependency(&self, name: impl AsRef<str>) -> Option<Dependency<'_>> {
+        match self {
+            Self::Cargo(cargo) => cargo.get_dev_dependency(name).map(Dependency::Cargo),
+        }
+    }
+
+    /// Gets the mutable dev dependency with the given name.
+    pub fn get_dev_dependency_mut(&mut self, name: impl AsRef<str>) -> Option<DependencyMut<'_>> {
+        match self {
+            Self::Cargo(cargo) => cargo.get_dev_dependency_mut(name).map(DependencyMut::Cargo),
+        }
+    }
+
+    /// Gets the dev dependencies.
+    pub fn dev_dependencies(&self) -> Dependencies<'_> {
+        match self {
+            Self::Cargo(cargo) => Dependencies::Cargo(cargo.dev_dependencies()),
+        }
+    }
+
+    /// Gets the mutable dev dependencies.
+    pub fn dev_dependencies_mut(&mut self) -> DependenciesMut<'_> {
+        match self {
+            Self::Cargo(cargo) => DependenciesMut::Cargo(cargo.dev_dependencies_mut()),
+        }
+    }
+
+    /// Gets the build dependency with the given name.
+    pub fn get_build_dependency(&self, name: impl AsRef<str>) -> Option<Dependency<'_>> {
+        match self {
+            Self::Cargo(cargo) => cargo.get_build_dependency(name).map(Dependency::Cargo),
+        }
+    }
+
+    /// Gets the mutable build dependency with the given name.
+    pub fn get_build_dependency_mut(&mut self, name: impl AsRef<str>) -> Option<DependencyMut<'_>> {
+        match self {
+            Self::Cargo(cargo) => cargo
+                .get_build_dependency_mut(name)
+                .map(DependencyMut::Cargo),
+        }
+    }
+
+    /// Gets the build dependencies.
+    pub fn build_dependencies(&self) -> Dependencies<'_> {
+        match self {
+            Self::Cargo(cargo) => Dependencies::Cargo(cargo.build_dependencies()),
+        }
+    }
+
+    /// Gets the mutable build dependencies.
+    pub fn build_dependencies_mut(&mut self) -> DependenciesMut<'_> {
+        match self {
+            Self::Cargo(cargo) => DependenciesMut::Cargo(cargo.build_dependencies_mut()),
+        }
+    }
+
     /// Gets the package contents.
     pub fn get_contents(&self) -> String {
         match self {

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -333,11 +333,17 @@ where
             .iter_mut()
             .find(|pkg| pkg.name() == package.as_ref())
         {
-            Some(package) => {
-                package.set_version(version);
+            Some(pkg) => {
+                pkg.set_version(version.clone());
 
-                if let Some(lockfile) = self.lockfiles.get_mut(&package.kind()) {
-                    lockfile.set_package_version(package.name(), package.version());
+                if let Some(lockfile) = self.lockfiles.get_mut(&pkg.kind()) {
+                    lockfile.set_package_version(pkg.name(), pkg.version());
+                }
+
+                for pkg in self.packages.iter_mut() {
+                    if let Some(mut dependency) = pkg.get_dependency_mut(package.as_ref()) {
+                        dependency.set_version(version.to_string());
+                    }
                 }
 
                 Ok(())
@@ -356,11 +362,19 @@ where
             .iter_mut()
             .find(|pkg| pkg.name() == package.as_ref())
         {
-            Some(package) => {
-                package.bump(bump)?;
+            Some(pkg) => {
+                pkg.bump(bump)?;
 
-                if let Some(lockfile) = self.lockfiles.get_mut(&package.kind()) {
-                    lockfile.set_package_version(package.name(), package.version());
+                if let Some(lockfile) = self.lockfiles.get_mut(&pkg.kind()) {
+                    lockfile.set_package_version(pkg.name(), pkg.version());
+                }
+
+                let version = pkg.version().to_owned();
+
+                for pkg in self.packages.iter_mut() {
+                    if let Some(mut dependency) = pkg.get_dependency_mut(package.as_ref()) {
+                        dependency.set_version(version.clone());
+                    }
                 }
 
                 Ok(())

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -343,14 +343,17 @@ where
                 for pkg in self.packages.iter_mut() {
                     if let Some(mut dependency) = pkg.get_dependency_mut(package.as_ref()) {
                         dependency.set_version(version.to_string());
+                        pkg.set_changed(true);
                     }
 
                     if let Some(mut dependency) = pkg.get_dev_dependency_mut(package.as_ref()) {
                         dependency.set_version(version.to_string());
+                        pkg.set_changed(true);
                     }
 
                     if let Some(mut dependency) = pkg.get_build_dependency_mut(package.as_ref()) {
                         dependency.set_version(version.to_string());
+                        pkg.set_changed(true);
                     }
                 }
 
@@ -382,14 +385,17 @@ where
                 for pkg in self.packages.iter_mut() {
                     if let Some(mut dependency) = pkg.get_dependency_mut(package.as_ref()) {
                         dependency.set_version(version.clone());
+                        pkg.set_changed(true);
                     }
 
                     if let Some(mut dependency) = pkg.get_dev_dependency_mut(package.as_ref()) {
                         dependency.set_version(version.clone());
+                        pkg.set_changed(true);
                     }
 
                     if let Some(mut dependency) = pkg.get_build_dependency_mut(package.as_ref()) {
                         dependency.set_version(version.clone());
+                        pkg.set_changed(true);
                     }
                 }
 

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -344,6 +344,14 @@ where
                     if let Some(mut dependency) = pkg.get_dependency_mut(package.as_ref()) {
                         dependency.set_version(version.to_string());
                     }
+
+                    if let Some(mut dependency) = pkg.get_dev_dependency_mut(package.as_ref()) {
+                        dependency.set_version(version.to_string());
+                    }
+
+                    if let Some(mut dependency) = pkg.get_build_dependency_mut(package.as_ref()) {
+                        dependency.set_version(version.to_string());
+                    }
                 }
 
                 Ok(())
@@ -373,6 +381,14 @@ where
 
                 for pkg in self.packages.iter_mut() {
                     if let Some(mut dependency) = pkg.get_dependency_mut(package.as_ref()) {
+                        dependency.set_version(version.clone());
+                    }
+
+                    if let Some(mut dependency) = pkg.get_dev_dependency_mut(package.as_ref()) {
+                        dependency.set_version(version.clone());
+                    }
+
+                    if let Some(mut dependency) = pkg.get_build_dependency_mut(package.as_ref()) {
                         dependency.set_version(version.clone());
                     }
                 }


### PR DESCRIPTION
Closes #72.

This adds support for package dependencies by providing types and methods to read and update basic dependency information.

The library internally handled dependencies to discover cargo workspace members other than those specified in the workspace manifest. However, the functionality was not exposed to end-users so it was not possible to get the dependencies of a package.

This change exposes the existing ability to get package dependencies and builds on it by adding the ability to mutate dependencies. This includes regular, dev and build dependencies but not target dependencies. At the moment this only supports setting the dependency version to enable the ability to update versions on release. The `Project` type has not yet been updated to expose mutable access to the packages so dependency mutation is internal only.