### PR TITLE
Add environment files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Secrets*.toml
 .shuttle*
+.env*


### PR DESCRIPTION
This simply adds a new entry to the `.gitignore` file to exclude environment files including both `.env` and `.envrc`.