### PR TITLE
Add project package release request builder

### DIFF
--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -29,7 +29,7 @@ pub use self::error::Error;
 pub use self::kind::PackageKind;
 pub use self::lockfile::Lockfile;
 use self::manifest::Manifest;
-pub use self::release::ReleaseRequestBuilder;
+pub use self::release::{ReleaseRequest, ReleaseRequestBuilder};
 
 /// An immutable package reference.
 #[derive(Clone, Copy)]

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -11,6 +11,7 @@ mod kind;
 mod lockfile;
 mod manifest;
 mod members;
+mod release;
 
 use std::fmt::{self, Display};
 use std::ops::Deref;
@@ -18,6 +19,7 @@ use std::path::{Path, PathBuf};
 
 use semver::Version;
 
+use crate::project::Project;
 use crate::repository::Repository;
 
 pub use self::bump::{Bump, BumpOrVersion, Error as BumpError};
@@ -27,11 +29,14 @@ pub use self::error::Error;
 pub use self::kind::PackageKind;
 pub use self::lockfile::Lockfile;
 use self::manifest::Manifest;
+pub use self::release::ReleaseRequestBuilder;
 
 /// An immutable package reference.
+#[derive(Clone, Copy)]
 pub struct PackageRef<'a> {
     pub(crate) package: &'a Package,
     pub(crate) path: &'a Path,
+    pub(crate) project: &'a Project,
 }
 
 impl<'a> PackageRef<'a> {
@@ -53,6 +58,24 @@ impl<'a> PackageRef<'a> {
     /// Gets the package path.
     pub fn path(&self) -> &'a Path {
         self.path
+    }
+
+    /// Checks if this is the primary package.
+    ///
+    /// A primary package shares the same name as the project and all releases
+    /// are tagged under the version number without the package name prefix.
+    pub fn is_primary(&self) -> bool {
+        self.package.name() == self.project.name()
+    }
+}
+
+impl<'a> PackageRef<'a> {
+    /// Constructs a new release request builder.
+    pub fn create_release_request(
+        self,
+        version: impl Into<BumpOrVersion>,
+    ) -> ReleaseRequestBuilder<'a> {
+        ReleaseRequestBuilder::new(self, version.into())
     }
 }
 

--- a/packages/ploys/src/package/release.rs
+++ b/packages/ploys/src/package/release.rs
@@ -1,0 +1,232 @@
+use semver::Version;
+
+use crate::changelog::{Changelog, Release};
+
+use super::{BumpOrVersion, PackageRef};
+
+/// The release request.
+pub struct ReleaseRequest<'a> {
+    #[allow(dead_code)]
+    package: PackageRef<'a>,
+    id: u64,
+    title: String,
+    notes: Release,
+    version: Version,
+}
+
+impl<'a> ReleaseRequest<'a> {
+    /// Gets the release request id.
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    /// Gets the release request title.
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    /// Gets the release request notes.
+    pub fn notes(&self) -> &Release {
+        &self.notes
+    }
+
+    /// Gets the release request version.
+    pub fn version(&self) -> &Version {
+        &self.version
+    }
+}
+
+/// The release request builder.
+///
+/// This configures the release request that will be generated on the remote
+/// repository.
+pub struct ReleaseRequestBuilder<'a> {
+    package: PackageRef<'a>,
+    version: BumpOrVersion,
+    options: Options,
+}
+
+impl<'a> ReleaseRequestBuilder<'a> {
+    /// Constructs a new release request builder.
+    pub(super) fn new(package: PackageRef<'a>, version: BumpOrVersion) -> Self {
+        Self {
+            package,
+            version,
+            options: Options::default(),
+        }
+    }
+
+    /// Update the package manifest.
+    pub fn update_package_manifest(mut self, enable: bool) -> Self {
+        self.options.update_package_manifest = enable;
+        self
+    }
+
+    /// Update the dependent package manifests.
+    pub fn update_dependent_package_manifests(mut self, enable: bool) -> Self {
+        self.options.update_dependent_package_manifests = enable;
+        self
+    }
+
+    /// Update the workspace lockfile.
+    pub fn update_lockfile(mut self, enable: bool) -> Self {
+        self.options.update_lockfile = enable;
+        self
+    }
+
+    /// Update the package changelog.
+    pub fn update_changelog(mut self, enable: bool) -> Self {
+        self.options.update_changelog = enable;
+        self
+    }
+
+    /// Finishes the release request.
+    pub fn finish(self) -> Result<ReleaseRequest<'a>, crate::project::Error> {
+        let Some(remote) = self.package.project.get_remote() else {
+            return Err(crate::project::Error::Unsupported);
+        };
+
+        let mut files = Vec::new();
+        let mut package = self.package.package.clone();
+
+        let version = match self.version {
+            BumpOrVersion::Bump(bump) => {
+                package.bump(bump).expect("bump");
+                package.version().parse().expect("version")
+            }
+            BumpOrVersion::Version(version) => {
+                package.set_version(version.clone());
+                version
+            }
+        };
+
+        if self.options.update_package_manifest {
+            files.push((self.package.path().to_owned(), package.to_string()));
+        }
+
+        if self.options.update_dependent_package_manifests {
+            for package in self.package.project.packages() {
+                if package.name() == self.package.name() {
+                    continue;
+                }
+
+                let mut pkg = package.package.clone();
+                let mut changed = false;
+
+                if let Some(mut dependency) = pkg.get_dependency_mut(self.package.name()) {
+                    dependency.set_version(version.to_string());
+                    changed = true;
+                }
+
+                if let Some(mut dependency) = pkg.get_dev_dependency_mut(self.package.name()) {
+                    dependency.set_version(version.to_string());
+                    changed = true;
+                }
+
+                if let Some(mut dependency) = pkg.get_build_dependency_mut(self.package.name()) {
+                    dependency.set_version(version.to_string());
+                    changed = true;
+                }
+
+                if changed {
+                    files.push((package.path().to_owned(), pkg.to_string()));
+                }
+            }
+        }
+
+        if self.options.update_lockfile {
+            if let Some((path, lockfile)) = self
+                .package
+                .project
+                .lockfiles()
+                .find(|(_, lockfile)| lockfile.kind() == self.package.kind())
+            {
+                let mut lockfile = lockfile.clone();
+
+                lockfile.set_package_version(self.package.name(), version.to_string());
+                files.push((path.to_owned(), lockfile.to_string()));
+            }
+        }
+
+        let mut release = self
+            .package
+            .project
+            .get_changelog_release(self.package.name(), version.to_string())?;
+
+        if self.options.update_changelog {
+            let path = self
+                .package
+                .path()
+                .parent()
+                .expect("parent")
+                .join("CHANGELOG.md");
+
+            let mut changelog = match self.package.project.get_file_contents(&path).ok() {
+                Some(bytes) => match String::from_utf8(bytes).ok() {
+                    Some(string) => string.parse::<Changelog>().expect("changelog"),
+                    None => Changelog::new(),
+                },
+                None => Changelog::new(),
+            };
+
+            changelog.add_release(release.clone());
+            files.push((path, changelog.to_string()));
+        }
+
+        release.set_description(format!(
+            "Releasing package `{}` version `{version}`.",
+            self.package.name()
+        ));
+
+        if let Some(url) = release.url() {
+            release.add_reference(version.to_string(), url.to_string());
+        }
+
+        let body = release.to_string();
+        let title = match self.package.is_primary() {
+            true => format!("Release `{version}`"),
+            false => format!("Release `{}@{version}`", self.package.name()),
+        };
+        let branch = match self.package.is_primary() {
+            true => format!("release/{version}"),
+            false => format!("release/{}-{version}", self.package.name()),
+        };
+
+        let default_branch = remote.get_default_branch()?;
+
+        remote.create_branch(&branch)?;
+
+        let sha = remote.commit(&title, files)?;
+
+        remote.update_branch(&branch, &sha)?;
+
+        let id = remote.create_pull_request(&branch, &default_branch, &title, &body)?;
+
+        Ok(ReleaseRequest {
+            package: self.package,
+            id,
+            title,
+            notes: release,
+            version,
+        })
+    }
+}
+
+/// The release request options.
+struct Options {
+    update_package_manifest: bool,
+    update_dependent_package_manifests: bool,
+    update_lockfile: bool,
+    update_changelog: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            update_package_manifest: true,
+            update_dependent_package_manifests: true,
+            update_lockfile: true,
+            update_changelog: true,
+        }
+    }
+}

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -210,14 +210,20 @@ impl Project {
     pub fn get_package(&self, name: impl AsRef<str>) -> Option<PackageRef<'_>> {
         self.files
             .get_package_by_name(name)
-            .map(|(path, package)| PackageRef { package, path })
+            .map(|(path, package)| PackageRef {
+                package,
+                path,
+                project: self,
+            })
     }
 
     /// Gets the project packages.
     pub fn packages(&self) -> impl Iterator<Item = PackageRef<'_>> {
-        self.files
-            .packages()
-            .map(|(path, package)| PackageRef { package, path })
+        self.files.packages().map(|(path, package)| PackageRef {
+            package,
+            path,
+            project: self,
+        })
     }
 
     // Gets the project lockfiles.

--- a/packages/ploys/src/repository/remote.rs
+++ b/packages/ploys/src/repository/remote.rs
@@ -33,6 +33,21 @@ pub trait Remote {
         is_primary: bool,
     ) -> Result<Release, Error>;
 
+    /// Gets the default branch.
+    fn get_default_branch(&self) -> Result<String, Error>;
+
+    /// Creates a new branch.
+    fn create_branch(&self, name: &str) -> Result<(), Error>;
+
     /// Updates the branch to point to the given SHA.
     fn update_branch(&self, name: &str, sha: &str) -> Result<(), Error>;
+
+    /// Creates a pull request.
+    fn create_pull_request(
+        &self,
+        head: &str,
+        base: &str,
+        title: &str,
+        body: &str,
+    ) -> Result<u64, Error>;
 }


### PR DESCRIPTION
This moves the logic of creating a release request from the backend to a new release request builder type.

The `ploys` library and `ploys-api` server are using a mix of blocking and async requests and the logic is split across both packages inconsistently. Much of the logic should be moved to the library with the server simply calling the appropriate APIs depending on the incoming webhook event. One such API is the ability to create a release request.

This change introduces the concept of a release request builder that allows users to configure how a release (pull) request is created. The various REST API calls have been moved to `Remote` trait methods with the `ReleaseRequestBuilder::finish` method combining the various calls.

The new API is as follows:

```rust
project
    .get_package(package)
    .unwrap()
    .create_release_request(version)
    .update_package_manifest(true)
    .update_dependent_package_manifests(true)
    .update_lockfile(true)
    .update_changelog(true)
    .finish()
    .unwrap();
```

The various update options default to `true` but in the future, once #48 lands, it should be possible to configure the defaults in the project configuration.

This also updates the `ploys-api` package to call this new API in a `tokio::task::spawn_blocking` call until the library can be updated with async support.