### PR TITLE
Rename project package release initiate to request

### DIFF
--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -62,8 +62,8 @@ pub async fn receive(state: State<AppState>, payload: Payload) -> Result<(), Err
             _ => Ok(()),
         },
         Payload::RepositoryDispatch(payload) => match &*payload.action {
-            "ploys-package-release-initiate" => {
-                initiate_release(payload, &state).await?;
+            "ploys-package-release-request" => {
+                request_release(payload, &state).await?;
 
                 Ok(())
             }
@@ -274,11 +274,11 @@ async fn create_release(
     Ok(())
 }
 
-/// Initiates the release process.
+/// Requests the package release.
 ///
 /// This does not yet support parallel release branches so simply ensures that
 /// all new versions are greater than the previous.
-async fn initiate_release(
+async fn request_release(
     payload: RepositoryDispatchPayload,
     state: &AppState,
 ) -> Result<(), Error> {

--- a/packages/ploys-cli/src/package/release.rs
+++ b/packages/ploys-cli/src/package/release.rs
@@ -41,7 +41,7 @@ impl Release {
             self.token,
         )?;
 
-        project.initiate_package_release(self.package, self.version)?;
+        project.request_package_release(self.package, self.version)?;
 
         Ok(())
     }

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -352,12 +352,12 @@ impl Project {
         Err(Error::Unsupported)
     }
 
-    /// Initiates the release of the specified package version.
+    /// Requests the release of the specified package version.
     ///
     /// It does not yet support parallel release or hotfix branches and expects
     /// all development to be on the default branch in the repository settings.
     #[allow(unused_variables)]
-    pub fn initiate_package_release(
+    pub fn request_package_release(
         &self,
         package: impl AsRef<str>,
         version: impl Into<crate::package::BumpOrVersion>,
@@ -365,7 +365,7 @@ impl Project {
         #[cfg(feature = "github")]
         #[allow(irrefutable_let_patterns)]
         if let Repository::GitHub(github) = &self.repository {
-            github.initiate_package_release(package.as_ref(), version.into())?;
+            github.request_package_release(package.as_ref(), version.into())?;
 
             return Ok(());
         }

--- a/packages/ploys/src/repository/github/mod.rs
+++ b/packages/ploys/src/repository/github/mod.rs
@@ -239,8 +239,8 @@ impl GitHub {
         Ok(commit_sha)
     }
 
-    /// Initiates the release of the specified package version.
-    pub(crate) fn initiate_package_release(
+    /// Requests the release of the specified package version.
+    pub(crate) fn request_package_release(
         &self,
         package: &str,
         version: BumpOrVersion,
@@ -255,7 +255,7 @@ impl GitHub {
             .post("dispatches", self.token.as_deref())
             .set("X-GitHub-Api-Version", "2022-11-28")
             .send_json(RepositoryDispatchEvent {
-                event_type: String::from("ploys-package-release-initiate"),
+                event_type: String::from("ploys-package-release-request"),
                 client_payload: ClientPayload {
                     package: package.to_owned(),
                     version: version.to_string(),


### PR DESCRIPTION
This replaces the term *initiate* with *request* for package releases.

The project is in a state of constant flux as various APIs are being built and terminology is worked out. In #109 a new way of releasing packages was introduced using the term *initiate* to denote creating and handling a repository dispatch event. This term should be replaced with the new term *request*.

GitHub uses the term *Pull Request* and GitLab uses the term *Merge Request* for requesting changes to be committed to the target branch. The project currently uses Pull Requests to merge releases and in the future may support GitLab as an alternative remote. Therefore it seems sensible to use the term *Release Request* to refer to release pull requests.

This change simply replaces all occurrences of *initiate* with *request* and tweaks the documentation accordingly. This is a breaking change as the repository dispatch event name is also changed and so the current release of the CLI will no longer function to create releases. This is acceptable in the current state of the project and adding backwards compatibility is not an immediate concern.