### PR TITLE
Add `Remote` repository trait

### DIFF
--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -4,6 +4,7 @@
 //! located on the local file system or in a remote version control system.
 
 mod error;
+mod remote;
 
 #[cfg(feature = "git")]
 pub mod git;
@@ -11,7 +12,6 @@ pub mod git;
 #[cfg(feature = "github")]
 pub mod github;
 
-#[cfg(any(feature = "git", feature = "github"))]
 pub mod revision;
 
 use std::path::{Path, PathBuf};
@@ -22,6 +22,7 @@ use crate::file::Fileset;
 use crate::package::{Lockfile, Package};
 
 pub use self::error::Error;
+pub(crate) use self::remote::Remote;
 
 /// A source code repository.
 pub enum Repository {

--- a/packages/ploys/src/repository/remote.rs
+++ b/packages/ploys/src/repository/remote.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+use semver::Version;
+
+use crate::changelog::Release;
+use crate::package::BumpOrVersion;
+
+use super::revision::Revision;
+use super::Error;
+
+/// A remote repository.
+///
+/// This defines the shared API of a remote repository to simplify feature flag
+/// handling.
+pub trait Remote {
+    /// Gets the revision.
+    fn revision(&self) -> &Revision;
+
+    /// Sets the revision.
+    fn set_revision(&mut self, revision: Revision);
+
+    /// Commits the changes to the repository.
+    fn commit(&self, message: &str, files: Vec<(PathBuf, String)>) -> Result<String, Error>;
+
+    /// Requests a package release.
+    fn request_package_release(&self, package: &str, version: BumpOrVersion) -> Result<(), Error>;
+
+    /// Gets the changelog release for the given package version.
+    fn get_changelog_release(
+        &self,
+        package: &str,
+        version: Version,
+        is_primary: bool,
+    ) -> Result<Release, Error>;
+}


### PR DESCRIPTION
This adds an internal `Remote` repository trait to simplify feature flag handling.

The `GitHub` repository type is enabled via a feature flag and is currently the only supported remote as `GitLab` and other repositories are not on the current roadmap. When disabled, there is no functionality to support various methods such as requesting a package release. This requires ugly `cfg` attributes to conditionally enable parts of the codebase. By swapping to a trait object it is possible to write much of the code without conditional compilation.

This change introduces a new `Remote` trait that is not exposed to users and moves various repository methods to it. The `Project::get_remote` and `Project::get_remote_mut` methods have been introduced to return trait objects to isolate the conditional compilation to a single location. Now the methods always exist regardless of features but the implementation comes from enabling the `github` feature.