### PR TITLE
Add changelog parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,6 +648,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,6 +2149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "io-close"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,6 +2346,15 @@ name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+
+[[package]]
+name = "markdown"
+version = "1.0.0-alpha.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6491e6c702bf7e3b24e769d800746d5f2c06a6c6a2db7992612e0f429029e81"
+dependencies = [
+ "unicode-id",
+]
 
 [[package]]
 name = "matchers"
@@ -2708,6 +2729,9 @@ dependencies = [
  "git2",
  "gix",
  "globset",
+ "indoc",
+ "markdown",
+ "pretty_assertions",
  "semver",
  "serde",
  "toml_edit",
@@ -2799,6 +2823,16 @@ checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -4273,6 +4307,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e90c70c9f0d4d1ee6d0a7d04aa06cb9bbd53d8cfbdd62a0269a7c2eb640552"
 
 [[package]]
+name = "unicode-id"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10103c57044730945224467c09f71a4db0071c123a0648cc3e818913bde6b561"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4819,6 +4859,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -16,6 +16,7 @@ github = ["dep:ureq"]
 [dependencies]
 gix = { version = "0.66.0", optional = true }
 globset = "0.4.13"
+markdown = "=1.0.0-alpha.21"
 semver = "1.0.19"
 serde = { version = "1.0.185", features = ["derive"] }
 toml_edit = { version = "0.22.14", features = ["serde"] }
@@ -30,3 +31,7 @@ optional = true
 [dependencies.auth-git2]
 version = "0.5.5"
 optional = true
+
+[dev-dependencies]
+indoc = "2.0.5"
+pretty_assertions = "1.4.1"

--- a/packages/ploys/src/changelog/change.rs
+++ b/packages/ploys/src/changelog/change.rs
@@ -1,0 +1,49 @@
+use std::fmt::{self, Display};
+
+use markdown::mdast::Node;
+
+use super::Text;
+
+/// A single change in a changelog.
+#[derive(Clone, Debug)]
+pub struct ChangeRef<'a> {
+    text: Text<'a>,
+}
+
+impl<'a> ChangeRef<'a> {
+    /// Gets the change message.
+    pub fn message(&self) -> String {
+        format!("{:#}", self.text)
+    }
+
+    /// Gets the url if set.
+    pub fn url(&self) -> Option<&str> {
+        self.text.nodes.iter().rev().find_map(|node| match node {
+            Node::Link(link) => Some(&*link.url),
+            _ => None,
+        })
+    }
+}
+
+impl<'a> ChangeRef<'a> {
+    /// Constructs the change reference from a slice of nodes.
+    pub(super) fn from_nodes(nodes: &'a [Node]) -> Option<Self> {
+        let Node::Paragraph(paragraph) = nodes.first()? else {
+            return None;
+        };
+
+        Some(Self {
+            text: Text::from_nodes(&paragraph.children),
+        })
+    }
+}
+
+impl<'a> Display for ChangeRef<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "- {:#}", self.text)
+        } else {
+            write!(f, "- {}", self.text)
+        }
+    }
+}

--- a/packages/ploys/src/changelog/changeset.rs
+++ b/packages/ploys/src/changelog/changeset.rs
@@ -1,0 +1,97 @@
+use std::fmt::{self, Display};
+
+use markdown::mdast::Node;
+
+use super::{ChangeRef, MultilineText};
+
+/// A changelog release labelled changeset.
+#[derive(Clone, Debug)]
+pub struct ChangesetRef<'a> {
+    label: &'a str,
+    nodes: &'a [Node],
+}
+
+impl<'a> ChangesetRef<'a> {
+    /// Gets the changeset label.
+    pub fn label(&self) -> &str {
+        self.label
+    }
+
+    /// Gets the changeset description.
+    pub fn description(&self) -> Option<MultilineText<'_>> {
+        MultilineText::from_nodes(self.nodes)
+    }
+
+    /// Gets an iterator over the changes.
+    pub fn changes(&self) -> impl Iterator<Item = ChangeRef<'a>> {
+        self.nodes
+            .iter()
+            .filter_map(|node| match node {
+                Node::List(list) => Some(list),
+                _ => None,
+            })
+            .flat_map(|list| {
+                list.children.iter().filter_map(|node| match node {
+                    Node::ListItem(item) => ChangeRef::from_nodes(&item.children),
+                    _ => None,
+                })
+            })
+    }
+}
+
+impl<'a> ChangesetRef<'a> {
+    /// Constructs the changeset reference from a slice of nodes.
+    pub(super) fn from_nodes(nodes: &'a [Node]) -> Option<Self> {
+        let Node::Heading(heading) = nodes.first()? else {
+            return None;
+        };
+
+        if heading.depth != 3 {
+            return None;
+        }
+
+        let label = heading.children.iter().find_map(|node| match node {
+            Node::Text(text) => Some(&*text.value),
+            _ => None,
+        })?;
+
+        Some(Self {
+            label,
+            nodes: &nodes[1..],
+        })
+    }
+}
+
+impl<'a> Display for ChangesetRef<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "### {}", self.label())?;
+
+        if let Some(description) = self.description() {
+            if f.alternate() {
+                write!(f, "\n\n{description:#}")?;
+            } else {
+                write!(f, "\n\n{description}")?;
+            }
+        }
+
+        let mut changes = self.changes().peekable();
+
+        if changes.peek().is_some() {
+            write!(f, "\n\n")?;
+
+            while let Some(change) = changes.next() {
+                if f.alternate() {
+                    write!(f, "{change:#}")?;
+                } else {
+                    write!(f, "{change}")?;
+                }
+
+                if changes.peek().is_some() {
+                    writeln!(f)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/packages/ploys/src/changelog/mod.rs
+++ b/packages/ploys/src/changelog/mod.rs
@@ -1,0 +1,304 @@
+mod change;
+mod changeset;
+mod reference;
+mod release;
+mod text;
+
+use std::convert::Infallible;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+
+use markdown::mdast::{Node, Root};
+use markdown::ParseOptions;
+
+pub use self::change::ChangeRef;
+pub use self::changeset::ChangesetRef;
+pub use self::reference::ReferenceRef;
+pub use self::release::ReleaseRef;
+pub use self::text::{MultilineText, Text};
+
+/// Represents a changelog file.
+///
+/// This uses the [keep a changelog](https://keepachangelog.com) format to parse
+/// and generate changelogs. There is very limited support for deviation from
+/// this format so the changelog should not yet be manually edited.
+#[derive(Clone, Debug)]
+pub struct Changelog(Node);
+
+impl Changelog {
+    /// Gets the changelog title.
+    pub fn title(&self) -> Option<Text<'_>> {
+        self.0
+            .children()?
+            .iter()
+            .find(|node| matches!(node, Node::Heading(heading) if heading.depth == 1))
+            .and_then(|node| Some(Text::from_nodes(node.children()?)))
+    }
+
+    /// Gets the changelog description.
+    pub fn description(&self) -> Option<MultilineText<'_>> {
+        self.get_sections()
+            .next()
+            .and_then(|nodes| match nodes.first() {
+                Some(Node::Heading(heading)) if heading.depth == 1 => {
+                    MultilineText::from_nodes(&nodes[1..])
+                }
+                Some(Node::Heading(heading)) if heading.depth == 2 => None,
+                _ => MultilineText::from_nodes(nodes),
+            })
+    }
+
+    /// Gets a release for the given version.
+    pub fn get_release(&self, version: impl AsRef<str>) -> Option<ReleaseRef<'_>> {
+        self.releases()
+            .find(|release| release.version() == version.as_ref())
+    }
+
+    /// Gets an iterator over the releases.
+    pub fn releases(&self) -> impl Iterator<Item = ReleaseRef<'_>> {
+        self.get_sections().filter_map(ReleaseRef::from_nodes)
+    }
+
+    /// Gets an iterator over the references.
+    pub fn references(&self) -> impl Iterator<Item = ReferenceRef<'_>> {
+        self.releases()
+            .last()
+            .into_iter()
+            .flat_map(|release| release.references())
+    }
+}
+
+impl Changelog {
+    /// Gets the sections separated by a second-level heading.
+    fn get_sections(&self) -> impl Iterator<Item = &[Node]> {
+        self.0.children().into_iter().flat_map(|nodes| {
+            nodes.chunk_by(|_, node| !matches!(node, Node::Heading(heading) if heading.depth == 2))
+        })
+    }
+}
+
+impl Default for Changelog {
+    fn default() -> Self {
+        Self(Node::Root(Root {
+            children: Vec::new(),
+            position: None,
+        }))
+    }
+}
+
+impl Display for Changelog {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(title) = self.title() {
+            if f.alternate() {
+                write!(f, "# {title:#}")?;
+            } else {
+                write!(f, "# {title}")?;
+            }
+        } else {
+            write!(f, "# Changelog")?;
+        }
+
+        if let Some(description) = self.description() {
+            if f.alternate() {
+                write!(f, "\n\n{description:#}")?;
+            } else {
+                write!(f, "\n\n{description}")?;
+            }
+        }
+
+        let mut releases = self.releases().peekable();
+
+        if releases.peek().is_some() {
+            write!(f, "\n\n")?;
+
+            while let Some(release) = releases.next() {
+                if f.alternate() {
+                    write!(f, "{release:#}")?;
+                } else {
+                    write!(f, "{release}")?;
+                }
+
+                if releases.peek().is_some() {
+                    write!(f, "\n\n")?;
+                }
+            }
+        }
+
+        writeln!(f)?;
+
+        Ok(())
+    }
+}
+
+impl FromStr for Changelog {
+    type Err = Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self(
+            markdown::to_mdast(value, &ParseOptions::default()).expect("markdown"),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use super::Changelog;
+
+    #[test]
+    fn test_changelog_parser() {
+        let changelog_text = indoc! {"
+            # Changelog
+
+            All notable changes to this project will be documented in this file.
+
+            The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+            and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+            ## [0.2.0] - 2024-01-04
+
+            ### Added
+
+            - Added three ([#3](https://github.com/ploys/example/pull/3))
+
+            ### Removed
+
+            - Removed four ([#4](https://github.com/ploys/example/pull/4))
+
+            ### Fixed
+
+            - Fixed five ([#5](https://github.com/ploys/example/pull/5))
+
+            ### Changed
+
+            - Changed six ([#6](https://github.com/ploys/example/pull/6))
+            - Changed seven ([#7](https://github.com/ploys/example/pull/7))
+            - Changed `eight` ([#8](https://github.com/ploys/example/pull/8))
+
+            ## [0.1.2] - 2024-01-03
+
+            ### Fixed
+
+            This changeset has a description.
+
+            - Fixed two ([#2](https://github.com/ploys/example/pull/2))
+
+            ## [0.1.1] - 2024-01-02
+
+            ### Fixed
+
+            - Fixed one ([#1](https://github.com/ploys/example/pull/1))
+
+            ## [0.1.0] - 2024-01-01
+
+            This is the initial release.
+
+            [0.2.0]: https://github.com/ploys/example/releases/tag/0.2.0
+            [0.1.2]: https://github.com/ploys/example/releases/tag/0.1.2
+            [0.1.1]: https://github.com/ploys/example/releases/tag/0.1.1
+            [0.1.0]: https://github.com/ploys/example/releases/tag/0.1.0
+        "};
+
+        let changelog = changelog_text.parse::<Changelog>().unwrap();
+
+        assert_eq!(changelog.title().unwrap().to_string(), "Changelog");
+
+        let mut references = changelog.references();
+
+        let t0 = references.next().unwrap();
+        let t1 = references.next().unwrap();
+        let t2 = references.next().unwrap();
+        let t3 = references.next().unwrap();
+
+        assert_eq!(t0.id(), "0.2.0");
+        assert_eq!(t1.id(), "0.1.2");
+        assert_eq!(t2.id(), "0.1.1");
+        assert_eq!(t3.id(), "0.1.0");
+
+        assert_eq!(
+            t0.url(),
+            "https://github.com/ploys/example/releases/tag/0.2.0"
+        );
+        assert_eq!(
+            t1.url(),
+            "https://github.com/ploys/example/releases/tag/0.1.2"
+        );
+        assert_eq!(
+            t2.url(),
+            "https://github.com/ploys/example/releases/tag/0.1.1"
+        );
+        assert_eq!(
+            t3.url(),
+            "https://github.com/ploys/example/releases/tag/0.1.0"
+        );
+
+        let r0 = changelog.get_release("0.1.0").unwrap();
+        let r1 = changelog.get_release("0.1.1").unwrap();
+        let r2 = changelog.get_release("0.1.2").unwrap();
+        let r3 = changelog.get_release("0.2.0").unwrap();
+
+        assert_eq!(r0.version(), "0.1.0");
+        assert_eq!(r1.version(), "0.1.1");
+        assert_eq!(r2.version(), "0.1.2");
+        assert_eq!(r3.version(), "0.2.0");
+
+        assert_eq!(r0.date(), Some("2024-01-01"));
+        assert_eq!(r1.date(), Some("2024-01-02"));
+        assert_eq!(r2.date(), Some("2024-01-03"));
+        assert_eq!(r3.date(), Some("2024-01-04"));
+
+        assert_eq!(
+            r0.description().unwrap().to_string(),
+            "This is the initial release.",
+        );
+
+        assert_eq!(r0.changesets().count(), 0);
+        assert_eq!(r1.changesets().count(), 1);
+        assert_eq!(r2.changesets().count(), 1);
+        assert_eq!(r3.changesets().count(), 4);
+
+        let s0 = r1.fixed().unwrap();
+        let s1 = r2.fixed().unwrap();
+        let s2 = r3.added().unwrap();
+        let s3 = r3.removed().unwrap();
+        let s4 = r3.fixed().unwrap();
+        let s5 = r3.changed().unwrap();
+
+        assert_eq!(s0.changes().count(), 1);
+        assert_eq!(s1.changes().count(), 1);
+        assert_eq!(s2.changes().count(), 1);
+        assert_eq!(s3.changes().count(), 1);
+        assert_eq!(s4.changes().count(), 1);
+        assert_eq!(s5.changes().count(), 3);
+
+        assert_eq!(s0.label(), "Fixed");
+        assert_eq!(s1.label(), "Fixed");
+        assert_eq!(s2.label(), "Added");
+        assert_eq!(s3.label(), "Removed");
+        assert_eq!(s4.label(), "Fixed");
+        assert_eq!(s5.label(), "Changed");
+
+        assert_eq!(
+            s1.description().unwrap().to_string(),
+            "This changeset has a description."
+        );
+
+        let mut changes = s5.changes();
+
+        let c0 = changes.next().unwrap();
+        let c1 = changes.next().unwrap();
+        let c2 = changes.next().unwrap();
+
+        assert_eq!(c0.message(), "Changed six (#6)");
+        assert_eq!(c1.message(), "Changed seven (#7)");
+        assert_eq!(c2.message(), "Changed `eight` (#8)");
+
+        assert_eq!(c0.url(), Some("https://github.com/ploys/example/pull/6"));
+        assert_eq!(c1.url(), Some("https://github.com/ploys/example/pull/7"));
+        assert_eq!(c2.url(), Some("https://github.com/ploys/example/pull/8"));
+
+        assert_eq!(changelog.to_string(), changelog_text);
+    }
+}

--- a/packages/ploys/src/changelog/reference.rs
+++ b/packages/ploys/src/changelog/reference.rs
@@ -1,0 +1,37 @@
+use std::fmt::{self, Display};
+
+use markdown::mdast::Definition;
+
+/// A changelog reference.
+pub struct ReferenceRef<'a> {
+    definition: &'a Definition,
+}
+
+impl<'a> ReferenceRef<'a> {
+    /// Gets the reference ID.
+    pub fn id(&self) -> &str {
+        &self.definition.identifier
+    }
+
+    /// Gets the reference URL.
+    pub fn url(&self) -> &str {
+        &self.definition.url
+    }
+}
+
+impl<'a> ReferenceRef<'a> {
+    /// Constructs the release reference from a definition.
+    pub(super) fn from_definition(definition: &'a Definition) -> Self {
+        Self { definition }
+    }
+}
+
+impl<'a> Display for ReferenceRef<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{}]: {}",
+            self.definition.identifier, self.definition.url
+        )
+    }
+}

--- a/packages/ploys/src/changelog/release.rs
+++ b/packages/ploys/src/changelog/release.rs
@@ -1,0 +1,175 @@
+use std::fmt::{self, Display};
+
+use markdown::mdast::Node;
+
+use super::{ChangesetRef, MultilineText, ReferenceRef};
+
+/// A changelog release entry.
+#[derive(Clone, Debug)]
+pub struct ReleaseRef<'a> {
+    version: &'a str,
+    date: Option<&'a str>,
+    nodes: &'a [Node],
+}
+
+impl<'a> ReleaseRef<'a> {
+    /// Gets the release version.
+    pub fn version(&self) -> &str {
+        self.version
+    }
+
+    /// Gets the release date.
+    pub fn date(&self) -> Option<&str> {
+        self.date
+    }
+
+    /// Gets the release description.
+    pub fn description(&self) -> Option<MultilineText<'_>> {
+        MultilineText::from_nodes(self.nodes)
+    }
+
+    /// Gets the `Added` changeset.
+    pub fn added(&self) -> Option<ChangesetRef<'a>> {
+        self.get_changeset("Added")
+    }
+
+    /// Gets the `Changed` changeset.
+    pub fn changed(&self) -> Option<ChangesetRef<'a>> {
+        self.get_changeset("Changed")
+    }
+
+    /// Gets the `Deprecated` changeset.
+    pub fn deprecated(&self) -> Option<ChangesetRef<'a>> {
+        self.get_changeset("Deprecated")
+    }
+
+    /// Gets the `Removed` changeset.
+    pub fn removed(&self) -> Option<ChangesetRef<'a>> {
+        self.get_changeset("Removed")
+    }
+
+    /// Gets the `Fixed` changeset.
+    pub fn fixed(&self) -> Option<ChangesetRef<'a>> {
+        self.get_changeset("Fixed")
+    }
+
+    /// Gets the `Security` changeset.
+    pub fn security(&self) -> Option<ChangesetRef<'a>> {
+        self.get_changeset("Security")
+    }
+
+    /// Gets the changeset for the given label.
+    pub fn get_changeset(&self, label: impl AsRef<str>) -> Option<ChangesetRef<'a>> {
+        self.changesets()
+            .find(|changeset| changeset.label() == label.as_ref())
+    }
+
+    /// Gets an iterator over the changesets.
+    pub fn changesets(&self) -> impl Iterator<Item = ChangesetRef<'a>> {
+        self.get_sections().filter_map(ChangesetRef::from_nodes)
+    }
+
+    /// Gets an iterator over the references.
+    pub fn references(&self) -> impl Iterator<Item = ReferenceRef<'a>> {
+        self.nodes
+            .chunk_by(|node, _| matches!(node, Node::Definition(_)))
+            .last()
+            .into_iter()
+            .flat_map(|nodes| {
+                nodes.iter().filter_map(|node| match node {
+                    Node::Definition(definition) => Some(ReferenceRef::from_definition(definition)),
+                    _ => None,
+                })
+            })
+    }
+}
+
+impl<'a> ReleaseRef<'a> {
+    /// Constructs the release reference from a slice of nodes.
+    pub(super) fn from_nodes(nodes: &'a [Node]) -> Option<Self> {
+        let Node::Heading(heading) = nodes.first()? else {
+            return None;
+        };
+
+        if heading.depth != 2 {
+            return None;
+        }
+
+        let version = heading.children.iter().find_map(|node| match node {
+            Node::LinkReference(link) => Some(&link.identifier),
+            _ => None,
+        })?;
+
+        let date = heading.children.iter().find_map(|node| match node {
+            Node::Text(text) => Some(text.value.trim().trim_start_matches('-').trim()),
+            _ => None,
+        });
+
+        Some(Self {
+            version,
+            date,
+            nodes: &nodes[1..],
+        })
+    }
+
+    /// Gets the sections separated by a third-level heading.
+    fn get_sections(&self) -> impl Iterator<Item = &'a [Node]> {
+        self.nodes
+            .chunk_by(|_, node| !matches!(node, Node::Heading(heading) if heading.depth == 3))
+    }
+}
+
+impl<'a> Display for ReleaseRef<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.date {
+            Some(date) => write!(f, "## [{}] - {date}", self.version)?,
+            None => write!(f, "## [{}]", self.version)?,
+        }
+
+        if let Some(description) = self.description() {
+            if f.alternate() {
+                write!(f, "\n\n{description:#}")?;
+            } else {
+                write!(f, "\n\n{description}")?;
+            }
+        }
+
+        let mut changesets = self.changesets().peekable();
+
+        if changesets.peek().is_some() {
+            write!(f, "\n\n")?;
+
+            while let Some(changeset) = changesets.next() {
+                if f.alternate() {
+                    write!(f, "{changeset:#}")?;
+                } else {
+                    write!(f, "{changeset}")?;
+                }
+
+                if changesets.peek().is_some() {
+                    write!(f, "\n\n")?;
+                }
+            }
+        }
+
+        let mut references = self.references().peekable();
+
+        if references.peek().is_some() {
+            write!(f, "\n\n")?;
+
+            while let Some(reference) = references.next() {
+                if f.alternate() {
+                    write!(f, "{reference:#}")?;
+                } else {
+                    write!(f, "{reference}")?;
+                }
+
+                if references.peek().is_some() {
+                    writeln!(f)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/packages/ploys/src/changelog/text.rs
+++ b/packages/ploys/src/changelog/text.rs
@@ -1,0 +1,119 @@
+use std::fmt::{self, Display};
+
+use markdown::mdast::Node;
+
+/// A changelog text section.
+#[derive(Clone, Debug)]
+pub struct Text<'a> {
+    pub(super) nodes: &'a [Node],
+}
+
+impl<'a> Text<'a> {
+    /// Constructs the text from a slice of nodes.
+    pub(super) fn from_nodes(nodes: &'a [Node]) -> Self {
+        Self { nodes }
+    }
+}
+
+impl<'a> Display for Text<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for node in self.nodes {
+            write_node(f, node)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// A changelog multiline text section.
+#[derive(Clone, Debug)]
+pub struct MultilineText<'a> {
+    nodes: &'a [Node],
+}
+
+impl<'a> MultilineText<'a> {
+    /// Constructs the multiline text from a slice of nodes.
+    pub(super) fn from_nodes(nodes: &'a [Node]) -> Option<Self> {
+        nodes
+            .split(|node| matches!(node, Node::Heading(_) | Node::List(_) | Node::Definition(_)))
+            .next()
+            .and_then(|nodes| match nodes.is_empty() {
+                true => None,
+                false => Some(Self { nodes }),
+            })
+    }
+}
+
+impl<'a> Display for MultilineText<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut nodes = self.nodes.iter().peekable();
+
+        while let Some(node) = nodes.next() {
+            if write_node(f, node)? && nodes.peek().is_some() {
+                write!(f, "\n\n")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Writes a markdown node.
+///
+/// Unfortunately, the `ToString` implementation does not render markdown and
+/// markdown generation from an AST is not yet supported by the `markdown`
+/// crate. This is a temporary solution until a better implementation can be
+/// found.
+pub(super) fn write_node(f: &mut fmt::Formatter<'_>, node: &Node) -> Result<bool, fmt::Error> {
+    let mut printed = false;
+
+    match node {
+        Node::Heading(heading) => {
+            write!(f, "{:#<width$} ", "", width = heading.depth as usize)?;
+
+            for node in &heading.children {
+                printed |= write_node(f, node)?;
+            }
+
+            Ok(printed)
+        }
+        Node::Paragraph(paragraph) => {
+            for node in &paragraph.children {
+                printed |= write_node(f, node)?;
+            }
+
+            Ok(printed)
+        }
+        Node::Text(text) => {
+            write!(f, "{}", text.value)?;
+
+            Ok(true)
+        }
+        Node::Link(link) => match f.alternate() {
+            true => {
+                for node in &link.children {
+                    printed |= write_node(f, node)?;
+                }
+
+                Ok(printed)
+            }
+            false => {
+                write!(f, "[")?;
+
+                for node in &link.children {
+                    printed |= write_node(f, node)?;
+                }
+
+                write!(f, "]({})", link.url)?;
+
+                Ok(printed)
+            }
+        },
+        Node::InlineCode(code) => {
+            write!(f, "`{}`", code.value)?;
+
+            Ok(true)
+        }
+        _ => Ok(printed),
+    }
+}

--- a/packages/ploys/src/lib.rs
+++ b/packages/ploys/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod changelog;
 pub mod lockfile;
 pub mod package;
 pub mod project;


### PR DESCRIPTION
Closes #83.

This adds the initial implementation of a changelog parser using the [keep a changelog](https://keepachangelog.com) format.

The change uses the latest alpha release of the `markdown` crate to somewhat replicate how the `toml_edit` crate is used for editing cargo package manifests and lockfiles without destructive changes to user-provided formatting. Rather than parse the AST upfront to build the changelog format it is instead lazy and simply wraps the markdown AST.

Unfortunately, the `Display` implementation can be destructive as it does not fully support or understand markdown outside of that used in the changelog format. For example, any text placed after a list of changes and before the next heading will be ignored. This is because the `markdown` crate does not yet support rendering the AST back to markdown and that would require a lot of work to implement in this project. There appears to be an unreleased utility crate for this but the project requires all dependencies to published on crates.io.

The long-term goal is to replace the `markdown` crate with a custom implementation that works better for the project and the changelog format. However, for now it is more than sufficient.

A notable inclusion in this implementation is the ability to set the alternate display mode for the format string to toggle off the rendering of URLs. This should enable the ability to use only hash links on GitHub to avoid hardcoding the repository URL.