### PR TITLE
Remove path from files

### DIFF
--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -72,16 +72,16 @@ impl Info {
 
         let max_name_len = project
             .packages()
-            .map(|pkg| pkg.name().len())
+            .map(|(_, pkg)| pkg.name().len())
             .max()
             .unwrap_or_default();
         let max_version_len = project
             .packages()
-            .map(|pkg| pkg.version().len())
+            .map(|(_, pkg)| pkg.version().len())
             .max()
             .unwrap_or_default();
 
-        for package in project.packages() {
+        for (_, package) in project.packages() {
             println!(
                 "{:<max_name_len$}  {:>max_version_len$}  {}",
                 package.name(),

--- a/packages/ploys/src/file/mod.rs
+++ b/packages/ploys/src/file/mod.rs
@@ -1,7 +1,5 @@
 mod fileset;
 
-use std::path::Path;
-
 use crate::package::{Lockfile, Package};
 
 pub use self::fileset::Fileset;
@@ -14,14 +12,6 @@ pub enum File {
 }
 
 impl File {
-    /// Gets the file path.
-    pub fn path(&self) -> &Path {
-        match self {
-            Self::Package(package) => package.path(),
-            Self::Lockfile(lockfile) => lockfile.kind().lockfile_name().expect("path"),
-        }
-    }
-
     /// Gets the file as a package.
     pub fn as_package(&self) -> Option<&Package> {
         match self {

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -125,9 +125,9 @@ impl Manifest {
     }
 
     /// Converts this manifest into a package with the given path.
-    pub fn into_package(self, path: PathBuf) -> Option<Cargo> {
+    pub fn into_package(self) -> Option<Cargo> {
         match self.package().is_some() {
-            true => Some(Cargo::new(self, path)),
+            true => Some(Cargo::new(self)),
             false => None,
         }
     }

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -5,8 +5,6 @@ mod error;
 mod lockfile;
 pub(super) mod manifest;
 
-use std::path::{Path, PathBuf};
-
 pub use self::dependency::{Dependencies, DependenciesMut, Dependency, DependencyMut};
 pub use self::error::Error;
 pub use self::lockfile::CargoLockfile;
@@ -18,16 +16,14 @@ use super::{Bump, BumpError};
 #[derive(Clone, Debug)]
 pub struct Cargo {
     manifest: Manifest,
-    path: PathBuf,
     changed: bool,
 }
 
 impl Cargo {
     /// Creates a new cargo package.
-    fn new(manifest: Manifest, path: PathBuf) -> Self {
+    fn new(manifest: Manifest) -> Self {
         Self {
             manifest,
-            path,
             changed: false,
         }
     }
@@ -58,11 +54,6 @@ impl Cargo {
             .set_version(version);
         self.changed = true;
         self
-    }
-
-    /// Gets the package path.
-    pub fn path(&self) -> &Path {
-        &self.path
     }
 
     /// Bumps the package version.
@@ -156,7 +147,7 @@ impl Cargo {
 
 impl PartialEq for Cargo {
     fn eq(&self, other: &Self) -> bool {
-        self.manifest == other.manifest && self.path == other.path
+        self.manifest == other.manifest
     }
 }
 

--- a/packages/ploys/src/package/lockfile.rs
+++ b/packages/ploys/src/package/lockfile.rs
@@ -3,6 +3,8 @@
 //! This module includes utilities for inspecting and managing lockfiles across
 //! different package managers.
 
+use std::path::PathBuf;
+
 use crate::package::{Error, PackageKind};
 use crate::repository::Repository;
 
@@ -51,7 +53,7 @@ impl Lockfile {
     /// Discovers project lockfiles.
     pub(crate) fn discover_lockfiles(
         repository: &Repository,
-    ) -> Result<Vec<Self>, crate::project::Error> {
+    ) -> Result<Vec<(PathBuf, Self)>, crate::project::Error> {
         let mut lockfiles = Vec::new();
 
         for kind in PackageKind::variants() {
@@ -59,7 +61,7 @@ impl Lockfile {
                 if let Ok(bytes) = repository.get_file_contents(lockfile_name) {
                     let lockfile = Lockfile::from_bytes(*kind, &bytes)?;
 
-                    lockfiles.push(lockfile);
+                    lockfiles.push((lockfile_name.to_owned(), lockfile));
                 }
             }
         }

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -11,7 +11,7 @@ mod lockfile;
 mod manifest;
 mod members;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use semver::Version;
 
@@ -50,13 +50,6 @@ impl Package {
     pub fn version(&self) -> &str {
         match self {
             Self::Cargo(cargo) => cargo.version(),
-        }
-    }
-
-    /// Gets the package manifest file path.
-    pub fn path(&self) -> &Path {
-        match self {
-            Self::Cargo(cargo) => cargo.path(),
         }
     }
 
@@ -193,7 +186,7 @@ impl Package {
     /// Discovers project packages.
     pub(super) fn discover_packages(
         repository: &Repository,
-    ) -> Result<Vec<Package>, crate::project::Error> {
+    ) -> Result<Vec<(PathBuf, Package)>, crate::project::Error> {
         let files = repository.get_files()?;
         let mut packages = Vec::new();
 

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -25,8 +25,8 @@ fn test_valid_local_project() -> Result<(), Error> {
     assert!(b.contains("[package]"));
     assert!(project.get_file_contents("packages/ploys").is_err());
 
-    assert!(project.packages().any(|pkg| pkg.name() == "ploys"));
-    assert!(project.packages().any(|pkg| pkg.name() == "ploys-cli"));
+    assert!(project.packages().any(|(_, pkg)| pkg.name() == "ploys"));
+    assert!(project.packages().any(|(_, pkg)| pkg.name() == "ploys-cli"));
 
     Ok(())
 }
@@ -58,8 +58,8 @@ fn test_valid_remote_project() -> Result<(), Error> {
     assert!(b.contains("[package]"));
     assert!(project.get_file_contents("packages/ploys").is_err());
 
-    assert!(project.packages().any(|pkg| pkg.name() == "ploys"));
-    assert!(project.packages().any(|pkg| pkg.name() == "ploys-cli"));
+    assert!(project.packages().any(|(_, pkg)| pkg.name() == "ploys"));
+    assert!(project.packages().any(|(_, pkg)| pkg.name() == "ploys-cli"));
 
     Ok(())
 }


### PR DESCRIPTION
This removes the path from the various file types in favour of using tuples to store the path separately.

The initial implementation of the `File` type included the `path` method to get the path from the file itself. This was useful in that it simplified the file handling and avoided the use of tuples or another structure to store the path separately. However, although the path was not itself mutable, it was possible to swap files in a fileset such that they no longer correspond to the correct key. Additionally, there are plans for including the changelog as a file that would require it to include a path.

This change removes the path from the `File` type and its variants and alters the various APIs to return a tuple instead.