### PR TITLE
Remove release branch creation webhook event handler

### DIFF
--- a/packages/ploys-api/src/github/webhook/payload.rs
+++ b/packages/ploys-api/src/github/webhook/payload.rs
@@ -21,7 +21,6 @@ use super::secret::WebhookSecret;
 
 /// The GitHub event payload.
 pub enum Payload {
-    Create(CreatePayload),
     PullRequest(PullRequestPayload),
     RepositoryDispatch(RepositoryDispatchPayload),
     Other(String, Value),
@@ -64,22 +63,11 @@ where
         let event = event.0.into_inner();
 
         Ok(match event.as_str() {
-            "create" => Self::Create(serde_json::from_slice(&bytes)?),
             "pull_request" => Self::PullRequest(serde_json::from_slice(&bytes)?),
             "repository_dispatch" => Self::RepositoryDispatch(serde_json::from_slice(&bytes)?),
             _ => Self::Other(event, serde_json::from_slice(&bytes)?),
         })
     }
-}
-
-/// The `create` webhook payload.
-#[derive(Debug, Deserialize)]
-pub struct CreatePayload {
-    pub r#ref: String,
-    pub ref_type: RefType,
-    pub master_branch: String,
-    pub repository: Repository,
-    pub installation: Installation,
 }
 
 /// The `pull_request` webhook payload.


### PR DESCRIPTION
This removes the release branch `create` webhook event handler.

The initial design of the release process involved creating the release branch locally with the GitHub App listening for the branch to be created on the remote. This evolved to sending a repository dispatch event for the App to create the release branch. However, the process was still split across multiple events with the App listening to the `create` event that it triggered itself. This adds some overhead in the release process as it needs to duplicate some logic with each request.

The removal of this is necessary before any further changes are made to improve the logic as it would otherwise interfere with the release process.

This change removes the `create` event handler and instead calls the `create_release_pull_request` function directly upon receiving the `ploys-package-release-request` repository dispatch event. This does not eliminate the duplicate logic or alter the logic of `create_release_pull_request` function in any way and instead spawns a new task to create the pull request immediately instead of waiting for the next event. The `tokio::task::spawn` call is important to avoid the request timeout as it does not yet use an event queue.