### PR TITLE
Refactor project changed files method

### DIFF
--- a/packages/ploys/src/file/mod.rs
+++ b/packages/ploys/src/file/mod.rs
@@ -53,6 +53,22 @@ impl File {
             _ => None,
         }
     }
+
+    /// Gets the contents of the file.
+    pub(crate) fn get_contents(&self) -> String {
+        match self {
+            Self::Package(package) => package.get_contents(),
+            Self::Lockfile(lockfile) => lockfile.get_contents(),
+        }
+    }
+
+    /// Checks if the file has been changed.
+    pub(crate) fn is_changed(&self) -> bool {
+        match self {
+            Self::Package(package) => package.is_changed(),
+            Self::Lockfile(lockfile) => lockfile.is_changed(),
+        }
+    }
 }
 
 impl From<Package> for File {

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -326,19 +326,10 @@ impl Project {
 
     /// Gets the changed files.
     pub fn get_changed_files(&self) -> impl Iterator<Item = (PathBuf, String)> + '_ {
-        self.packages()
-            .filter(|package| package.is_changed())
-            .map(|package| (package.path().to_owned(), package.get_contents()))
-            .chain(
-                self.lockfiles()
-                    .filter(|lockfile| lockfile.is_changed())
-                    .filter_map(|lockfile| {
-                        lockfile
-                            .kind()
-                            .lockfile_name()
-                            .map(|name| (name.to_owned(), lockfile.get_contents()))
-                    }),
-            )
+        self.files
+            .files()
+            .filter(|file| file.is_changed())
+            .map(|file| (file.path().to_owned(), file.get_contents()))
     }
 }
 


### PR DESCRIPTION
This refactors the `Project::get_changed_files` method to simplify the logic and support future file formats.

The initial implementation of the `get_changed_files` method hardcoded support for packages and lockfiles but this does not scale to support other future file formats.

This change simply refactors the `Project::get_changed_files` method and introduces new crate-scoped `File::get_contents` and `File:: is_changed` methods to simplify the logic. The change may be short-lived as the immediate goal is to change the logic how files are handled and marked as changed.