### PR TITLE
Add changelog builder

### DIFF
--- a/packages/ploys/src/changelog/change.rs
+++ b/packages/ploys/src/changelog/change.rs
@@ -1,8 +1,107 @@
 use std::fmt::{self, Display};
 
 use markdown::mdast::Node;
+use markdown::ParseOptions;
 
 use super::Text;
+
+/// A changelog change.
+#[derive(Clone, Debug)]
+pub struct Change {
+    message: String,
+    url: Option<(String, String)>,
+}
+
+impl Change {
+    /// Constructs a new change.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            url: None,
+        }
+    }
+
+    /// Gets the change message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Gets the change URL.
+    pub fn url(&self) -> Option<(&str, &str)> {
+        self.url.as_ref().map(|(label, url)| (&**label, &**url))
+    }
+
+    /// Sets the change URL.
+    pub fn set_url(&mut self, label: impl Into<String>, url: impl Into<String>) -> &mut Self {
+        self.url = Some((label.into(), url.into()));
+        self
+    }
+
+    /// Builds the change with the given URL.
+    pub fn with_url(mut self, label: impl Into<String>, url: impl Into<String>) -> Self {
+        self.set_url(label, url);
+        self
+    }
+}
+
+impl Change {
+    /// Converts the change into markdown nodes.
+    pub(super) fn into_nodes(self) -> Vec<Node> {
+        let mut nodes = Vec::new();
+
+        let md = markdown::to_mdast(&self.message, &ParseOptions::default()).expect("markdown");
+
+        if let Node::Root(root) = md {
+            nodes.extend(root.children);
+        }
+
+        if let Some(Node::Paragraph(paragraph)) = nodes.first_mut() {
+            if let Some((label, url)) = self.url {
+                if let Some(Node::Text(text)) = paragraph.children.last_mut() {
+                    text.value.push_str(" (");
+                } else {
+                    paragraph.children.push(Node::Text(markdown::mdast::Text {
+                        value: String::from(" ("),
+                        position: None,
+                    }));
+                }
+
+                paragraph.children.push(Node::Link(markdown::mdast::Link {
+                    children: vec![Node::Text(markdown::mdast::Text {
+                        value: label,
+                        position: None,
+                    })],
+                    position: None,
+                    url,
+                    title: None,
+                }));
+
+                paragraph.children.push(Node::Text(markdown::mdast::Text {
+                    value: String::from(")"),
+                    position: None,
+                }));
+            }
+        }
+
+        nodes
+    }
+}
+
+impl Display for Change {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "- {}", self.message)?;
+
+        if let Some((label, url)) = &self.url {
+            if f.alternate() {
+                write!(f, " ({label})")?;
+            } else {
+                write!(f, " ([{label}]({url}))")?;
+            }
+        }
+
+        Ok(())
+    }
+}
 
 /// A single change in a changelog.
 #[derive(Clone, Debug)]
@@ -45,5 +144,28 @@ impl<'a> Display for ChangeRef<'a> {
         } else {
             write!(f, "- {}", self.text)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::Change;
+
+    #[test]
+    fn test_change() {
+        let change = Change::new("Changed `something`")
+            .with_url("#1", "https://github.com/ploys/example/pull/1");
+
+        assert_eq!(change.message(), "Changed `something`");
+        assert_eq!(
+            change.url(),
+            Some(("#1", "https://github.com/ploys/example/pull/1"))
+        );
+        assert_eq!(
+            change.to_string(),
+            "- Changed `something` ([#1](https://github.com/ploys/example/pull/1))"
+        );
     }
 }

--- a/packages/ploys/src/changelog/changeset.rs
+++ b/packages/ploys/src/changelog/changeset.rs
@@ -1,8 +1,182 @@
 use std::fmt::{self, Display};
 
 use markdown::mdast::Node;
+use markdown::ParseOptions;
 
-use super::{ChangeRef, MultilineText};
+use super::{Change, ChangeRef, MultilineText};
+
+/// A changelog changeset.
+#[derive(Clone, Debug)]
+pub struct Changeset {
+    label: String,
+    description: Option<String>,
+    changes: Vec<Change>,
+}
+
+impl Changeset {
+    /// Constructs a new changeset.
+    pub fn new(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            description: None,
+            changes: Vec::new(),
+        }
+    }
+
+    /// Constructs a new `Added` changeset.
+    pub fn added() -> Self {
+        Self::new("Added")
+    }
+
+    /// Constructs a new `Changed` changeset.
+    pub fn changed() -> Self {
+        Self::new("Changed")
+    }
+
+    /// Constructs a new `Deprecated` changeset.
+    pub fn deprecated() -> Self {
+        Self::new("Deprecated")
+    }
+
+    /// Constructs a new `Removed` changeset.
+    pub fn removed() -> Self {
+        Self::new("Removed")
+    }
+
+    /// Constructs a new `Fixed` changeset.
+    pub fn fixed() -> Self {
+        Self::new("Fixed")
+    }
+
+    /// Constructs a new `Security` changeset.
+    pub fn security() -> Self {
+        Self::new("Security")
+    }
+
+    /// Gets the changeset label.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Gets the changeset description.
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    /// Sets the changeset description.
+    pub fn set_description(&mut self, description: impl Into<String>) -> &mut Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Builds the changeset with the given description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.set_description(description);
+        self
+    }
+
+    /// Adds a change to the changeset.
+    pub fn add_change(&mut self, change: impl Into<Change>) -> &mut Self {
+        self.changes.push(change.into());
+        self
+    }
+
+    /// Builds the changeset with the given change.
+    pub fn with_change(mut self, change: impl Into<Change>) -> Self {
+        self.add_change(change);
+        self
+    }
+
+    /// Gets an iterator over the changes.
+    pub fn changes(&self) -> impl Iterator<Item = &Change> {
+        self.changes.iter()
+    }
+}
+
+impl Changeset {
+    /// Converts the changeset into markdown nodes.
+    pub(super) fn into_nodes(self) -> Vec<Node> {
+        let mut nodes = Vec::new();
+
+        let heading = Node::Heading(markdown::mdast::Heading {
+            children: vec![Node::Text(markdown::mdast::Text {
+                value: self.label,
+                position: None,
+            })],
+            position: None,
+            depth: 3,
+        });
+
+        nodes.push(heading);
+
+        if let Some(description) = self.description {
+            let md = markdown::to_mdast(&description, &ParseOptions::default()).expect("markdown");
+
+            if let Node::Root(root) = md {
+                nodes.extend(root.children);
+            }
+        }
+
+        if !self.changes.is_empty() {
+            let list = Node::List(markdown::mdast::List {
+                children: self
+                    .changes
+                    .into_iter()
+                    .map(|change| {
+                        Node::ListItem(markdown::mdast::ListItem {
+                            children: change.into_nodes(),
+                            position: None,
+                            spread: false,
+                            checked: None,
+                        })
+                    })
+                    .collect(),
+                position: None,
+                ordered: false,
+                start: None,
+                spread: false,
+            });
+
+            nodes.push(list);
+        }
+
+        nodes
+    }
+}
+
+impl Display for Changeset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "### {}", self.label())?;
+
+        if let Some(description) = self.description() {
+            if f.alternate() {
+                write!(f, "\n\n{description:#}")?;
+            } else {
+                write!(f, "\n\n{description}")?;
+            }
+        }
+
+        let mut changes = self.changes().peekable();
+
+        if changes.peek().is_some() {
+            write!(f, "\n\n")?;
+
+            while let Some(change) = changes.next() {
+                if f.alternate() {
+                    write!(f, "{change:#}")?;
+                } else {
+                    write!(f, "{change}")?;
+                }
+
+                if changes.peek().is_some() {
+                    writeln!(f)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
 
 /// A changelog release labelled changeset.
 #[derive(Clone, Debug)]
@@ -93,5 +267,42 @@ impl<'a> Display for ChangesetRef<'a> {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use crate::changelog::Change;
+
+    use super::Changeset;
+
+    #[test]
+    fn test_changeset() {
+        let changeset = Changeset::fixed()
+            .with_description("Fixed some things.")
+            .with_change(
+                Change::new("Fixed `one`")
+                    .with_url("#1", "https://github.com/ploys/example/pull/1"),
+            )
+            .with_change(
+                Change::new("Fixed `two`")
+                    .with_url("#2", "https://github.com/ploys/example/pull/2"),
+            );
+
+        let output = indoc! {"
+            ### Fixed
+
+            Fixed some things.
+
+            - Fixed `one` ([#1](https://github.com/ploys/example/pull/1))
+            - Fixed `two` ([#2](https://github.com/ploys/example/pull/2))\
+        "};
+
+        assert_eq!(changeset.description(), Some("Fixed some things."));
+        assert_eq!(changeset.changes().count(), 2);
+        assert_eq!(changeset.to_string(), output);
     }
 }

--- a/packages/ploys/src/changelog/mod.rs
+++ b/packages/ploys/src/changelog/mod.rs
@@ -11,10 +11,10 @@ use std::str::FromStr;
 use markdown::mdast::{Node, Root};
 use markdown::ParseOptions;
 
-pub use self::change::ChangeRef;
-pub use self::changeset::ChangesetRef;
+pub use self::change::{Change, ChangeRef};
+pub use self::changeset::{Changeset, ChangesetRef};
 pub use self::reference::ReferenceRef;
-pub use self::release::ReleaseRef;
+pub use self::release::{Release, ReleaseRef};
 pub use self::text::{MultilineText, Text};
 
 /// Represents a changelog file.
@@ -26,6 +26,11 @@ pub use self::text::{MultilineText, Text};
 pub struct Changelog(Node);
 
 impl Changelog {
+    /// Constructs a new changelog.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Gets the changelog title.
     pub fn title(&self) -> Option<Text<'_>> {
         self.0
@@ -46,6 +51,27 @@ impl Changelog {
                 Some(Node::Heading(heading)) if heading.depth == 2 => None,
                 _ => MultilineText::from_nodes(nodes),
             })
+    }
+
+    /// Adds a new release to the changelog.
+    pub fn add_release(&mut self, release: impl Into<Release>) -> &mut Self {
+        let release = release.into();
+        let version = release.version().to_owned();
+        let url = release.url().map(ToOwned::to_owned);
+
+        self.add_release_section(release);
+
+        if let Some(url) = url {
+            self.add_release_reference(version, url);
+        }
+
+        self
+    }
+
+    /// Builds the changelog with the given release.
+    pub fn with_release(mut self, release: impl Into<Release>) -> Self {
+        self.add_release(release);
+        self
     }
 
     /// Gets a release for the given version.
@@ -75,12 +101,106 @@ impl Changelog {
             nodes.chunk_by(|_, node| !matches!(node, Node::Heading(heading) if heading.depth == 2))
         })
     }
+
+    /// Adds a release section.
+    fn add_release_section(&mut self, release: Release) {
+        let nodes = self.0.children_mut().expect("children");
+        let index = nodes
+            .iter()
+            .position(|node| matches!(node, Node::Heading(heading) if heading.depth == 2))
+            .unwrap_or(nodes.len());
+
+        let _ = nodes
+            .splice(index..index, release.into_nodes())
+            .collect::<Vec<_>>();
+    }
+
+    /// Adds a release reference.
+    fn add_release_reference(&mut self, version: String, url: String) {
+        let nodes = self.0.children_mut().expect("children");
+        let mut position = None;
+
+        for (index, node) in nodes.iter().enumerate().rev() {
+            match node {
+                Node::Definition(_) => {
+                    position = Some(index);
+                }
+                _ => break,
+            }
+        }
+
+        let position = position.unwrap_or(nodes.len());
+
+        nodes.insert(
+            position,
+            Node::Definition(markdown::mdast::Definition {
+                position: None,
+                url,
+                title: None,
+                identifier: version,
+                label: None,
+            }),
+        );
+    }
 }
 
 impl Default for Changelog {
     fn default() -> Self {
         Self(Node::Root(Root {
-            children: Vec::new(),
+            children: vec![
+                Node::Heading(markdown::mdast::Heading {
+                    children: vec![Node::Text(markdown::mdast::Text {
+                        value: String::from("Changelog"),
+                        position: None,
+                    })],
+                    position: None,
+                    depth: 1,
+                }),
+                Node::Paragraph(markdown::mdast::Paragraph {
+                    children: vec![Node::Text(markdown::mdast::Text {
+                        value: String::from(
+                            "All notable changes to this package will be documented in this file.",
+                        ),
+                        position: None,
+                    })],
+                    position: None,
+                }),
+                Node::Paragraph(markdown::mdast::Paragraph {
+                    children: vec![
+                        Node::Text(markdown::mdast::Text {
+                            value: String::from("The format is based on "),
+                            position: None,
+                        }),
+                        Node::Link(markdown::mdast::Link {
+                            children: vec![Node::Text(markdown::mdast::Text {
+                                value: String::from("Keep a Changelog"),
+                                position: None,
+                            })],
+                            position: None,
+                            url: String::from("https://keepachangelog.com/en/1.1.0/"),
+                            title: None,
+                        }),
+                        Node::Text(markdown::mdast::Text {
+                            value: String::from(",\nand this project adheres to "),
+                            position: None,
+                        }),
+                        Node::Link(markdown::mdast::Link {
+                            children: vec![Node::Text(markdown::mdast::Text {
+                                value: String::from("Semantic Versioning"),
+                                position: None,
+                            })],
+                            position: None,
+                            url: String::from("https://semver.org/spec/v2.0.0.html"),
+                            title: None,
+                        }),
+                        Node::Text(markdown::mdast::Text {
+                            value: String::from("."),
+                            position: None,
+                        }),
+                    ],
+                    position: None,
+                }),
+            ],
             position: None,
         }))
     }
@@ -145,7 +265,7 @@ mod tests {
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
-    use super::Changelog;
+    use super::{Change, Changelog, Changeset, Release};
 
     #[test]
     fn test_changelog_parser() {
@@ -300,5 +420,60 @@ mod tests {
         assert_eq!(c2.url(), Some("https://github.com/ploys/example/pull/8"));
 
         assert_eq!(changelog.to_string(), changelog_text);
+    }
+
+    #[test]
+    fn test_changelog_builder() {
+        let changelog = Changelog::new()
+            .with_release(
+                Release::new("0.1.0")
+                    .with_date("2024-01-01")
+                    .with_description("This is the initial release.")
+                    .with_url("https://github.com/ploys/example/releases/tag/0.1.0"),
+            )
+            .with_release(
+                Release::new("0.2.0")
+                    .with_date("2024-01-02")
+                    .with_changeset(
+                        Changeset::fixed()
+                            .with_description("Fixed a few things.")
+                            .with_change(
+                                Change::new("Fixed one")
+                                    .with_url("#1", "https://github.com/ploys/example/pull/1"),
+                            )
+                            .with_change(
+                                Change::new("Fixed `two`")
+                                    .with_url("#2", "https://github.com/ploys/example/pull/2"),
+                            ),
+                    )
+                    .with_url("https://github.com/ploys/example/releases/tag/0.2.0"),
+            );
+
+        let output = indoc! {"
+            # Changelog
+
+            All notable changes to this package will be documented in this file.
+
+            The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+            and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+            ## [0.2.0] - 2024-01-02
+
+            ### Fixed
+
+            Fixed a few things.
+
+            - Fixed one ([#1](https://github.com/ploys/example/pull/1))
+            - Fixed `two` ([#2](https://github.com/ploys/example/pull/2))
+
+            ## [0.1.0] - 2024-01-01
+
+            This is the initial release.
+
+            [0.2.0]: https://github.com/ploys/example/releases/tag/0.2.0
+            [0.1.0]: https://github.com/ploys/example/releases/tag/0.1.0
+        "};
+
+        assert_eq!(changelog.to_string(), output);
     }
 }


### PR DESCRIPTION
Closes #84.

This extends the work in #87 to add the ability to build a changelog adhering to the [keep a changelog](https://keepachangelog.com/) format. This only includes support for additive changes to a new or existing changelog and does not support altering existing sections. This should be sufficient to build changelogs as part of the release flow.