### PR TITLE
Derive `EnumIs` and `EnumTryAs` for `File`

### DIFF
--- a/packages/ploys/src/file/fileset.rs
+++ b/packages/ploys/src/file/fileset.rs
@@ -57,12 +57,13 @@ impl Fileset {
 
     /// Gets a lockfile with the given kind.
     pub fn get_lockfile_by_kind(&self, kind: PackageKind) -> Option<&Lockfile> {
-        self.get_file(kind.lockfile_name()?)?.as_lockfile()
+        self.get_file(kind.lockfile_name()?)?.try_as_lockfile_ref()
     }
 
     /// Gets a mutable lockfile with the given kind.
     pub fn get_lockfile_by_kind_mut(&mut self, kind: PackageKind) -> Option<&mut Lockfile> {
-        self.get_file_mut(kind.lockfile_name()?)?.as_lockfile_mut()
+        self.get_file_mut(kind.lockfile_name()?)?
+            .try_as_lockfile_mut()
     }
 
     /// Gets an iterator over the files.
@@ -82,25 +83,25 @@ impl Fileset {
     /// Gets an iterator over the packages.
     pub fn packages(&self) -> impl Iterator<Item = (&Path, &Package)> {
         self.files()
-            .filter_map(|(path, file)| Some((path, file.as_package()?)))
+            .filter_map(|(path, file)| Some((path, file.try_as_package_ref()?)))
     }
 
     /// Gets an iterator over the mutable packages.
     pub fn packages_mut(&mut self) -> impl Iterator<Item = (&Path, &mut Package)> {
         self.files_mut()
-            .filter_map(|(path, file)| Some((path, file.as_package_mut()?)))
+            .filter_map(|(path, file)| Some((path, file.try_as_package_mut()?)))
     }
 
     /// Gets an iterator over the lockfiles.
     pub fn lockfiles(&self) -> impl Iterator<Item = (&Path, &Lockfile)> {
         self.files()
-            .filter_map(|(path, file)| Some((path, file.as_lockfile()?)))
+            .filter_map(|(path, file)| Some((path, file.try_as_lockfile_ref()?)))
     }
 
     /// Gets an iterator over the mutable lockfiles.
     pub fn lockfiles_mut(&mut self) -> impl Iterator<Item = (&Path, &mut Lockfile)> {
         self.files_mut()
-            .filter_map(|(path, file)| Some((path, file.as_lockfile_mut()?)))
+            .filter_map(|(path, file)| Some((path, file.try_as_lockfile_mut()?)))
     }
 
     /// Gets the number of files in the fileset.

--- a/packages/ploys/src/file/mod.rs
+++ b/packages/ploys/src/file/mod.rs
@@ -2,84 +2,20 @@ mod fileset;
 
 use std::fmt::{self, Display};
 
+use strum::{EnumIs, EnumTryAs};
+
 use crate::changelog::Changelog;
 use crate::package::{Lockfile, Manifest, Package};
 
 pub use self::fileset::Fileset;
 
 /// A file in one of a number of formats.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, EnumIs, EnumTryAs)]
 pub enum File {
     Package(Package),
     Manifest(Manifest),
     Lockfile(Lockfile),
     Changelog(Changelog),
-}
-
-impl File {
-    /// Gets the file as a package.
-    pub fn as_package(&self) -> Option<&Package> {
-        match self {
-            Self::Package(package) => Some(package),
-            _ => None,
-        }
-    }
-
-    /// Gets the file as a mutable package.
-    pub fn as_package_mut(&mut self) -> Option<&mut Package> {
-        match self {
-            Self::Package(package) => Some(package),
-            _ => None,
-        }
-    }
-
-    /// Gets the file as a package manifest.
-    pub fn as_manifest(&self) -> Option<&Manifest> {
-        match self {
-            Self::Manifest(manifest) => Some(manifest),
-            _ => None,
-        }
-    }
-
-    /// Gets the file as a mutable package manifest.
-    pub fn as_manifest_mut(&mut self) -> Option<&mut Manifest> {
-        match self {
-            Self::Manifest(manifest) => Some(manifest),
-            _ => None,
-        }
-    }
-
-    /// Gets the file as a lockfile.
-    pub fn as_lockfile(&self) -> Option<&Lockfile> {
-        match self {
-            Self::Lockfile(lockfile) => Some(lockfile),
-            _ => None,
-        }
-    }
-
-    /// Gets the file as a mutable lockfile.
-    pub fn as_lockfile_mut(&mut self) -> Option<&mut Lockfile> {
-        match self {
-            Self::Lockfile(lockfile) => Some(lockfile),
-            _ => None,
-        }
-    }
-
-    /// Gets the file as a changelog.
-    pub fn as_changelog(&self) -> Option<&Changelog> {
-        match self {
-            Self::Changelog(changelog) => Some(changelog),
-            _ => None,
-        }
-    }
-
-    /// Gets the file as a mutable changelog.
-    pub fn as_changelog_mut(&mut self) -> Option<&mut Changelog> {
-        match self {
-            Self::Changelog(changelog) => Some(changelog),
-            _ => None,
-        }
-    }
 }
 
 impl Display for File {


### PR DESCRIPTION
This derives `EnumIs` and `EnumTryAs` for the `File` type.

The `strum` crate was introduced as a dependency in #139 to simplify enumerating over package kinds. The inclusion of the new dependency also allows for the `File` implementation to be simplified using other derive macros. The `EnumIs` adds `is_variant` methods and `EnumTryAs` adds `try_as_variant_ref` and `try_as_variant_mut` methods.

This change removes the various manual `as_variant` and `as_variant_mut` methods in favour of using the ones provided by `strum`. This reduces boilerplate and ensures that no methods are skipped when new variants are added.