### PR TITLE
Remove `Fileset::get_package_by_name` methods

### DIFF
--- a/packages/ploys/src/file/fileset.rs
+++ b/packages/ploys/src/file/fileset.rs
@@ -55,21 +55,6 @@ impl Fileset {
         self.files.get_mut(path.as_ref())?.as_mut()
     }
 
-    /// Gets a package with the given name.
-    pub fn get_package_by_name(&self, name: impl AsRef<str>) -> Option<(&Path, &Package)> {
-        self.packages()
-            .find(|(_, package)| package.name() == name.as_ref())
-    }
-
-    /// Gets a mutable package with the given name.
-    pub fn get_package_by_name_mut(
-        &mut self,
-        name: impl AsRef<str>,
-    ) -> Option<(&Path, &mut Package)> {
-        self.packages_mut()
-            .find(|(_, package)| package.name() == name.as_ref())
-    }
-
     /// Gets a lockfile with the given kind.
     pub fn get_lockfile_by_kind(&self, kind: PackageKind) -> Option<&Lockfile> {
         self.get_file(kind.lockfile_name()?)?.as_lockfile()

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -207,13 +207,8 @@ impl Project {
 
     /// Gets a package with the given name.
     pub fn get_package(&self, name: impl AsRef<str>) -> Option<PackageRef<'_>> {
-        self.files
-            .get_package_by_name(name)
-            .map(|(path, package)| PackageRef {
-                package,
-                path,
-                project: self,
-            })
+        self.packages()
+            .find(|package| package.name() == name.as_ref())
     }
 
     /// Gets the project packages.


### PR DESCRIPTION
This simply removes the `Fileset::get_package_by_name` and `Fileset::get_package_by_name_mut` methods.

These methods were added to the `Fileset` type but upcoming changes plan to redesign how packages and package manifests are handled.

This change removes the two methods and updates the `Project::get_package` implementation to use and filter the `Project::packages` method instead.