### PR TITLE
Replace project source generic with enum

### DIFF
--- a/packages/ploys-cli/src/package/release.rs
+++ b/packages/ploys-cli/src/package/release.rs
@@ -1,7 +1,6 @@
 use anyhow::Error;
 use clap::Args;
 use ploys::package::BumpOrVersion;
-use ploys::project::source::github::GitHub;
 use ploys::project::Project;
 
 use crate::util::repo_or_url::RepoOrUrl;
@@ -37,7 +36,7 @@ impl Release {
             }
         };
 
-        let project = Project::<GitHub>::github_with_authentication_token(
+        let project = Project::github_with_authentication_token(
             remote.try_into_repo()?.to_string(),
             self.token,
         )?;

--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -1,9 +1,7 @@
 use anyhow::Error;
 use clap::Args;
 use console::style;
-use ploys::project::source::github::GitHub;
 use ploys::project::source::revision::Revision;
-use ploys::project::source::Source;
 use ploys::project::Project;
 
 use crate::util::repo_or_url::RepoOrUrl;
@@ -37,13 +35,11 @@ impl Info {
     pub fn exec(self) -> Result<(), Error> {
         match &self.remote {
             Some(remote) => match &self.token {
-                Some(token) => self.print(
-                    Project::<GitHub>::github_with_revision_and_authentication_token(
-                        remote.clone().try_into_repo()?.to_string(),
-                        self.revision(),
-                        token,
-                    )?,
-                ),
+                Some(token) => self.print(Project::github_with_revision_and_authentication_token(
+                    remote.clone().try_into_repo()?.to_string(),
+                    self.revision(),
+                    token,
+                )?),
                 None => self.print(Project::github_with_revision(
                     remote.clone().try_into_repo()?.to_string(),
                     self.revision(),
@@ -67,11 +63,7 @@ impl Info {
         }
     }
 
-    pub fn print<T>(&self, project: Project<T>) -> Result<(), Error>
-    where
-        T: Source,
-        ploys::project::Error: From<T::Error>,
-    {
+    pub fn print(&self, project: Project) -> Result<(), Error> {
         println!("{}:\n", style("Project").underlined().bold());
         println!("Name:       {}", project.name());
         println!("Repository: {}", project.get_url()?);

--- a/packages/ploys/src/lockfile/mod.rs
+++ b/packages/ploys/src/lockfile/mod.rs
@@ -48,13 +48,9 @@ impl LockFile {
     }
 
     /// Discovers project lockfiles.
-    pub(super) fn discover_lockfiles<T>(
-        source: &T,
-    ) -> Result<HashMap<PackageKind, Self>, crate::project::Error>
-    where
-        T: Source,
-        crate::project::Error: From<T::Error>,
-    {
+    pub(super) fn discover_lockfiles(
+        source: &Source,
+    ) -> Result<HashMap<PackageKind, Self>, crate::project::Error> {
         let mut lockfiles = HashMap::new();
 
         for kind in PackageKind::variants() {

--- a/packages/ploys/src/package/manifest.rs
+++ b/packages/ploys/src/package/manifest.rs
@@ -43,15 +43,11 @@ impl Manifest {
     }
 
     /// Finds member packages using the closure to query individual paths.
-    pub fn discover_packages<T>(
+    pub fn discover_packages(
         self,
         files: &[PathBuf],
-        source: &T,
-    ) -> Result<Vec<Package>, crate::project::Error>
-    where
-        T: Source,
-        crate::project::Error: From<T::Error>,
-    {
+        source: &Source,
+    ) -> Result<Vec<Package>, crate::project::Error> {
         let members = self.members()?;
         let file_name = self.file_name();
 

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -189,11 +189,9 @@ impl Package {
 
 impl Package {
     /// Discovers project packages.
-    pub(super) fn discover_packages<T>(source: &T) -> Result<Vec<Package>, crate::project::Error>
-    where
-        T: Source,
-        crate::project::Error: From<T::Error>,
-    {
+    pub(super) fn discover_packages(
+        source: &Source,
+    ) -> Result<Vec<Package>, crate::project::Error> {
         let files = source.get_files()?;
         let mut packages = Vec::new();
 

--- a/packages/ploys/src/project/source/error.rs
+++ b/packages/ploys/src/project/source/error.rs
@@ -1,0 +1,46 @@
+use std::fmt::{self, Display};
+
+/// The project source error.
+#[derive(Debug)]
+pub enum Error {
+    #[cfg(feature = "git")]
+    Git(super::git::Error),
+    #[cfg(feature = "github")]
+    GitHub(super::github::Error),
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            #[cfg(feature = "git")]
+            Self::Git(git) => Some(git),
+            #[cfg(feature = "github")]
+            Self::GitHub(github) => Some(github),
+        }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            #[cfg(feature = "git")]
+            Self::Git(git) => Display::fmt(git, f),
+            #[cfg(feature = "github")]
+            Self::GitHub(github) => Display::fmt(github, f),
+        }
+    }
+}
+
+#[cfg(feature = "git")]
+impl From<super::git::Error> for Error {
+    fn from(err: super::git::Error) -> Self {
+        Self::Git(err)
+    }
+}
+
+#[cfg(feature = "github")]
+impl From<super::github::Error> for Error {
+    fn from(err: super::github::Error) -> Self {
+        Self::GitHub(err)
+    }
+}

--- a/packages/ploys/src/project/source/git/mod.rs
+++ b/packages/ploys/src/project/source/git/mod.rs
@@ -15,7 +15,6 @@ use url::Url;
 pub use self::error::Error;
 
 use super::revision::Revision;
-use super::Source;
 
 /// The local Git repository source.
 pub struct Git {
@@ -54,10 +53,8 @@ impl Git {
     }
 }
 
-impl Source for Git {
-    type Error = Error;
-
-    fn get_name(&self) -> Result<String, Self::Error> {
+impl Git {
+    pub fn get_name(&self) -> Result<String, Error> {
         let path = self.repository.path().join("..").canonicalize()?;
 
         if let Some(file_stem) = path.file_stem() {
@@ -70,7 +67,7 @@ impl Source for Git {
         )))
     }
 
-    fn get_url(&self) -> Result<Url, Self::Error> {
+    pub fn get_url(&self) -> Result<Url, Error> {
         match self
             .repository
             .find_default_remote(Direction::Push)
@@ -88,7 +85,7 @@ impl Source for Git {
         }
     }
 
-    fn get_files(&self) -> Result<Vec<PathBuf>, Self::Error> {
+    pub fn get_files(&self) -> Result<Vec<PathBuf>, Error> {
         let spec = self.revision.to_string();
         let tree = self
             .repository
@@ -112,7 +109,7 @@ impl Source for Git {
         Ok(entries)
     }
 
-    fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Self::Error>
+    pub fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Error>
     where
         P: AsRef<Path>,
     {

--- a/packages/ploys/src/project/source/github/mod.rs
+++ b/packages/ploys/src/project/source/github/mod.rs
@@ -21,7 +21,6 @@ pub use self::error::Error;
 pub use self::repo::Repository;
 
 use super::revision::{Reference, Revision};
-use super::Source;
 
 /// The remote GitHub repository source.
 #[derive(Clone, Debug)]
@@ -283,20 +282,18 @@ impl GitHub {
     }
 }
 
-impl Source for GitHub {
-    type Error = Error;
-
-    fn get_name(&self) -> Result<String, Self::Error> {
+impl GitHub {
+    pub fn get_name(&self) -> Result<String, Error> {
         Ok(self.repository.name().to_owned())
     }
 
-    fn get_url(&self) -> Result<Url, Self::Error> {
+    pub fn get_url(&self) -> Result<Url, Error> {
         Ok(format!("https://github.com/{}", self.repository)
             .parse()
             .unwrap())
     }
 
-    fn get_files(&self) -> Result<Vec<PathBuf>, Self::Error> {
+    pub fn get_files(&self) -> Result<Vec<PathBuf>, Error> {
         let request = self
             .repository
             .get(
@@ -321,7 +318,7 @@ impl Source for GitHub {
         Ok(entries)
     }
 
-    fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Self::Error>
+    pub fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Error>
     where
         P: AsRef<Path>,
     {
@@ -368,8 +365,6 @@ struct RepositoryDispatchEvent<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::project::source::Source;
-
     use super::{Error, GitHub};
 
     #[test]

--- a/packages/ploys/src/project/source/mod.rs
+++ b/packages/ploys/src/project/source/mod.rs
@@ -3,6 +3,8 @@
 //! This module contains the common functionality that is shared by different
 //! project sources.
 
+mod error;
+
 #[cfg(feature = "git")]
 pub mod git;
 
@@ -16,22 +18,57 @@ use std::path::{Path, PathBuf};
 
 use url::Url;
 
-/// A project source.
-pub trait Source {
-    /// The source error.
-    type Error;
+pub use self::error::Error;
 
+/// A project source.
+pub enum Source {
+    #[cfg(feature = "git")]
+    Git(self::git::Git),
+    #[cfg(feature = "github")]
+    GitHub(self::github::GitHub),
+}
+
+impl Source {
     /// Queries the source name.
-    fn get_name(&self) -> Result<String, Self::Error>;
+    pub fn get_name(&self) -> Result<String, Error> {
+        match self {
+            #[cfg(feature = "git")]
+            Self::Git(git) => Ok(git.get_name()?),
+            #[cfg(feature = "github")]
+            Self::GitHub(github) => Ok(github.get_name()?),
+        }
+    }
 
     /// Queries the source URL.
-    fn get_url(&self) -> Result<Url, Self::Error>;
+    pub fn get_url(&self) -> Result<Url, Error> {
+        match self {
+            #[cfg(feature = "git")]
+            Self::Git(git) => Ok(git.get_url()?),
+            #[cfg(feature = "github")]
+            Self::GitHub(github) => Ok(github.get_url()?),
+        }
+    }
 
     /// Queries the project files.
-    fn get_files(&self) -> Result<Vec<PathBuf>, Self::Error>;
+    pub fn get_files(&self) -> Result<Vec<PathBuf>, Error> {
+        match self {
+            #[cfg(feature = "git")]
+            Self::Git(git) => Ok(git.get_files()?),
+            #[cfg(feature = "github")]
+            Self::GitHub(github) => Ok(github.get_files()?),
+        }
+    }
 
     /// Queries the contents of a project file.
-    fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Self::Error>
+    pub fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Error>
     where
-        P: AsRef<Path>;
+        P: AsRef<Path>,
+    {
+        match self {
+            #[cfg(feature = "git")]
+            Self::Git(git) => Ok(git.get_file_contents(path)?),
+            #[cfg(feature = "github")]
+            Self::GitHub(github) => Ok(github.get_file_contents(path)?),
+        }
+    }
 }


### PR DESCRIPTION
This change replaces the project source generic and `Source` trait with a new `Source` enum.

The goal is to support multiple sources in a single project and this change facilitates this by removing the generic and replacing it with an enumeration. This means that there is a single type of project that may internally use a single or multiple sources without diverging the code.

This change not only adds a new `Source` enum to replace the trait but also adds a new source `Error` type, moves the existing source error variants under the source variant, and adds a new `Unsupported` error variant to handle unsupported sources.