### PR TITLE
Derive `strum::EnumIter` for `PackageKind`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2651,6 +2651,7 @@ dependencies = [
  "pretty_assertions",
  "semver",
  "serde",
+ "strum 0.26.3",
  "time",
  "toml_edit",
  "ureq",
@@ -3455,7 +3456,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "strum 0.26.2",
+ "strum 0.26.3",
  "thiserror",
  "tower",
  "tracing",
@@ -3640,9 +3641,9 @@ checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros 0.26.4",
 ]

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -19,6 +19,7 @@ globset = "0.4.13"
 markdown = "=1.0.0-alpha.21"
 semver = "1.0.19"
 serde = { version = "1.0.185", features = ["derive"] }
+strum = { version = "0.26.3", features = ["derive"] }
 time = { version = "0.3.36", features = ["serde", "formatting", "parsing"] }
 toml_edit = { version = "0.22.14", features = ["serde"] }
 ureq = { version = "2.7.1", features = ["json"], optional = true }

--- a/packages/ploys/src/package/kind.rs
+++ b/packages/ploys/src/package/kind.rs
@@ -1,18 +1,15 @@
 use std::path::Path;
 
+use strum::EnumIter;
+
 /// The package kind.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, EnumIter)]
 pub enum PackageKind {
     /// The cargo package kind.
     Cargo,
 }
 
 impl PackageKind {
-    /// Gets the package variants.
-    pub(super) fn variants() -> &'static [Self] {
-        &[Self::Cargo]
-    }
-
     /// Gets the package file name.
     pub fn file_name(&self) -> &'static Path {
         match self {

--- a/packages/ploys/src/package/lockfile.rs
+++ b/packages/ploys/src/package/lockfile.rs
@@ -6,6 +6,8 @@
 use std::fmt::{self, Display};
 use std::path::PathBuf;
 
+use strum::IntoEnumIterator;
+
 use crate::package::{Error, PackageKind};
 use crate::repository::Repository;
 
@@ -43,10 +45,10 @@ impl Lockfile {
     ) -> Result<Vec<(PathBuf, Self)>, crate::project::Error> {
         let mut lockfiles = Vec::new();
 
-        for kind in PackageKind::variants() {
+        for kind in PackageKind::iter() {
             if let Some(lockfile_name) = kind.lockfile_name() {
                 if let Ok(bytes) = repository.get_file_contents(lockfile_name) {
-                    let lockfile = Lockfile::from_bytes(*kind, &bytes)?;
+                    let lockfile = Lockfile::from_bytes(kind, &bytes)?;
 
                     lockfiles.push((lockfile_name.to_owned(), lockfile));
                 }

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -18,6 +18,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
 use semver::Version;
+use strum::IntoEnumIterator;
 
 use crate::project::Project;
 use crate::repository::Repository;
@@ -232,9 +233,9 @@ impl Package {
         let files = repository.get_files()?;
         let mut packages = Vec::new();
 
-        for kind in PackageKind::variants() {
+        for kind in PackageKind::iter() {
             if let Ok(bytes) = repository.get_file_contents(kind.file_name()) {
-                let manifest = Manifest::from_bytes(*kind, &bytes)?;
+                let manifest = Manifest::from_bytes(kind, &bytes)?;
 
                 packages.extend(manifest.discover_packages(&files, repository)?);
             }


### PR DESCRIPTION
This introduces the `strum` crate to derive `EnumIter` for `PackageKind`.

The `PackageKind` enum currently only supports a single type of package but the plan is to eventually support other package managers such as *NPM* and *Composer*. Package discovery currently relies on a `PackageKind::variants` associated function to iterate over the supported package types. This function must be kept in sync with the enum variants and so using a crate like `strum` to automatically derive this will avoid any issues.

This change simply adds the `strum` crate as a dependency with the `derive` feature enabled, derives `EnumIter` for `PackageKind`, and removes the `variants` function. The crate is already in the dependency tree due to `shuttle-common` and so should provide little development overhead.