### PR TITLE
Add `File::Changelog` enum variant

### DIFF
--- a/packages/ploys/src/changelog/mod.rs
+++ b/packages/ploys/src/changelog/mod.rs
@@ -22,7 +22,7 @@ pub use self::text::{MultilineText, Text};
 /// This uses the [keep a changelog](https://keepachangelog.com) format to parse
 /// and generate changelogs. There is very limited support for deviation from
 /// this format so the changelog should not yet be manually edited.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Changelog(Node);
 
 impl Changelog {

--- a/packages/ploys/src/file/mod.rs
+++ b/packages/ploys/src/file/mod.rs
@@ -2,6 +2,7 @@ mod fileset;
 
 use std::fmt::{self, Display};
 
+use crate::changelog::Changelog;
 use crate::package::{Lockfile, Package};
 
 pub use self::fileset::Fileset;
@@ -11,6 +12,7 @@ pub use self::fileset::Fileset;
 pub enum File {
     Package(Package),
     Lockfile(Lockfile),
+    Changelog(Changelog),
 }
 
 impl File {
@@ -45,6 +47,22 @@ impl File {
             _ => None,
         }
     }
+
+    /// Gets the file as a changelog.
+    pub fn as_changelog(&self) -> Option<&Changelog> {
+        match self {
+            Self::Changelog(changelog) => Some(changelog),
+            _ => None,
+        }
+    }
+
+    /// Gets the file as a mutable changelog.
+    pub fn as_changelog_mut(&mut self) -> Option<&mut Changelog> {
+        match self {
+            Self::Changelog(changelog) => Some(changelog),
+            _ => None,
+        }
+    }
 }
 
 impl Display for File {
@@ -52,6 +70,7 @@ impl Display for File {
         match self {
             Self::Package(package) => Display::fmt(package, f),
             Self::Lockfile(lockfile) => Display::fmt(lockfile, f),
+            Self::Changelog(changelog) => Display::fmt(changelog, f),
         }
     }
 }
@@ -65,5 +84,11 @@ impl From<Package> for File {
 impl From<Lockfile> for File {
     fn from(value: Lockfile) -> Self {
         Self::Lockfile(value)
+    }
+}
+
+impl From<Changelog> for File {
+    fn from(value: Changelog) -> Self {
+        Self::Changelog(value)
     }
 }


### PR DESCRIPTION
This adds the `Changelog` type as a `File` enum variant.

Now that the notion of changed files has been removed in #137 it is possible to add the changelog as a supported file type without adding the ability to mark changelogs as changed.

This change simply adds the new variant, adds `PartialEq` and `Eq` derives to the `Changelog` type, adds the `From` implementation for converting from the `Changelog` type, and adds `as_changelog` and `as_changelog_mut` methods to mirror the other variant methods. This does not yet include a way to use this new variant inside of a `Project`.