### PR TITLE
Remove `Project::commit` method

### DIFF
--- a/packages/ploys/src/repository/github/mod.rs
+++ b/packages/ploys/src/repository/github/mod.rs
@@ -180,14 +180,6 @@ impl GitHub {
 }
 
 impl Remote for GitHub {
-    fn revision(&self) -> &Revision {
-        &self.revision
-    }
-
-    fn set_revision(&mut self, revision: Revision) {
-        self.revision = revision;
-    }
-
     fn commit(&self, message: &str, files: Vec<(PathBuf, String)>) -> Result<String, super::Error> {
         #[derive(Serialize)]
         struct CreateBlob {

--- a/packages/ploys/src/repository/remote.rs
+++ b/packages/ploys/src/repository/remote.rs
@@ -5,7 +5,6 @@ use semver::Version;
 use crate::changelog::Release;
 use crate::package::BumpOrVersion;
 
-use super::revision::Revision;
 use super::Error;
 
 /// A remote repository.
@@ -13,12 +12,6 @@ use super::Error;
 /// This defines the shared API of a remote repository to simplify feature flag
 /// handling.
 pub trait Remote {
-    /// Gets the revision.
-    fn revision(&self) -> &Revision;
-
-    /// Sets the revision.
-    fn set_revision(&mut self, revision: Revision);
-
     /// Commits the changes to the repository.
     fn commit(&self, message: &str, files: Vec<(PathBuf, String)>) -> Result<String, Error>;
 


### PR DESCRIPTION
This removes the `Project::commit` method and other unused methods that it depended on.

The `Project` type is undergoing a major change to add support for configuration files in #48. This includes a major redesign of which APIs are exposed and how changes to project files are made. With the introduction of #134 there is no longer a requirement for exposing a `commit` method to users. The library is not meant to be a *git* client or only support *git* as a version control system and so hiding those details now that they are no longer required by other packages in the workspace is the best course of action.

This change simply removes the `Project::commit` method and various other methods that became unused after removal, including `Project::get_remote_mut`, `Remote::revision` and `Remote::set_revision`.