### PR TITLE
Fix missing `time` crate `parsing` and `formatting` features

### DIFF
--- a/packages/ploys-api/Cargo.toml
+++ b/packages/ploys-api/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0.117"
 sha2 = "0.10.8"
 shuttle-axum = "0.48.0"
 shuttle-runtime = "0.48.0"
-time = { version = "0.3.36", features = ["serde"] }
+time = { version = "0.3.36", features = ["serde", "formatting", "parsing"] }
 tokio = { version = "1.33.0", features = ["rt", "macros"] }
 tower-service = "0.3.3"
 

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -19,7 +19,7 @@ globset = "0.4.13"
 markdown = "=1.0.0-alpha.21"
 semver = "1.0.19"
 serde = { version = "1.0.185", features = ["derive"] }
-time = { version = "0.3.36", features = ["serde", "formatting"] }
+time = { version = "0.3.36", features = ["serde", "formatting", "parsing"] }
 toml_edit = { version = "0.22.14", features = ["serde"] }
 ureq = { version = "2.7.1", features = ["json"], optional = true }
 url = "2.4.0"


### PR DESCRIPTION
This fixes the missing `formatting` and `parsing` features of the `time` crate.

This issue caused the latest release to fail and was entirely user error. The `time` crate uses the `formatting` feature for serialization and `parsing` feature for deserialization. The [documentation](https://docs.rs/time/0.3.36/time/serde/iso8601/index.html) says that the type is available for either of those features but the wrong feature was chosen for the usage.

This did not show in the continuous integration environment because the feature was indirectly enabled via the `jsonwebtoken` dependency of `ploys-api` and both were built together. The publish command only built the `ploys` package and it failed.

The change simply enables both to avoid the situation again although `ploys` only requires `parsing` and `ploys-api` only requires `formatting` at this time.