### PR TITLE
Fix changelog generation for release with no commits

### DIFF
--- a/packages/ploys/src/project/source/github/pull_request.rs
+++ b/packages/ploys/src/project/source/github/pull_request.rs
@@ -173,7 +173,7 @@ fn all(repository: &Repository, token: Option<&str>) -> Result<Vec<PullRequest>,
         }
 
         if commits.page_info.has_next_page {
-            cursor = Some(commits.page_info.end_cursor);
+            cursor = commits.page_info.end_cursor;
 
             continue;
         }
@@ -263,7 +263,7 @@ fn until(
         }
 
         if commits.page_info.has_next_page {
-            cursor = Some(commits.page_info.end_cursor);
+            cursor = commits.page_info.end_cursor;
 
             continue;
         }
@@ -347,7 +347,7 @@ fn between(
         }
 
         if commits.page_info.has_next_page {
-            cursor = Some(commits.page_info.end_cursor);
+            cursor = commits.page_info.end_cursor;
 
             continue;
         }
@@ -466,7 +466,7 @@ struct ResponseCommits {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ResponsePageInfo {
-    end_cursor: String,
+    end_cursor: Option<String>,
     has_next_page: bool,
 }
 


### PR DESCRIPTION
This fixes a deserialization issue where the GraphQL response for finding pull requests returns no end cursor due to no changes in a release.

Although an unlikely scenario, in real world projects it is possible for a release to contain no changes since the previous release. The implementation of the release generation searches for pull requests associated with commits using the GitHub GraphQL API and supports pagination using cursors. However, the deserialization does not support a null end cursor when there are no items in the response.

This simply alters the logic to use an `Option` for the `end_cursor` field which somewhat simplifies the code by avoiding the need to manually wrap a `Some` around the returned cursor.