### PR TITLE
Remove project `release_package` method

### DIFF
--- a/packages/ploys/src/project/source/git/git2/mod.rs
+++ b/packages/ploys/src/project/source/git/git2/mod.rs
@@ -50,38 +50,6 @@ impl Git2 {
 }
 
 impl Git2 {
-    /// Creates a new branch.
-    pub(crate) fn create_branch(&self, branch_name: &str) -> Result<String, Error> {
-        let spec = self.revision.to_string();
-        let commit = self.repository.revparse_single(&spec)?.peel_to_commit()?;
-        let sha = commit.id().to_string();
-        let remote_name = self
-            .get_default_remote_name()?
-            .ok_or_else(Error::remote_not_found)?;
-
-        let mut remote = self.repository.find_remote(&remote_name)?;
-        let mut branch = self.repository.branch(branch_name, &commit, false)?;
-
-        let config = self.repository.config()?;
-        let auth = GitAuthenticator::new_empty()
-            .try_cred_helper(true)
-            .try_ssh_agent(true)
-            .add_default_ssh_keys();
-
-        let mut remote_callbacks = RemoteCallbacks::new();
-        let mut options = PushOptions::default();
-
-        remote_callbacks.credentials(auth.credentials(&config));
-        options.remote_callbacks(remote_callbacks);
-
-        let refspec = format!("refs/heads/{branch_name}:refs/heads/{branch_name}");
-
-        branch.set_upstream(Some(branch_name))?;
-        remote.push(&[refspec], Some(&mut options))?;
-
-        Ok(sha)
-    }
-
     /// Commits the changes to the repository.
     pub(crate) fn commit(
         &self,

--- a/packages/ploys/src/project/source/git/mod.rs
+++ b/packages/ploys/src/project/source/git/mod.rs
@@ -60,14 +60,6 @@ impl Git {
 }
 
 impl Git {
-    /// Creates a new branch.
-    pub(crate) fn create_branch(&mut self, branch_name: &str) -> Result<String, Error> {
-        match self {
-            Self::Gix(_) => unreachable!("upgrade called first"),
-            Self::Git2(git2) => git2.create_branch(branch_name),
-        }
-    }
-
     /// Commits the changes to the repository.
     pub(crate) fn commit(
         &self,

--- a/packages/ploys/src/project/source/github/mod.rs
+++ b/packages/ploys/src/project/source/github/mod.rs
@@ -124,40 +124,6 @@ impl GitHub {
         }
     }
 
-    /// Creates a new branch.
-    pub(crate) fn create_branch(&self, branch_name: &str) -> Result<String, Error> {
-        #[derive(serde::Serialize)]
-        struct Body {
-            r#ref: String,
-            sha: String,
-        }
-
-        #[derive(serde::Deserialize)]
-        struct RefResponse {
-            object: Object,
-        }
-
-        #[derive(serde::Deserialize)]
-        struct Object {
-            sha: String,
-        }
-
-        let sha = self
-            .repository
-            .post("git/refs", self.token.as_deref())
-            .set("Accept", "application/vnd.github+json")
-            .set("X-GitHub-Api-Version", "2022-11-28")
-            .send_json(Body {
-                r#ref: format!("refs/heads/{}", branch_name),
-                sha: self.sha()?,
-            })?
-            .into_json::<RefResponse>()?
-            .object
-            .sha;
-
-        Ok(sha)
-    }
-
     /// Commits the changes to the repository.
     pub(crate) fn commit(
         &self,


### PR DESCRIPTION
This removes the `release_package` method that powered the old `release` command.

The new `initiate_package_release` method was introduced in #109 to supersede this method by changing the implementation of initiating releases from creating a branch from the client to sending an event to the GitHub App. Both have a form of authentication but the event payload enables the ability to provide actual context instead of parsing this from the branch name. The implementation may change again in the future if the backend API gets its own authentication system.