### PR TITLE
Add `Remote::update_branch` method

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -337,8 +337,13 @@ impl Project {
         let remote = self.get_remote_mut().ok_or(Error::Unsupported)?;
         let sha = remote.commit(message.as_ref(), files)?;
 
-        if !matches!(remote.revision(), Revision::Reference(Reference::Branch(_))) {
-            remote.set_revision(Revision::sha(sha.clone()));
+        match remote.revision() {
+            Revision::Reference(Reference::Branch(branch)) => {
+                remote.update_branch(branch, &sha)?;
+            }
+            _ => {
+                remote.set_revision(Revision::sha(sha.clone()));
+            }
         }
 
         Ok(sha)

--- a/packages/ploys/src/repository/remote.rs
+++ b/packages/ploys/src/repository/remote.rs
@@ -32,4 +32,7 @@ pub trait Remote {
         version: Version,
         is_primary: bool,
     ) -> Result<Release, Error>;
+
+    /// Updates the branch to point to the given SHA.
+    fn update_branch(&self, name: &str, sha: &str) -> Result<(), Error>;
 }


### PR DESCRIPTION
This adds a new `Remote::update_branch` trait method to update the branch outside of the `commit` method.

The implementation of `Remote::commit` currently checks if the project is set to a branch and automatically updates the reference to point to the new commit. This works for the current usage of `commit` but not for other planned changes.

This change introduces the new `Remote::update_branch` method, removes the branch check from `Remote::commit`, and updates the `Project::commit` logic to manually update the branch if set.