### PR TITLE
Add changelog release generator date and URL

### DIFF
--- a/packages/ploys/src/project/source/github/mod.rs
+++ b/packages/ploys/src/project/source/github/mod.rs
@@ -3,8 +3,8 @@
 //! This module contains the utilities related to remote GitHub project
 //! management.
 
+mod changelog;
 mod error;
-mod pull_request;
 mod repo;
 
 use std::io;
@@ -14,7 +14,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::changelog::{Change, Changeset, Release};
+use crate::changelog::Release;
 
 pub use self::error::Error;
 pub use self::repo::Repository;
@@ -280,47 +280,13 @@ impl GitHub {
         version: Version,
         is_primary: bool,
     ) -> Result<Release, Error> {
-        let pull_requests = self::pull_request::get_pull_requests(
+        self::changelog::get_release(
             &self.repository,
             package,
             &version,
             is_primary,
             self.token.as_deref(),
-        )?;
-
-        let package_label = format!("package: {package}");
-        let pull_requests = pull_requests
-            .into_iter()
-            .filter(|pull_request| {
-                pull_request
-                    .labels
-                    .nodes
-                    .iter()
-                    .any(|label| label.name == package_label)
-            })
-            .filter(|pull_request| {
-                !pull_request
-                    .labels
-                    .nodes
-                    .iter()
-                    .any(|label| label.name.contains("release"))
-            });
-
-        let mut release = Release::new(version.to_string());
-        let mut changeset = Changeset::changed();
-
-        for pull_request in pull_requests {
-            changeset.add_change(
-                Change::new(pull_request.title)
-                    .with_url(format!("#{}", pull_request.number), pull_request.permalink),
-            );
-        }
-
-        if changeset.changes().count() > 0 {
-            release.add_changeset(changeset);
-        }
-
-        Ok(release)
+        )
     }
 }
 


### PR DESCRIPTION
This updates the changelog release generator to include the release date and URL.

The initial implementation of the changelog release generator in #90 only included the title and changes but not the additional options such as date and URL. The date is a standard part of the [keep a changelog](http://keepachangelog.com) format and the URL is used by the full changelog as a footer reference.

This change is deceptively large as it includes a number of refactorings to get the release date without querying the release itself. The release date is obtained from the commit date or the current date if the release is new. It does so by using the GraphQL API to get the tags as, unlike the REST API, it is possible to return the date in the same response. This means for a small project it is possible to get everything it needs to build the release notes in 2 requests.

Unfortunately, the GraphQL API does not support more refined searches under specific tag prefixes so for a large project this could ultimately require more requests as it needs to load every tag in batches of 100. However, the previous implementation would still need to load all tags for the primary package in a single request in addition to finding the current version in a separate request so it should still be an improvement.

The commit date should be suitable here as the release will be automatically generated for the release commit. However, it may be better to actually query the release in case some time has passed between commit and release creation. For example, after waiting for a long-running GitHub Actions workflow to complete before creating the release.

The logic for generating the release has moved into the `changelog` module which was previously the `pull_request` module and the type visibility has been adjusted accordingly.