### PR TITLE
Add project fileset for packages and lockfiles

### DIFF
--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -91,7 +91,7 @@ pub async fn create_release_pull_request(
     let revision = Revision::branch(format!("release/{release}"));
     let mut project =
         Project::github_with_revision_and_authentication_token(repository_name, revision, &token)?;
-    let package = project.packages().iter().find(|package| {
+    let package = project.packages().find(|package| {
         release.starts_with(package.name())
             && release.as_bytes().get(package.name().len()) == Some(&b'-')
             && release[package.name().len() + 1..]
@@ -111,7 +111,6 @@ pub async fn create_release_pull_request(
             let version = release.parse::<Version>().map_err(|_| Error::Payload)?;
             let package = project
                 .packages()
-                .iter()
                 .find(|package| package.name() == project.name())
                 .ok_or_else(|| ploys::project::Error::PackageNotFound(project.name().to_owned()))?;
 
@@ -187,7 +186,7 @@ async fn create_release(
     let revision = Revision::sha(sha);
     let project =
         Project::github_with_revision_and_authentication_token(repository_name, revision, &token)?;
-    let package = project.packages().iter().find(|package| {
+    let package = project.packages().find(|package| {
         release.starts_with(package.name())
             && release.as_bytes().get(package.name().len()) == Some(&b'-')
             && release[package.name().len() + 1..]
@@ -207,7 +206,6 @@ async fn create_release(
             let version = release.parse::<Version>().map_err(|_| Error::Payload)?;
             let package = project
                 .packages()
-                .iter()
                 .find(|package| package.name() == project.name())
                 .ok_or_else(|| ploys::project::Error::PackageNotFound(project.name().to_owned()))?;
 
@@ -301,7 +299,6 @@ async fn initiate_release(
             project.bump_package_version(&package, bump)?;
             project
                 .packages()
-                .iter()
                 .find(|pkg| pkg.name() == package)
                 .ok_or_else(|| ploys::project::Error::PackageNotFound(package.clone()))?
                 .version()
@@ -312,7 +309,6 @@ async fn initiate_release(
         BumpOrVersion::Version(version) => {
             let current_version = project
                 .packages()
-                .iter()
                 .find(|pkg| pkg.name() == package)
                 .ok_or_else(|| ploys::project::Error::PackageNotFound(package.clone()))?
                 .version()

--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -70,19 +70,18 @@ impl Info {
 
         println!("\n{}:\n", style("Packages").underlined().bold());
 
-        let packages = project.packages();
-        let max_name_len = packages
-            .iter()
+        let max_name_len = project
+            .packages()
             .map(|pkg| pkg.name().len())
             .max()
             .unwrap_or_default();
-        let max_version_len = packages
-            .iter()
+        let max_version_len = project
+            .packages()
             .map(|pkg| pkg.version().len())
             .max()
             .unwrap_or_default();
 
-        for package in packages {
+        for package in project.packages() {
             println!(
                 "{:<max_name_len$}  {:>max_version_len$}  {}",
                 package.name(),

--- a/packages/ploys/src/lockfile/mod.rs
+++ b/packages/ploys/src/lockfile/mod.rs
@@ -6,8 +6,6 @@
 pub mod cargo;
 mod error;
 
-use std::collections::HashMap;
-
 use crate::package::PackageKind;
 use crate::project::source::Source;
 
@@ -22,6 +20,13 @@ pub enum LockFile {
 }
 
 impl LockFile {
+    /// Gets the lockfile kind.
+    pub fn kind(&self) -> PackageKind {
+        match self {
+            Self::Cargo(_) => PackageKind::Cargo,
+        }
+    }
+
     /// Sets the package version.
     pub fn set_package_version<P, V>(&mut self, package: P, version: V)
     where
@@ -48,17 +53,15 @@ impl LockFile {
     }
 
     /// Discovers project lockfiles.
-    pub(super) fn discover_lockfiles(
-        source: &Source,
-    ) -> Result<HashMap<PackageKind, Self>, crate::project::Error> {
-        let mut lockfiles = HashMap::new();
+    pub(super) fn discover_lockfiles(source: &Source) -> Result<Vec<Self>, crate::project::Error> {
+        let mut lockfiles = Vec::new();
 
         for kind in PackageKind::variants() {
             if let Some(lockfile_name) = kind.lockfile_name() {
                 if let Ok(bytes) = source.get_file_contents(lockfile_name) {
                     let lockfile = LockFile::from_bytes(*kind, &bytes)?;
 
-                    lockfiles.insert(*kind, lockfile);
+                    lockfiles.push(lockfile);
                 }
             }
         }

--- a/packages/ploys/src/project/file.rs
+++ b/packages/ploys/src/project/file.rs
@@ -1,0 +1,192 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::lockfile::LockFile;
+use crate::package::{Package, PackageKind};
+
+/// A collection of files.
+#[derive(Clone, Debug, Default)]
+pub struct Fileset {
+    /// The internal file map.
+    ///
+    /// This maps the path to an optional file where the `Some` option variant
+    /// represents a file that exists, `None` represents a file that does not
+    /// exist, and no entry where the existence is not yet known.
+    files: HashMap<PathBuf, Option<File>>,
+}
+
+impl Fileset {
+    /// Constructs a new fileset.
+    pub fn new() -> Self {
+        Self {
+            files: HashMap::new(),
+        }
+    }
+
+    /// Builds the fileset with the given files.
+    pub fn with_files<I, T>(mut self, files: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<File>,
+    {
+        self.extend(files);
+        self
+    }
+
+    /// Inserts the given file.
+    pub fn insert_file(&mut self, file: impl Into<File>) -> &mut Self {
+        let file = file.into();
+
+        self.files.insert(file.path().to_owned(), Some(file));
+        self
+    }
+
+    /// Gets the file at the given path.
+    pub fn get_file(&self, path: impl AsRef<Path>) -> Option<&File> {
+        self.files.get(path.as_ref())?.as_ref()
+    }
+
+    /// Gets the mutable file at the given path.
+    pub fn get_file_mut(&mut self, path: impl AsRef<Path>) -> Option<&mut File> {
+        self.files.get_mut(path.as_ref())?.as_mut()
+    }
+
+    /// Gets a package with the given name.
+    pub fn get_package_by_name(&self, name: impl AsRef<str>) -> Option<&Package> {
+        self.packages()
+            .find(|package| package.name() == name.as_ref())
+    }
+
+    /// Gets a mutable package with the given name.
+    pub fn get_package_by_name_mut(&mut self, name: impl AsRef<str>) -> Option<&mut Package> {
+        self.packages_mut()
+            .find(|package| package.name() == name.as_ref())
+    }
+
+    /// Gets a lockfile with the given kind.
+    pub fn get_lockfile_by_kind(&self, kind: PackageKind) -> Option<&LockFile> {
+        self.get_file(kind.lockfile_name()?)?.as_lockfile()
+    }
+
+    /// Gets a mutable lockfile with the given kind.
+    pub fn get_lockfile_by_kind_mut(&mut self, kind: PackageKind) -> Option<&mut LockFile> {
+        self.get_file_mut(kind.lockfile_name()?)?.as_lockfile_mut()
+    }
+
+    /// Gets an iterator over the files.
+    pub fn files(&self) -> impl Iterator<Item = &File> {
+        self.files.values().filter_map(Option::as_ref)
+    }
+
+    /// Gets an iterator over the mutable files.
+    pub fn files_mut(&mut self) -> impl Iterator<Item = &mut File> {
+        self.files.values_mut().filter_map(Option::as_mut)
+    }
+
+    /// Gets an iterator over the packages.
+    pub fn packages(&self) -> impl Iterator<Item = &Package> {
+        self.files().filter_map(File::as_package)
+    }
+
+    /// Gets an iterator over the mutable packages.
+    pub fn packages_mut(&mut self) -> impl Iterator<Item = &mut Package> {
+        self.files_mut().filter_map(File::as_package_mut)
+    }
+
+    /// Gets an iterator over the lockfiles.
+    pub fn lockfiles(&self) -> impl Iterator<Item = &LockFile> {
+        self.files().filter_map(File::as_lockfile)
+    }
+
+    /// Gets an iterator over the mutable lockfiles.
+    pub fn lockfiles_mut(&mut self) -> impl Iterator<Item = &mut LockFile> {
+        self.files_mut().filter_map(File::as_lockfile_mut)
+    }
+
+    /// Gets the number of files in the fileset.
+    pub fn len(&self) -> usize {
+        self.files.values().filter(|file| file.is_some()).count()
+    }
+
+    /// Checks whether the fileset is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<T> Extend<T> for Fileset
+where
+    T: Into<File>,
+{
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = T>,
+    {
+        self.files.extend(
+            iter.into_iter()
+                .map(Into::into)
+                .map(|file| (file.path().to_owned(), Some(file))),
+        );
+    }
+}
+
+/// A file in one of a number of formats.
+#[derive(Clone, Debug)]
+pub enum File {
+    Package(Package),
+    Lockfile(LockFile),
+}
+
+impl File {
+    /// Gets the file path.
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Package(package) => package.path(),
+            Self::Lockfile(lockfile) => lockfile.kind().lockfile_name().expect("path"),
+        }
+    }
+
+    /// Gets the file as a package.
+    pub fn as_package(&self) -> Option<&Package> {
+        match self {
+            Self::Package(package) => Some(package),
+            _ => None,
+        }
+    }
+
+    /// Gets the file as a mutable package.
+    pub fn as_package_mut(&mut self) -> Option<&mut Package> {
+        match self {
+            Self::Package(package) => Some(package),
+            _ => None,
+        }
+    }
+
+    /// Gets the file as a lockfile.
+    pub fn as_lockfile(&self) -> Option<&LockFile> {
+        match self {
+            Self::Lockfile(lockfile) => Some(lockfile),
+            _ => None,
+        }
+    }
+
+    /// Gets the file as a mutable lockfile.
+    pub fn as_lockfile_mut(&mut self) -> Option<&mut LockFile> {
+        match self {
+            Self::Lockfile(lockfile) => Some(lockfile),
+            _ => None,
+        }
+    }
+}
+
+impl From<Package> for File {
+    fn from(value: Package) -> Self {
+        Self::Package(value)
+    }
+}
+
+impl From<LockFile> for File {
+    fn from(value: LockFile) -> Self {
+        Self::Lockfile(value)
+    }
+}

--- a/packages/ploys/src/project/file.rs
+++ b/packages/ploys/src/project/file.rs
@@ -1,4 +1,6 @@
+use std::collections::hash_map::IntoValues;
 use std::collections::HashMap;
+use std::iter::Flatten;
 use std::path::{Path, PathBuf};
 
 use crate::lockfile::LockFile;
@@ -127,6 +129,33 @@ where
                 .map(Into::into)
                 .map(|file| (file.path().to_owned(), Some(file))),
         );
+    }
+}
+
+impl IntoIterator for Fileset {
+    type Item = File;
+    type IntoIter = Flatten<IntoValues<PathBuf, Option<File>>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.files.into_values().flatten()
+    }
+}
+
+impl<T> FromIterator<T> for Fileset
+where
+    T: Into<File>,
+{
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        Self {
+            files: iter
+                .into_iter()
+                .map(Into::into)
+                .map(|file| (file.path().to_owned(), Some(file)))
+                .collect(),
+        }
     }
 }
 

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -25,10 +25,8 @@ fn test_valid_local_project() -> Result<(), Error> {
     assert!(b.contains("[package]"));
     assert!(project.get_file_contents("packages/ploys").is_err());
 
-    let packages = project.packages();
-
-    assert!(packages.iter().any(|pkg| pkg.name() == "ploys"));
-    assert!(packages.iter().any(|pkg| pkg.name() == "ploys-cli"));
+    assert!(project.packages().any(|pkg| pkg.name() == "ploys"));
+    assert!(project.packages().any(|pkg| pkg.name() == "ploys-cli"));
 
     Ok(())
 }
@@ -60,10 +58,8 @@ fn test_valid_remote_project() -> Result<(), Error> {
     assert!(b.contains("[package]"));
     assert!(project.get_file_contents("packages/ploys").is_err());
 
-    let packages = project.packages();
-
-    assert!(packages.iter().any(|pkg| pkg.name() == "ploys"));
-    assert!(packages.iter().any(|pkg| pkg.name() == "ploys-cli"));
+    assert!(project.packages().any(|pkg| pkg.name() == "ploys"));
+    assert!(project.packages().any(|pkg| pkg.name() == "ploys-cli"));
 
     Ok(())
 }


### PR DESCRIPTION
This adds a new project fileset type for storing packages and lockfiles.

The current implementation of the project stores packages and lockfiles directly inside the project type under separate fields. However, the goal is to support multiple sources where each source could have a different set of files. This could be because the user is in the process of adding a new package or updating the state of a lockfile. The file storage should therefore be moved to the source but in order to facilitate that there should be a simplified way to handle groups of files.

This change simply introduces the `File` and `Fileset` types and updates the logic to use this type to store the package and lockfile information.