### PR TITLE
Add package release `repository_dispatch` event handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.10.0",
 ]
 
 [[package]]
@@ -616,6 +616,41 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2109,6 +2144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,6 +2177,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2146,6 +2188,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]
@@ -2756,6 +2799,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_with",
  "sha2",
  "shuttle-axum",
  "shuttle-runtime",
@@ -3406,6 +3450,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3688,6 +3762,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"

--- a/packages/ploys-api/Cargo.toml
+++ b/packages/ploys-api/Cargo.toml
@@ -21,6 +21,7 @@ reqwest = { version = "0.12.8", features = ["json"] }
 semver = "1.0.19"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.117"
+serde_with = "3.11.0"
 sha2 = "0.10.8"
 shuttle-axum = "0.48.0"
 shuttle-runtime = "0.48.0"

--- a/packages/ploys-api/src/github/webhook/error.rs
+++ b/packages/ploys-api/src/github/webhook/error.rs
@@ -13,6 +13,7 @@ pub enum Error {
     Request(reqwest::Error),
     Project(ploys::project::Error),
     Utf8(FromUtf8Error),
+    Json(serde_json::Error),
 }
 
 impl Error {
@@ -23,6 +24,7 @@ impl Error {
             Self::Request(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Project(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Utf8(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Json(_) => StatusCode::UNPROCESSABLE_ENTITY,
         }
     }
 
@@ -33,6 +35,7 @@ impl Error {
             Self::Request(error) => Cow::Owned(format!("Request: {error}")),
             Self::Project(error) => Cow::Owned(format!("Project: {error}")),
             Self::Utf8(error) => Cow::Owned(format!("UTF-8: {error}")),
+            Self::Json(error) => Cow::Owned(format!("JSON: {error}")),
         }
     }
 }
@@ -51,6 +54,7 @@ impl std::error::Error for Error {
             Self::Request(err) => Some(err),
             Self::Project(err) => Some(err),
             Self::Utf8(err) => Some(err),
+            Self::Json(err) => Some(err),
         }
     }
 }
@@ -82,5 +86,11 @@ impl From<ploys::project::Error> for Error {
 impl From<FromUtf8Error> for Error {
     fn from(error: FromUtf8Error) -> Self {
         Self::Utf8(error)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
     }
 }

--- a/packages/ploys-api/src/github/webhook/payload.rs
+++ b/packages/ploys-api/src/github/webhook/payload.rs
@@ -23,6 +23,7 @@ use super::secret::WebhookSecret;
 pub enum Payload {
     Create(CreatePayload),
     PullRequest(PullRequestPayload),
+    RepositoryDispatch(RepositoryDispatchPayload),
     Other(String, Value),
 }
 
@@ -65,6 +66,7 @@ where
         Ok(match event.as_str() {
             "create" => Self::Create(serde_json::from_slice(&bytes)?),
             "pull_request" => Self::PullRequest(serde_json::from_slice(&bytes)?),
+            "repository_dispatch" => Self::RepositoryDispatch(serde_json::from_slice(&bytes)?),
             _ => Self::Other(event, serde_json::from_slice(&bytes)?),
         })
     }
@@ -85,6 +87,16 @@ pub struct CreatePayload {
 pub struct PullRequestPayload {
     pub action: String,
     pub pull_request: PullRequest,
+    pub repository: Repository,
+    pub installation: Installation,
+}
+
+/// The `repository_dispatch` webhook payload.
+#[derive(Debug, Deserialize)]
+pub struct RepositoryDispatchPayload {
+    pub action: String,
+    pub branch: String,
+    pub client_payload: Value,
     pub repository: Repository,
     pub installation: Installation,
 }


### PR DESCRIPTION
This adds a new `repository_dispatch` event handler for the `ploys-package-release-initiate` event.

The current release workflow for a package involves creating a new release branch from the CLI, either via the local git repository or via the GitHub API. However, supporting two similar APIs can cause extra work and some functionality has already been split between the different implementations. The goal is to reduce this complexity by focusing on the GitHub API.

This is the first step of implementing #107 to add a new webhook event handler that uses the GitHub API to send messages to the GitHub App as an authenticated user. Changes to the library and CLI will be added in follow-up PRs.

This change only includes the changes necessary for the GitHub App to receive the event and create the release branch. To avoid long running requests it does not do any further work and simply delegates to the branch creation event handler. In the future this can be consolidated into a single process. It does not support parallel release branches and instead uses the default branch supplied by the webhook payload.