### PR TITLE
Remove project source configuration

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -58,45 +58,6 @@ pub struct Project<T> {
     lockfiles: HashMap<PackageKind, LockFile>,
 }
 
-impl<T> Project<T>
-where
-    T: Source,
-    Error: From<T::Error>,
-{
-    /// Opens the project.
-    pub fn open() -> Result<Self, Error>
-    where
-        T::Config: Default,
-    {
-        let source = T::open()?;
-        let name = source.get_name()?;
-        let packages = Package::discover_packages(&source)?;
-        let lockfiles = LockFile::discover_lockfiles(&source)?;
-
-        Ok(Self {
-            source,
-            name,
-            packages,
-            lockfiles,
-        })
-    }
-
-    /// Opens the project with the given source configuration.
-    pub fn open_with(config: T::Config) -> Result<Self, Error> {
-        let source = T::open_with(config)?;
-        let name = source.get_name()?;
-        let packages = Package::discover_packages(&source)?;
-        let lockfiles = LockFile::discover_lockfiles(&source)?;
-
-        Ok(Self {
-            source,
-            name,
-            packages,
-            lockfiles,
-        })
-    }
-}
-
 #[cfg(feature = "git")]
 impl Project<self::source::git::Git> {
     /// Opens a project with the Git source.

--- a/packages/ploys/src/project/source/git/mod.rs
+++ b/packages/ploys/src/project/source/git/mod.rs
@@ -55,15 +55,7 @@ impl Git {
 }
 
 impl Source for Git {
-    type Config = GitConfig;
     type Error = Error;
-
-    fn open_with(config: Self::Config) -> Result<Self, Self::Error>
-    where
-        Self: Sized,
-    {
-        Self::new(config.path)
-    }
 
     fn get_name(&self) -> Result<String, Self::Error> {
         let path = self.repository.path().join("..").canonicalize()?;
@@ -140,30 +132,5 @@ impl Source for Git {
         } else {
             Err(io::Error::from(io::ErrorKind::NotFound))?
         }
-    }
-}
-
-/// The Git source configuration.
-pub struct GitConfig {
-    path: PathBuf,
-    revision: Revision,
-}
-
-impl GitConfig {
-    /// Creates a new Git source configuration.
-    pub fn new<P>(path: P) -> Self
-    where
-        P: Into<PathBuf>,
-    {
-        Self {
-            path: path.into(),
-            revision: Revision::Head,
-        }
-    }
-
-    /// Builds the configuration with the given revision.
-    pub fn with_revision(mut self, revision: impl Into<Revision>) -> Self {
-        self.revision = revision.into();
-        self
     }
 }

--- a/packages/ploys/src/project/source/github/mod.rs
+++ b/packages/ploys/src/project/source/github/mod.rs
@@ -284,21 +284,7 @@ impl GitHub {
 }
 
 impl Source for GitHub {
-    type Config = GitHubConfig;
     type Error = Error;
-
-    fn open_with(config: Self::Config) -> Result<Self, Self::Error>
-    where
-        Self: Sized,
-    {
-        match config.token {
-            Some(token) => Ok(Self::new(config.repo)?
-                .with_revision(config.revision)
-                .with_authentication_token(token)
-                .validated()?),
-            None => Ok(Self::new(config.repo)?.with_revision(config.revision)),
-        }
-    }
 
     fn get_name(&self) -> Result<String, Self::Error> {
         Ok(self.repository.name().to_owned())
@@ -360,39 +346,6 @@ impl Source for GitHub {
             }
             _ => Err(io::Error::from(io::ErrorKind::NotFound))?,
         }
-    }
-}
-
-/// The GitHub source configuration.
-pub struct GitHubConfig {
-    repo: String,
-    revision: Revision,
-    token: Option<String>,
-}
-
-impl GitHubConfig {
-    /// Creates a new GitHub source configuration.
-    pub fn new<T>(repo: T) -> Self
-    where
-        T: Into<String>,
-    {
-        Self {
-            repo: repo.into(),
-            revision: Revision::head(),
-            token: None,
-        }
-    }
-
-    /// Builds the configuration with the given revision.
-    pub fn with_revision(mut self, revision: impl Into<Revision>) -> Self {
-        self.revision = revision.into();
-        self
-    }
-
-    /// Builds the configuration with the given authentication token.
-    pub fn with_authentication_token(mut self, token: impl Into<String>) -> Self {
-        self.token = Some(token.into());
-        self
     }
 }
 

--- a/packages/ploys/src/project/source/mod.rs
+++ b/packages/ploys/src/project/source/mod.rs
@@ -18,25 +18,8 @@ use url::Url;
 
 /// A project source.
 pub trait Source {
-    /// The source configuration.
-    type Config;
-
     /// The source error.
     type Error;
-
-    /// Opens the source.
-    fn open() -> Result<Self, Self::Error>
-    where
-        Self::Config: Default,
-        Self: Sized,
-    {
-        Self::open_with(Self::Config::default())
-    }
-
-    /// Opens the source with the given configuration.
-    fn open_with(config: Self::Config) -> Result<Self, Self::Error>
-    where
-        Self: Sized;
 
     /// Queries the source name.
     fn get_name(&self) -> Result<String, Self::Error>;


### PR DESCRIPTION
This removes the project source configuration associated types and constructor methods.

The original plan for the `Project` type was to support multiple sources through generics but that led to diverging code and complexity when multiple sources needed to be handled. The plan is to migrate to multiple sources through an enumeration instead of a generic. This involves replacing the `Source` trait with an `enum` but the associated configuration complicates the situation.

This change simply removes the associated configuration types for project sources and removes both the `open` and `open_with` methods that use it. The configuration type was not used internally in the project or tested in any way so is not really beneficial outside of generically creating a project which will no longer be supported.