### PR TITLE
Remove local git project `commit` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,17 +182,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "auth-git2"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3810b5af212b013fe7302b12d86616c6c39a48e18f2e4b812a5a9e5710213791"
-dependencies = [
- "dirs",
- "git2",
- "terminal-prompt",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,27 +692,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2333,16 +2301,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags 2.5.0",
- "libc",
-]
-
-[[package]]
 name = "libssh2-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2661,12 +2619,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "ordered-float"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,7 +2720,6 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 name = "ploys"
 version = "0.2.0"
 dependencies = [
- "auth-git2",
  "git2",
  "gix",
  "globset",
@@ -3001,17 +2952,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
 ]
 
 [[package]]
@@ -3914,16 +3854,6 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "terminal-prompt"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572818b3472910acbd5dff46a3413715c18e934b071ab2ba464a7b2c2af16376"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [features]
 default = ["git", "github"]
-git = ["dep:gix", "dep:git2", "dep:auth-git2"]
+git = ["dep:gix", "dep:git2"]
 github = ["dep:ureq"]
 
 [dependencies]
@@ -27,10 +27,6 @@ url = "2.4.0"
 [dependencies.git2]
 version = "0.19.0"
 features = ["vendored-libgit2", "vendored-openssl"]
-optional = true
-
-[dependencies.auth-git2]
-version = "0.5.5"
 optional = true
 
 [dev-dependencies]

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -456,35 +456,6 @@ impl Project<self::source::git::Git> {
     }
 }
 
-#[cfg(feature = "git")]
-impl Project<self::source::git::Git> {
-    /// Commits the changes to the repository.
-    ///
-    /// This method takes a message and collection of files to include with the
-    /// commit.
-    pub fn commit(
-        &mut self,
-        message: impl AsRef<str>,
-        files: impl IntoIterator<Item = (std::path::PathBuf, String)>,
-    ) -> Result<String, Error> {
-        use self::source::revision::{Reference, Revision};
-
-        self.upgrade()?;
-
-        let files = self.get_changed_files().chain(files);
-        let sha = self.source.commit(message, files)?;
-
-        if !matches!(
-            self.source.revision(),
-            Revision::Reference(Reference::Branch(_))
-        ) {
-            self.source.set_revision(Revision::sha(sha.clone()));
-        }
-
-        Ok(sha)
-    }
-}
-
 #[cfg(feature = "github")]
 impl Project<self::source::github::GitHub> {
     /// Commits the changes to the repository.

--- a/packages/ploys/src/project/source/git/mod.rs
+++ b/packages/ploys/src/project/source/git/mod.rs
@@ -59,20 +59,6 @@ impl Git {
     }
 }
 
-impl Git {
-    /// Commits the changes to the repository.
-    pub(crate) fn commit(
-        &self,
-        message: impl AsRef<str>,
-        files: impl Iterator<Item = (PathBuf, String)>,
-    ) -> Result<String, Error> {
-        match self {
-            Self::Gix(_) => unreachable!("upgrade called first"),
-            Self::Git2(git2) => git2.commit(message, files),
-        }
-    }
-}
-
 impl Source for Git {
     type Config = GitConfig;
     type Error = Error;


### PR DESCRIPTION
This removes the `commit` method from local git projects.

The project is still in its early stages with a lot of churn as it becomes apparent how the project should work. The original plan was to support different project sources and while this is still the case the way in which they are handled needs to be updated.

The different sources allowed projects to implement different functionality depending on the source. This was beneficial for the type system but it is now clear that this fragments the design. The `commit` method is an example of this where the local Git and remote GitHub sources behave similarly but different enough in the context of the project. A remote commit serves a different purpose to a local commit.

This change simply removes the `commit` method for git projects and removes the `auth-git2` dependency used for pushing to the remote repository.