### PR TITLE
Add initial package changelogs

### DIFF
--- a/packages/ploys-api/CHANGELOG.md
+++ b/packages/ploys-api/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-10-14
+
+### Changed
+
+- Add shuttle application boilerplate ([#24](https://github.com/ploys/ploys/pull/24))
+- Bump shuttle-runtime to 0.45.0 and axum to 0.7.5 ([#29](https://github.com/ploys/ploys/pull/29))
+- Add GitHub webhook endpoint ([#30](https://github.com/ploys/ploys/pull/30))
+- Bump shuttle-runtime to 0.47.0 ([#32](https://github.com/ploys/ploys/pull/32))
+- Add GitHub webhook endpoint secret validation ([#33](https://github.com/ploys/ploys/pull/33))
+- Add automated release pull request creation ([#58](https://github.com/ploys/ploys/pull/58))
+- Add automated release creation ([#64](https://github.com/ploys/ploys/pull/64))
+- Bump `shuttle-runtime` to `0.48.0` ([#68](https://github.com/ploys/ploys/pull/68))
+- Add release workflow with deploy job ([#69](https://github.com/ploys/ploys/pull/69))
+
+[0.1.0]: https://github.com/ploys/ploys/releases/tag/ploys-api-0.1.0

--- a/packages/ploys-cli/CHANGELOG.md
+++ b/packages/ploys-cli/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-10-16
+
+### Changed
+
+- Add command line application boilerplate ([#1](https://github.com/ploys/ploys/pull/1))
+- Add inspect command ([#2](https://github.com/ploys/ploys/pull/2))
+- Add support for inspecting remote repositories ([#3](https://github.com/ploys/ploys/pull/3))
+- Add inspect command authentication token option ([#4](https://github.com/ploys/ploys/pull/4))
+- Refactor inspect command to use library utility ([#6](https://github.com/ploys/ploys/pull/6))
+- Add inspect command discovered packages output ([#11](https://github.com/ploys/ploys/pull/11))
+- Rename inspect command to project info ([#14](https://github.com/ploys/ploys/pull/14))
+- Add release command ([#47](https://github.com/ploys/ploys/pull/47))
+- Add `project info` command git revision arguments ([#54](https://github.com/ploys/ploys/pull/54))
+- Add CI test target `aarch64-apple-darwin` ([#77](https://github.com/ploys/ploys/pull/77))
+- Add release workflow build job ([#78](https://github.com/ploys/ploys/pull/78))
+- Add release workflow publish for `ploys-cli` package ([#79](https://github.com/ploys/ploys/pull/79))
+- Set `ploys` dependency version ([#80](https://github.com/ploys/ploys/pull/80))
+
+[0.1.0]: https://github.com/ploys/ploys/releases/tag/ploys-cli-0.1.0

--- a/packages/ploys/CHANGELOG.md
+++ b/packages/ploys/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-10-15
+
+### Changed
+
+- Add utility to load basic project information ([#5](https://github.com/ploys/ploys/pull/5))
+- Combine local project Git error variants ([#7](https://github.com/ploys/ploys/pull/7))
+- Add method to query project files ([#8](https://github.com/ploys/ploys/pull/8))
+- Add method to get project file content ([#9](https://github.com/ploys/ploys/pull/9))
+- Add package discovery ([#10](https://github.com/ploys/ploys/pull/10))
+- Remove project name readme lookup ([#12](https://github.com/ploys/ploys/pull/12))
+- Rename local and remote project variants ([#13](https://github.com/ploys/ploys/pull/13))
+- Add generic project source ([#15](https://github.com/ploys/ploys/pull/15))
+- Use toml_edit crate to preserve formatting ([#16](https://github.com/ploys/ploys/pull/16))
+- Add package bump method ([#17](https://github.com/ploys/ploys/pull/17))
+- Add project package cache ([#18](https://github.com/ploys/ploys/pull/18))
+- Add project name cache ([#19](https://github.com/ploys/ploys/pull/19))
+- Add project package bump method ([#20](https://github.com/ploys/ploys/pull/20))
+- Move package discovery from project source ([#21](https://github.com/ploys/ploys/pull/21))
+- Add initial lockfile support ([#22](https://github.com/ploys/ploys/pull/22))
+- Refactor inconsistent error naming ([#23](https://github.com/ploys/ploys/pull/23))
+- Add debug implementation for cargo dependencies ([#26](https://github.com/ploys/ploys/pull/26))
+- Bump toml_edit to 0.22.14 ([#27](https://github.com/ploys/ploys/pull/27))
+- Bump gix to 0.63.0 ([#28](https://github.com/ploys/ploys/pull/28))
+- Bump gix to 0.66.0 ([#31](https://github.com/ploys/ploys/pull/31))
+- Add ability to load GitHub project at a specific commit ([#34](https://github.com/ploys/ploys/pull/34))
+- Add `git2` integration ([#44](https://github.com/ploys/ploys/pull/44))
+- Add project source feature flags ([#45](https://github.com/ploys/ploys/pull/45))
+- Add project package release methods ([#46](https://github.com/ploys/ploys/pull/46))
+- Add method to get project file changes ([#49](https://github.com/ploys/ploys/pull/49))
+- Add ability to load Git project at a specific commit ([#50](https://github.com/ploys/ploys/pull/50))
+- Change project reference from commit to branch on release ([#51](https://github.com/ploys/ploys/pull/51))
+- Change git source to create branch on current reference ([#52](https://github.com/ploys/ploys/pull/52))
+- Unify project source `Reference` types as `Revision` ([#53](https://github.com/ploys/ploys/pull/53))
+- Add project commit methods ([#57](https://github.com/ploys/ploys/pull/57))
+- Add release workflow publish job ([#73](https://github.com/ploys/ploys/pull/73))
+
+[0.1.0]: https://github.com/ploys/ploys/releases/tag/0.1.0


### PR DESCRIPTION
This manually adds the initial package changelogs generated by the project for the initial release that predates support for generating changelogs.

This is in preparation for the `0.2.0` release of the `ploys` and `ploys-api` packages to provide a linear commit history of changes starting with the first release.