### PR TITLE
Add ability to commit additional files

### DIFF
--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -114,7 +114,7 @@ pub async fn create_release_pull_request(
     };
 
     project.set_package_version(&package, version.clone())?;
-    project.commit(&message)?;
+    project.commit(&message, None)?;
 
     let issue_number = client
         .post(format!(

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -459,12 +459,19 @@ impl Project<self::source::git::Git> {
 #[cfg(feature = "git")]
 impl Project<self::source::git::Git> {
     /// Commits the changes to the repository.
-    pub fn commit(&mut self, message: impl AsRef<str>) -> Result<String, Error> {
+    ///
+    /// This method takes a message and collection of files to include with the
+    /// commit.
+    pub fn commit(
+        &mut self,
+        message: impl AsRef<str>,
+        files: impl IntoIterator<Item = (std::path::PathBuf, String)>,
+    ) -> Result<String, Error> {
         use self::source::revision::{Reference, Revision};
 
         self.upgrade()?;
 
-        let files = self.get_changed_files();
+        let files = self.get_changed_files().chain(files);
         let sha = self.source.commit(message, files)?;
 
         if !matches!(
@@ -525,10 +532,17 @@ impl Project<self::source::git::Git> {
 #[cfg(feature = "github")]
 impl Project<self::source::github::GitHub> {
     /// Commits the changes to the repository.
-    pub fn commit(&mut self, message: impl AsRef<str>) -> Result<String, Error> {
+    ///
+    /// This method takes a message and collection of files to include with the
+    /// commit.
+    pub fn commit(
+        &mut self,
+        message: impl AsRef<str>,
+        files: impl IntoIterator<Item = (std::path::PathBuf, String)>,
+    ) -> Result<String, Error> {
         use self::source::revision::{Reference, Revision};
 
-        let files = self.get_changed_files();
+        let files = self.get_changed_files().chain(files);
         let sha = self.source.commit(message, files)?;
 
         if !matches!(


### PR DESCRIPTION
This updates the project `commit` methods with a new `files` parameter to commit additional files.

The `Git` and `GitHub` project types have a `commit` method to commit in-memory changes back to the repository. However, the project has no knowledge of other files such as the `CHANGELOG.md` file for release notes. This means that a second commit would be required to update any additional files.

This change adds a new parameter so that it is possible to pass new or updated files to the same commit. This allows the release process to update the changelog without a second commit. The implementation does not perform any deduplication of files so including the file multiple times or overwriting a changed package manifest may produce unexpected results.