### PR TITLE
Add `package release` command

### DIFF
--- a/packages/ploys-cli/src/main.rs
+++ b/packages/ploys-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod package;
 mod project;
 mod release;
 mod util;
@@ -5,6 +6,7 @@ mod util;
 use anyhow::Error;
 use clap::{Parser, Subcommand};
 
+use self::package::Package;
 use self::project::Project;
 use self::release::Release;
 
@@ -21,6 +23,7 @@ impl Args {
     fn exec(self) -> Result<(), Error> {
         match self.command {
             Command::Project(project) => project.exec(),
+            Command::Package(package) => package.exec(),
             Command::Release(release) => release.exec(),
         }
     }
@@ -31,6 +34,8 @@ impl Args {
 enum Command {
     /// Manages the project.
     Project(Project),
+    /// Manages the packages.
+    Package(Package),
     /// Manages releases.
     Release(Release),
 }

--- a/packages/ploys-cli/src/package/mod.rs
+++ b/packages/ploys-cli/src/package/mod.rs
@@ -1,0 +1,29 @@
+mod release;
+
+use anyhow::Error;
+use clap::{Args, Subcommand};
+
+use self::release::Release;
+
+/// The package command.
+#[derive(Args)]
+pub struct Package {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+impl Package {
+    /// Executes the package command.
+    pub fn exec(self) -> Result<(), Error> {
+        match self.command {
+            Command::Release(release) => release.exec(),
+        }
+    }
+}
+
+/// The inner package command.
+#[derive(Subcommand)]
+enum Command {
+    /// Creates a new release.
+    Release(Release),
+}

--- a/packages/ploys-cli/src/package/release.rs
+++ b/packages/ploys-cli/src/package/release.rs
@@ -1,0 +1,49 @@
+use anyhow::Error;
+use clap::Args;
+use ploys::package::BumpOrVersion;
+use ploys::project::source::github::GitHub;
+use ploys::project::Project;
+
+use crate::util::repo_or_url::RepoOrUrl;
+
+/// The release command.
+#[derive(Args)]
+pub struct Release {
+    /// The package identifier.
+    package: String,
+
+    /// The package version or level (major, minor, patch, rc, beta, alpha).
+    version: BumpOrVersion,
+
+    /// The remote GitHub repository owner/repo or URL.
+    #[clap(long)]
+    remote: Option<RepoOrUrl>,
+
+    /// The authentication token for GitHub API access.
+    #[clap(long, env = "GITHUB_TOKEN", hide_env_values = true)]
+    token: String,
+}
+
+impl Release {
+    /// Executes the command.
+    pub fn exec(self) -> Result<(), Error> {
+        let remote = match self.remote {
+            Some(remote) => remote,
+            None => {
+                let project = Project::git(".")?;
+                let url = project.get_url()?;
+
+                RepoOrUrl::Url(url)
+            }
+        };
+
+        let project = Project::<GitHub>::github_with_authentication_token(
+            remote.try_into_repo()?.to_string(),
+            self.token,
+        )?;
+
+        project.initiate_package_release(self.package, self.version)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #107.

This adds a new `package release` command that uses the new `initiate_package_release` method from #109.

This new command is meant to replace the existing `release` command using the new method for initiating the release process. This will allow the library to be simplified to a point where it will be possible to redesign under a single project type.