### PR TITLE
Add new `PackageRef` type to restore `path` method

### DIFF
--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -72,16 +72,16 @@ impl Info {
 
         let max_name_len = project
             .packages()
-            .map(|(_, pkg)| pkg.name().len())
+            .map(|pkg| pkg.name().len())
             .max()
             .unwrap_or_default();
         let max_version_len = project
             .packages()
-            .map(|(_, pkg)| pkg.version().len())
+            .map(|pkg| pkg.version().to_string().len())
             .max()
             .unwrap_or_default();
 
-        for (_, package) in project.packages() {
+        for package in project.packages() {
             println!(
                 "{:<max_name_len$}  {:>max_version_len$}  {}",
                 package.name(),

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -13,7 +13,8 @@ mod manifest;
 mod members;
 
 use std::fmt::{self, Display};
-use std::path::PathBuf;
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
 
 use semver::Version;
 
@@ -26,6 +27,42 @@ pub use self::error::Error;
 pub use self::kind::PackageKind;
 pub use self::lockfile::Lockfile;
 use self::manifest::Manifest;
+
+/// An immutable package reference.
+pub struct PackageRef<'a> {
+    pub(crate) package: &'a Package,
+    pub(crate) path: &'a Path,
+}
+
+impl<'a> PackageRef<'a> {
+    /// Gets the package name.
+    pub fn name(&self) -> &'a str {
+        self.package.name()
+    }
+
+    /// Gets the package description.
+    pub fn description(&self) -> Option<&str> {
+        self.package.description()
+    }
+
+    /// Gets the package version.
+    pub fn version(&self) -> Version {
+        self.package.version().parse().expect("version")
+    }
+
+    /// Gets the package path.
+    pub fn path(&self) -> &'a Path {
+        self.path
+    }
+}
+
+impl<'a> Deref for PackageRef<'a> {
+    type Target = Package;
+
+    fn deref(&self) -> &Self::Target {
+        self.package
+    }
+}
 
 /// A package in one of several supported formats.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -41,7 +41,7 @@ impl<'a> PackageRef<'a> {
     }
 
     /// Gets the package description.
-    pub fn description(&self) -> Option<&str> {
+    pub fn description(&self) -> Option<&'a str> {
         self.package.description()
     }
 

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -42,7 +42,7 @@ use semver::Version;
 use url::Url;
 
 use crate::file::Fileset;
-use crate::package::{Bump, Lockfile, Package};
+use crate::package::{Bump, Lockfile, PackageRef};
 use crate::repository::Repository;
 
 pub use self::error::Error;
@@ -205,9 +205,18 @@ impl Project {
         Ok(self.repository.get_url()?)
     }
 
+    /// Gets a package with the given name.
+    pub fn get_package(&self, name: impl AsRef<str>) -> Option<PackageRef<'_>> {
+        self.files
+            .get_package_by_name(name)
+            .map(|(path, package)| PackageRef { package, path })
+    }
+
     /// Gets the project packages.
-    pub fn packages(&self) -> impl Iterator<Item = (&Path, &Package)> {
-        self.files.packages()
+    pub fn packages(&self) -> impl Iterator<Item = PackageRef<'_>> {
+        self.files
+            .packages()
+            .map(|(path, package)| PackageRef { package, path })
     }
 
     // Gets the project lockfiles.

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -17,8 +17,8 @@ fn test_valid_local_project() -> Result<(), Error> {
     assert!(b.contains("[package]"));
     assert!(project.get_file_contents("packages/ploys").is_err());
 
-    assert!(project.packages().any(|(_, pkg)| pkg.name() == "ploys"));
-    assert!(project.packages().any(|(_, pkg)| pkg.name() == "ploys-cli"));
+    assert!(project.packages().any(|pkg| pkg.name() == "ploys"));
+    assert!(project.packages().any(|pkg| pkg.name() == "ploys-cli"));
 
     Ok(())
 }
@@ -44,8 +44,8 @@ fn test_valid_remote_project() -> Result<(), Error> {
     assert!(b.contains("[package]"));
     assert!(project.get_file_contents("packages/ploys").is_err());
 
-    assert!(project.packages().any(|(_, pkg)| pkg.name() == "ploys"));
-    assert!(project.packages().any(|(_, pkg)| pkg.name() == "ploys-cli"));
+    assert!(project.packages().any(|pkg| pkg.name() == "ploys"));
+    assert!(project.packages().any(|pkg| pkg.name() == "ploys-cli"));
 
     Ok(())
 }


### PR DESCRIPTION
This adds a new `PackageRef` type that wraps both a reference to a `Package` and a `Path`.

In #123 the `path` methods and fields were removed from files so that they no longer stored the file path. This eliminated a potential issue where the file path could be changed, invalidating any maps where the path is used as the key. However, the change caused more complexity in the code to deal with the path in a tuple.

This change adds a new wrapper type that combines a reference to a package and its path. This restores the previous functionality of being able to call the `path` method without needing to handle a tuple.

The new type can now be used an entry point for package-specific methods because it is also possible to store a reference back to the project in order to query other information such as actual dependencies.