### PR TITLE
Move `File` and `Fileset` types to root `file` module

### DIFF
--- a/packages/ploys/src/file/fileset.rs
+++ b/packages/ploys/src/file/fileset.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 
 use crate::package::{Lockfile, Package, PackageKind};
 
+use super::File;
+
 /// A collection of files.
 #[derive(Clone, Debug, Default)]
 pub struct Fileset {
@@ -155,66 +157,5 @@ where
                 .map(|file| (file.path().to_owned(), Some(file)))
                 .collect(),
         }
-    }
-}
-
-/// A file in one of a number of formats.
-#[derive(Clone, Debug)]
-pub enum File {
-    Package(Package),
-    Lockfile(Lockfile),
-}
-
-impl File {
-    /// Gets the file path.
-    pub fn path(&self) -> &Path {
-        match self {
-            Self::Package(package) => package.path(),
-            Self::Lockfile(lockfile) => lockfile.kind().lockfile_name().expect("path"),
-        }
-    }
-
-    /// Gets the file as a package.
-    pub fn as_package(&self) -> Option<&Package> {
-        match self {
-            Self::Package(package) => Some(package),
-            _ => None,
-        }
-    }
-
-    /// Gets the file as a mutable package.
-    pub fn as_package_mut(&mut self) -> Option<&mut Package> {
-        match self {
-            Self::Package(package) => Some(package),
-            _ => None,
-        }
-    }
-
-    /// Gets the file as a lockfile.
-    pub fn as_lockfile(&self) -> Option<&Lockfile> {
-        match self {
-            Self::Lockfile(lockfile) => Some(lockfile),
-            _ => None,
-        }
-    }
-
-    /// Gets the file as a mutable lockfile.
-    pub fn as_lockfile_mut(&mut self) -> Option<&mut Lockfile> {
-        match self {
-            Self::Lockfile(lockfile) => Some(lockfile),
-            _ => None,
-        }
-    }
-}
-
-impl From<Package> for File {
-    fn from(value: Package) -> Self {
-        Self::Package(value)
-    }
-}
-
-impl From<Lockfile> for File {
-    fn from(value: Lockfile) -> Self {
-        Self::Lockfile(value)
     }
 }

--- a/packages/ploys/src/file/mod.rs
+++ b/packages/ploys/src/file/mod.rs
@@ -1,0 +1,68 @@
+mod fileset;
+
+use std::path::Path;
+
+use crate::package::{Lockfile, Package};
+
+pub use self::fileset::Fileset;
+
+/// A file in one of a number of formats.
+#[derive(Clone, Debug)]
+pub enum File {
+    Package(Package),
+    Lockfile(Lockfile),
+}
+
+impl File {
+    /// Gets the file path.
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Package(package) => package.path(),
+            Self::Lockfile(lockfile) => lockfile.kind().lockfile_name().expect("path"),
+        }
+    }
+
+    /// Gets the file as a package.
+    pub fn as_package(&self) -> Option<&Package> {
+        match self {
+            Self::Package(package) => Some(package),
+            _ => None,
+        }
+    }
+
+    /// Gets the file as a mutable package.
+    pub fn as_package_mut(&mut self) -> Option<&mut Package> {
+        match self {
+            Self::Package(package) => Some(package),
+            _ => None,
+        }
+    }
+
+    /// Gets the file as a lockfile.
+    pub fn as_lockfile(&self) -> Option<&Lockfile> {
+        match self {
+            Self::Lockfile(lockfile) => Some(lockfile),
+            _ => None,
+        }
+    }
+
+    /// Gets the file as a mutable lockfile.
+    pub fn as_lockfile_mut(&mut self) -> Option<&mut Lockfile> {
+        match self {
+            Self::Lockfile(lockfile) => Some(lockfile),
+            _ => None,
+        }
+    }
+}
+
+impl From<Package> for File {
+    fn from(value: Package) -> Self {
+        Self::Package(value)
+    }
+}
+
+impl From<Lockfile> for File {
+    fn from(value: Lockfile) -> Self {
+        Self::Lockfile(value)
+    }
+}

--- a/packages/ploys/src/lib.rs
+++ b/packages/ploys/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod changelog;
+pub mod file;
 pub mod package;
 pub mod project;
 pub mod repository;

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -35,18 +35,17 @@
 //! ```
 
 mod error;
-mod file;
 
 use std::path::{Path, PathBuf};
 
 use semver::Version;
 use url::Url;
 
+use crate::file::Fileset;
 use crate::package::{Bump, Lockfile, Package};
 use crate::repository::Repository;
 
 pub use self::error::Error;
-pub use self::file::{File, Fileset};
 
 /// A project from one of several supported repositories.
 pub struct Project {


### PR DESCRIPTION
This moves the `File` and `Fileset` types out of the `project` module into a `file` module in the library root.

File handling is not intrinsically linked to the `Project` type and there are plans to alter the file handling functionality so that other formats become views over known data types. This means that now would be a good opportunity to move the `file` module outside of the `project` module and split out the `Fileset` type to its own module.

This change simply moves the `file` module out of the `project` module and separates the `Fileset` type into a private submodule under it.