### PR TITLE
Implement `PartialEq` and `Eq` for files

### DIFF
--- a/packages/ploys/src/file/fileset.rs
+++ b/packages/ploys/src/file/fileset.rs
@@ -8,7 +8,7 @@ use crate::package::{Lockfile, Package, PackageKind};
 use super::File;
 
 /// A collection of files.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Fileset {
     /// The internal file map.
     ///

--- a/packages/ploys/src/file/mod.rs
+++ b/packages/ploys/src/file/mod.rs
@@ -7,7 +7,7 @@ use crate::package::{Lockfile, Package};
 pub use self::fileset::Fileset;
 
 /// A file in one of a number of formats.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum File {
     Package(Package),
     Lockfile(Lockfile),

--- a/packages/ploys/src/package/cargo/lockfile.rs
+++ b/packages/ploys/src/package/cargo/lockfile.rs
@@ -51,6 +51,14 @@ impl CargoLockfile {
     }
 }
 
+impl PartialEq for CargoLockfile {
+    fn eq(&self, other: &Self) -> bool {
+        self.manifest.to_string() == other.manifest.to_string()
+    }
+}
+
+impl Eq for CargoLockfile {}
+
 /// The mutable packages table.
 struct PackagesMut<'a>(Option<&'a mut ArrayOfTables>);
 

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -133,6 +133,14 @@ impl Manifest {
     }
 }
 
+impl PartialEq for Manifest {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.to_string() == other.0.to_string()
+    }
+}
+
+impl Eq for Manifest {}
+
 /// The workspace table.
 pub struct Workspace<'a>(&'a dyn TableLike);
 

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -15,7 +15,7 @@ use self::manifest::Manifest;
 use super::{Bump, BumpError};
 
 /// A `Cargo.toml` package for Rust.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Cargo {
     manifest: Manifest,
     path: PathBuf,

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -15,7 +15,7 @@ use self::manifest::Manifest;
 use super::{Bump, BumpError};
 
 /// A `Cargo.toml` package for Rust.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct Cargo {
     manifest: Manifest,
     path: PathBuf,
@@ -153,3 +153,11 @@ impl Cargo {
         self.changed = changed;
     }
 }
+
+impl PartialEq for Cargo {
+    fn eq(&self, other: &Self) -> bool {
+        self.manifest == other.manifest && self.path == other.path
+    }
+}
+
+impl Eq for Cargo {}

--- a/packages/ploys/src/package/lockfile.rs
+++ b/packages/ploys/src/package/lockfile.rs
@@ -9,7 +9,7 @@ use crate::repository::Repository;
 use super::cargo::CargoLockfile;
 
 /// A lockfile in one of several supported formats.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Lockfile {
     /// A `Cargo.lock` lockfile for Rust.
     Cargo(CargoLockfile),

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -25,7 +25,7 @@ pub use self::lockfile::Lockfile;
 use self::manifest::Manifest;
 
 /// A package in one of several supported formats.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Package {
     /// A `Cargo.toml` package for Rust.
     Cargo(Cargo),


### PR DESCRIPTION
This implements `PartialEq` and `Eq` for filesets and files.

The current implementation for detecting file changes involves setting a `changed` field in the file. The aim is to replace this by comparing the stored file with the file in the repository to simplify the logic and remove the additional field.

This change simply adds the appropriate derives and manual trait implementations.