### PR TITLE
Implement `Display` for files

### DIFF
--- a/packages/ploys/src/file/mod.rs
+++ b/packages/ploys/src/file/mod.rs
@@ -1,5 +1,7 @@
 mod fileset;
 
+use std::fmt::{self, Display};
+
 use crate::package::{Lockfile, Package};
 
 pub use self::fileset::Fileset;
@@ -44,19 +46,20 @@ impl File {
         }
     }
 
-    /// Gets the contents of the file.
-    pub(crate) fn get_contents(&self) -> String {
-        match self {
-            Self::Package(package) => package.get_contents(),
-            Self::Lockfile(lockfile) => lockfile.get_contents(),
-        }
-    }
-
     /// Checks if the file has been changed.
     pub(crate) fn is_changed(&self) -> bool {
         match self {
             Self::Package(package) => package.is_changed(),
             Self::Lockfile(lockfile) => lockfile.is_changed(),
+        }
+    }
+}
+
+impl Display for File {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Package(package) => Display::fmt(package, f),
+            Self::Lockfile(lockfile) => Display::fmt(lockfile, f),
         }
     }
 }

--- a/packages/ploys/src/package/cargo/lockfile.rs
+++ b/packages/ploys/src/package/cargo/lockfile.rs
@@ -1,5 +1,7 @@
 //! The `Cargo.lock` lockfile for Rust.
 
+use std::fmt::{self, Display};
+
 use toml_edit::{ArrayOfTables, DocumentMut, Item, TableLike, Value};
 
 use crate::package::cargo::Error;
@@ -24,11 +26,6 @@ impl CargoLockfile {
         }
     }
 
-    /// Gets the contents of the lockfile.
-    pub fn get_contents(&self) -> String {
-        self.manifest.to_string()
-    }
-
     /// Checks if the lockfile has been changed.
     pub fn is_changed(&self) -> bool {
         self.changed
@@ -48,6 +45,12 @@ impl CargoLockfile {
                 .get_mut("package")
                 .and_then(Item::as_array_of_tables_mut),
         )
+    }
+}
+
+impl Display for CargoLockfile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.manifest, f)
     }
 }
 

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -1,3 +1,4 @@
+use std::fmt::{self, Display};
 use std::path::PathBuf;
 
 use globset::{Glob, GlobSetBuilder};
@@ -130,6 +131,12 @@ impl Manifest {
             true => Some(Cargo::new(self)),
             false => None,
         }
+    }
+}
+
+impl Display for Manifest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
     }
 }
 

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -5,6 +5,8 @@ mod error;
 mod lockfile;
 pub(super) mod manifest;
 
+use std::fmt::{self, Display};
+
 pub use self::dependency::{Dependencies, DependenciesMut, Dependency, DependencyMut};
 pub use self::error::Error;
 pub use self::lockfile::CargoLockfile;
@@ -129,11 +131,6 @@ impl Cargo {
         self.manifest.build_dependencies_mut()
     }
 
-    /// Gets the package contents.
-    pub fn get_contents(&self) -> String {
-        self.manifest.0.to_string()
-    }
-
     /// Checks if the package has been changed.
     pub fn is_changed(&self) -> bool {
         self.changed
@@ -142,6 +139,12 @@ impl Cargo {
     /// Sets the package as changed.
     pub(crate) fn set_changed(&mut self, changed: bool) {
         self.changed = changed;
+    }
+}
+
+impl Display for Cargo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.manifest, f)
     }
 }
 

--- a/packages/ploys/src/package/lockfile.rs
+++ b/packages/ploys/src/package/lockfile.rs
@@ -3,6 +3,7 @@
 //! This module includes utilities for inspecting and managing lockfiles across
 //! different package managers.
 
+use std::fmt::{self, Display};
 use std::path::PathBuf;
 
 use crate::package::{Error, PackageKind};
@@ -36,13 +37,6 @@ impl Lockfile {
         }
     }
 
-    /// Gets the contents of the lockfile.
-    pub fn get_contents(&self) -> String {
-        match self {
-            Self::Cargo(cargo) => cargo.get_contents(),
-        }
-    }
-
     /// Checks if the lockfile has been changed.
     pub fn is_changed(&self) -> bool {
         match self {
@@ -73,6 +67,14 @@ impl Lockfile {
     fn from_bytes(kind: PackageKind, bytes: &[u8]) -> Result<Self, Error> {
         match kind {
             PackageKind::Cargo => Ok(Self::Cargo(CargoLockfile::from_bytes(bytes)?)),
+        }
+    }
+}
+
+impl Display for Lockfile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cargo(cargo) => Display::fmt(cargo, f),
         }
     }
 }

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -12,6 +12,7 @@ mod lockfile;
 mod manifest;
 mod members;
 
+use std::fmt::{self, Display};
 use std::path::PathBuf;
 
 use semver::Version;
@@ -162,13 +163,6 @@ impl Package {
         }
     }
 
-    /// Gets the package contents.
-    pub fn get_contents(&self) -> String {
-        match self {
-            Self::Cargo(cargo) => cargo.get_contents(),
-        }
-    }
-
     /// Checks if the package has been changed.
     pub fn is_changed(&self) -> bool {
         match self {
@@ -201,6 +195,14 @@ impl Package {
         }
 
         Ok(packages)
+    }
+}
+
+impl Display for Package {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cargo(cargo) => Display::fmt(cargo, f),
+        }
     }
 }
 

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -309,7 +309,7 @@ impl Project {
         self.files
             .files()
             .filter(|(_, file)| file.is_changed())
-            .map(|(path, file)| (path.to_owned(), file.get_contents()))
+            .map(|(path, file)| (path.to_owned(), file.to_string()))
     }
 }
 


### PR DESCRIPTION
This implements `Display` for files to replace the various `get_contents` methods.

The current plan is for the project to only support a subset of files that are formatted as UTF-8 and can be converted to a string. This includes various configuration and documentation formats such as TOML, JSON and Markdown. Therefore using the `Display` trait and the associated `ToString` trait would be better here than using custom methods. If other types of files are required in the future then a `to_bytes` method might be more appropriate.

This change simply adds the `Display` implementation on the various file types and formats, as well as removes the various `get_contents` methods.