### PR TITLE
Add project `initiate_package_release` method

### DIFF
--- a/packages/ploys/src/package/bump.rs
+++ b/packages/ploys/src/package/bump.rs
@@ -166,6 +166,15 @@ pub enum BumpOrVersion {
     Version(Version),
 }
 
+impl Display for BumpOrVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Bump(bump) => Display::fmt(bump, f),
+            Self::Version(version) => Display::fmt(version, f),
+        }
+    }
+}
+
 impl FromStr for BumpOrVersion {
     type Err = Error;
 

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -597,6 +597,21 @@ impl Project<self::source::github::GitHub> {
         Ok(())
     }
 
+    /// Initiates the release of the specified package version.
+    ///
+    /// It does not yet support parallel release or hotfix branches and expects
+    /// all development to be on the default branch in the repository settings.
+    pub fn initiate_package_release(
+        &self,
+        package: impl AsRef<str>,
+        version: impl Into<crate::package::BumpOrVersion>,
+    ) -> Result<(), Error> {
+        self.source
+            .initiate_package_release(package.as_ref(), version.into())?;
+
+        Ok(())
+    }
+
     /// Gets the changelog release for the given package version.
     ///
     /// This method queries the GitHub API to generate new release information


### PR DESCRIPTION
This adds a new `initiate_package_release` method to GitHub projects that sends a `ploys-package-release-initiate` repository dispatch event.

This new method is intended to replace the existing `release_package` method and only supports the GitHub project. This is the second step of #107 which adds support for creating the event from the library. The next step is using this in the CLI.