### PR TITLE
Revert "Release `0.2.0` (#101)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,7 +2723,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "ploys"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "auth-git2",
  "git2",

--- a/packages/ploys-api/Cargo.toml
+++ b/packages/ploys-api/Cargo.toml
@@ -29,7 +29,7 @@ tokio = { version = "1.33.0", features = ["rt", "macros"] }
 tower-service = "0.3.3"
 
 [dependencies.ploys]
-version = "0.2.0"
+version = "0.1.0"
 path = "../ploys"
 features = ["github"]
 default-features = false

--- a/packages/ploys-cli/Cargo.toml
+++ b/packages/ploys-cli/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 anyhow = "1.0.72"
 clap = { version = "4.3.21", features = ["derive", "env"] }
 console = "0.15.7"
-ploys = { version = "0.2.0", path = "../ploys" }
+ploys = { version = "0.1.0", path = "../ploys" }
 url = "2.4.0"
 
 [dev-dependencies]

--- a/packages/ploys/CHANGELOG.md
+++ b/packages/ploys/CHANGELOG.md
@@ -5,20 +5,6 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2024-10-24
-
-### Changed
-
-- Add CI test target `aarch64-apple-darwin` ([#77](https://github.com/ploys/ploys/pull/77))
-- Add support for package dependencies ([#82](https://github.com/ploys/ploys/pull/82))
-- Add changelog parser ([#87](https://github.com/ploys/ploys/pull/87))
-- Add changelog builder ([#88](https://github.com/ploys/ploys/pull/88))
-- Add changelog release generator ([#90](https://github.com/ploys/ploys/pull/90))
-- Add ability to commit additional files ([#92](https://github.com/ploys/ploys/pull/92))
-- Fix changelog generation for release with no commits ([#93](https://github.com/ploys/ploys/pull/93))
-- Add changelog release generator date and URL ([#94](https://github.com/ploys/ploys/pull/94))
-- Add initial package changelogs ([#99](https://github.com/ploys/ploys/pull/99))
-
 ## [0.1.0] - 2024-10-15
 
 ### Changed
@@ -55,5 +41,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add project commit methods ([#57](https://github.com/ploys/ploys/pull/57))
 - Add release workflow publish job ([#73](https://github.com/ploys/ploys/pull/73))
 
-[0.2.0]: https://github.com/ploys/ploys/releases/tag/0.2.0
 [0.1.0]: https://github.com/ploys/ploys/releases/tag/0.1.0

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ploys"
-version = "0.2.0"
+version = "0.1.0"
 description = "A utility to manage projects, packages, releases and deployments."
 authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
 homepage = "https://ploys.dev"


### PR DESCRIPTION
Reverts #101.

The release failed to publish so `0.2.0` was not officially released. This revert is somewhat of an experiment for handling releases that fail.