### PR TITLE
Remove notion of changed files

### DIFF
--- a/packages/ploys/src/file/mod.rs
+++ b/packages/ploys/src/file/mod.rs
@@ -45,14 +45,6 @@ impl File {
             _ => None,
         }
     }
-
-    /// Checks if the file has been changed.
-    pub(crate) fn is_changed(&self) -> bool {
-        match self {
-            Self::Package(package) => package.is_changed(),
-            Self::Lockfile(lockfile) => lockfile.is_changed(),
-        }
-    }
 }
 
 impl Display for File {

--- a/packages/ploys/src/package/cargo/lockfile.rs
+++ b/packages/ploys/src/package/cargo/lockfile.rs
@@ -10,7 +10,6 @@ use crate::package::cargo::Error;
 #[derive(Clone, Debug)]
 pub struct CargoLockfile {
     manifest: DocumentMut,
-    changed: bool,
 }
 
 impl CargoLockfile {
@@ -22,20 +21,13 @@ impl CargoLockfile {
     {
         if let Some(mut package) = self.packages_mut().get_mut(package.as_ref()) {
             package.set_version(version);
-            self.changed = true;
         }
-    }
-
-    /// Checks if the lockfile has been changed.
-    pub fn is_changed(&self) -> bool {
-        self.changed
     }
 
     /// Creates a manifest from the given bytes.
     pub(crate) fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         Ok(Self {
             manifest: std::str::from_utf8(bytes)?.parse()?,
-            changed: false,
         })
     }
 

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -15,19 +15,15 @@ use self::manifest::Manifest;
 use super::{Bump, BumpError};
 
 /// A `Cargo.toml` package for Rust.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Cargo {
     manifest: Manifest,
-    changed: bool,
 }
 
 impl Cargo {
     /// Creates a new cargo package.
     fn new(manifest: Manifest) -> Self {
-        Self {
-            manifest,
-            changed: false,
-        }
+        Self { manifest }
     }
 
     /// Gets the package name.
@@ -54,7 +50,6 @@ impl Cargo {
             .package_mut()
             .expect("package")
             .set_version(version);
-        self.changed = true;
         self
     }
 
@@ -130,11 +125,6 @@ impl Cargo {
     pub fn build_dependencies_mut(&mut self) -> DependenciesMut<'_> {
         self.manifest.build_dependencies_mut()
     }
-
-    /// Checks if the package has been changed.
-    pub fn is_changed(&self) -> bool {
-        self.changed
-    }
 }
 
 impl Display for Cargo {
@@ -142,11 +132,3 @@ impl Display for Cargo {
         Display::fmt(&self.manifest, f)
     }
 }
-
-impl PartialEq for Cargo {
-    fn eq(&self, other: &Self) -> bool {
-        self.manifest == other.manifest
-    }
-}
-
-impl Eq for Cargo {}

--- a/packages/ploys/src/package/lockfile.rs
+++ b/packages/ploys/src/package/lockfile.rs
@@ -37,13 +37,6 @@ impl Lockfile {
         }
     }
 
-    /// Checks if the lockfile has been changed.
-    pub fn is_changed(&self) -> bool {
-        match self {
-            Self::Cargo(cargo) => cargo.is_changed(),
-        }
-    }
-
     /// Discovers project lockfiles.
     pub(crate) fn discover_lockfiles(
         repository: &Repository,

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -222,13 +222,6 @@ impl Package {
             Self::Cargo(cargo) => DependenciesMut::Cargo(cargo.build_dependencies_mut()),
         }
     }
-
-    /// Checks if the package has been changed.
-    pub fn is_changed(&self) -> bool {
-        match self {
-            Self::Cargo(cargo) => cargo.is_changed(),
-        }
-    }
 }
 
 impl Package {

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -36,7 +36,7 @@
 
 mod error;
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use semver::Version;
 use url::Url;
@@ -239,14 +239,6 @@ impl Project {
         P: AsRef<Path>,
     {
         Ok(self.repository.get_file_contents(path)?)
-    }
-
-    /// Gets the changed files.
-    pub fn get_changed_files(&self) -> impl Iterator<Item = (PathBuf, String)> + '_ {
-        self.files
-            .files()
-            .filter(|(_, file)| file.is_changed())
-            .map(|(path, file)| (path.to_owned(), file.to_string()))
     }
 }
 


### PR DESCRIPTION
This removes the notion of changed files in the project.

The initial implementation of the `Project` type acted as a base for all changes to the project and so required a means of tracking file changes in order to commit only changed files. Although the change status was stored in the files themselves only some mutation methods marked the file as changed and so it was not really a long term solution. However, the current goal is to remove file mutation from the project type in favour of tracking it external structs such as the release request builder introduced in #134.

This change simply removes the `Project::get_changed_files` method, the various `changed` fields, and the `is_changed` methods. It also swaps the `PartialEq` and `Eq` implementations to derives where the `changed` field would have caused an incorrect comparison.