### PR TITLE
Remove `Project` package version mutation methods

### DIFF
--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -135,11 +135,6 @@ impl Cargo {
     pub fn is_changed(&self) -> bool {
         self.changed
     }
-
-    /// Sets the package as changed.
-    pub(crate) fn set_changed(&mut self, changed: bool) {
-        self.changed = changed;
-    }
 }
 
 impl Display for Cargo {

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -229,13 +229,6 @@ impl Package {
             Self::Cargo(cargo) => cargo.is_changed(),
         }
     }
-
-    /// Sets the package as changed.
-    pub(crate) fn set_changed(&mut self, changed: bool) {
-        match self {
-            Self::Cargo(cargo) => cargo.set_changed(changed),
-        }
-    }
 }
 
 impl Package {


### PR DESCRIPTION
This removes the `Project::set_package_version` and `Project::bump_package_version` methods.

The introduction of the release request builder in #134 means that the package version mutation methods are no longer required to be exposed on the `Project` type and can therefore be removed. This is part of an ongoing plan to redesign the project type to no longer store mutable files, requiring that all changes go through an intermediate type, such as the release request builder.

This change simply removes the `Project::set_package_version` and `Project::bump_package_version` methods as well as the unused `set_changed` methods.