### PR TITLE
Export updated `Manifest` and `CargoManifest` types

### DIFF
--- a/packages/ploys/src/file/mod.rs
+++ b/packages/ploys/src/file/mod.rs
@@ -3,7 +3,7 @@ mod fileset;
 use std::fmt::{self, Display};
 
 use crate::changelog::Changelog;
-use crate::package::{Lockfile, Package};
+use crate::package::{Lockfile, Manifest, Package};
 
 pub use self::fileset::Fileset;
 
@@ -11,6 +11,7 @@ pub use self::fileset::Fileset;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum File {
     Package(Package),
+    Manifest(Manifest),
     Lockfile(Lockfile),
     Changelog(Changelog),
 }
@@ -28,6 +29,22 @@ impl File {
     pub fn as_package_mut(&mut self) -> Option<&mut Package> {
         match self {
             Self::Package(package) => Some(package),
+            _ => None,
+        }
+    }
+
+    /// Gets the file as a package manifest.
+    pub fn as_manifest(&self) -> Option<&Manifest> {
+        match self {
+            Self::Manifest(manifest) => Some(manifest),
+            _ => None,
+        }
+    }
+
+    /// Gets the file as a mutable package manifest.
+    pub fn as_manifest_mut(&mut self) -> Option<&mut Manifest> {
+        match self {
+            Self::Manifest(manifest) => Some(manifest),
             _ => None,
         }
     }
@@ -69,6 +86,7 @@ impl Display for File {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Package(package) => Display::fmt(package, f),
+            Self::Manifest(manifest) => Display::fmt(manifest, f),
             Self::Lockfile(lockfile) => Display::fmt(lockfile, f),
             Self::Changelog(changelog) => Display::fmt(changelog, f),
         }
@@ -78,6 +96,12 @@ impl Display for File {
 impl From<Package> for File {
     fn from(value: Package) -> Self {
         Self::Package(value)
+    }
+}
+
+impl From<Manifest> for File {
+    fn from(value: Manifest) -> Self {
+        Self::Manifest(value)
     }
 }
 

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -12,9 +12,9 @@ use super::Cargo;
 
 /// The cargo package manifest.
 #[derive(Clone, Debug)]
-pub struct Manifest(pub(super) DocumentMut);
+pub struct CargoManifest(DocumentMut);
 
-impl Manifest {
+impl CargoManifest {
     /// Gets the workspace table.
     pub fn workspace(&self) -> Option<Workspace<'_>> {
         match self.0.get("workspace") {
@@ -134,19 +134,19 @@ impl Manifest {
     }
 }
 
-impl Display for Manifest {
+impl Display for CargoManifest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.0, f)
     }
 }
 
-impl PartialEq for Manifest {
+impl PartialEq for CargoManifest {
     fn eq(&self, other: &Self) -> bool {
         self.0.to_string() == other.0.to_string()
     }
 }
 
-impl Eq for Manifest {}
+impl Eq for CargoManifest {}
 
 /// The workspace table.
 pub struct Workspace<'a>(&'a dyn TableLike);

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -3,26 +3,26 @@
 mod dependency;
 mod error;
 mod lockfile;
-pub(super) mod manifest;
+mod manifest;
 
 use std::fmt::{self, Display};
 
 pub use self::dependency::{Dependencies, DependenciesMut, Dependency, DependencyMut};
 pub use self::error::Error;
 pub use self::lockfile::CargoLockfile;
-use self::manifest::Manifest;
+pub use self::manifest::CargoManifest;
 
 use super::{Bump, BumpError};
 
 /// A `Cargo.toml` package for Rust.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Cargo {
-    manifest: Manifest,
+    manifest: CargoManifest,
 }
 
 impl Cargo {
     /// Creates a new cargo package.
-    fn new(manifest: Manifest) -> Self {
+    fn new(manifest: CargoManifest) -> Self {
         Self { manifest }
     }
 

--- a/packages/ploys/src/package/manifest.rs
+++ b/packages/ploys/src/package/manifest.rs
@@ -1,14 +1,17 @@
+use std::fmt::{self, Display};
 use std::path::{Path, PathBuf};
+
+use strum::{EnumIs, EnumTryAs};
 
 use crate::repository::Repository;
 
-use super::cargo::manifest::Manifest as CargoManifest;
+use super::cargo::CargoManifest;
 use super::error::Error;
 use super::members::Members;
 use super::{Package, PackageKind};
 
 /// The package manifest.
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, EnumIs, EnumTryAs)]
 pub enum Manifest {
     /// A cargo package manifest.
     Cargo(CargoManifest),
@@ -23,7 +26,7 @@ impl Manifest {
     }
 
     /// Gets the file name for the manifest.
-    pub fn file_name(&self) -> &'static Path {
+    pub(crate) fn file_name(&self) -> &'static Path {
         self.package_kind().file_name()
     }
 
@@ -43,7 +46,7 @@ impl Manifest {
     }
 
     /// Finds member packages using the closure to query individual paths.
-    pub fn discover_packages(
+    pub(crate) fn discover_packages(
         self,
         files: &[PathBuf],
         repository: &Repository,
@@ -88,5 +91,13 @@ impl Manifest {
         Some(match self {
             Self::Cargo(manifest) => Package::Cargo(manifest.into_package()?),
         })
+    }
+}
+
+impl Display for Manifest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cargo(cargo) => Display::fmt(cargo, f),
+        }
     }
 }

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -29,7 +29,7 @@ pub use self::dependency::{Dependencies, DependenciesMut, Dependency, Dependency
 pub use self::error::Error;
 pub use self::kind::PackageKind;
 pub use self::lockfile::Lockfile;
-use self::manifest::Manifest;
+pub use self::manifest::Manifest;
 pub use self::release::{ReleaseRequest, ReleaseRequestBuilder};
 
 /// An immutable package reference.


### PR DESCRIPTION
This exposes updated `Manifest` and `CargoManifest` types to users of the library.

The various manifest types are internally used by the package types and not exported to users of the library. These should be updated with additional functionality and exposed as available file types.

This change renames the cargo-specific `Manifest` type to `CargoManifest` to match the naming convention used for the `CargoLockfile` type, publicly exports both manifest types from the library, adds a `File::Manifest` variant, and adds various derives and trait implementations.