### PR TITLE
Derive `EnumIs` and `EnumTryAs` for `Lockfile`

### DIFF
--- a/packages/ploys/src/package/lockfile.rs
+++ b/packages/ploys/src/package/lockfile.rs
@@ -6,7 +6,7 @@
 use std::fmt::{self, Display};
 use std::path::PathBuf;
 
-use strum::IntoEnumIterator;
+use strum::{EnumIs, EnumTryAs, IntoEnumIterator};
 
 use crate::package::{Error, PackageKind};
 use crate::repository::Repository;
@@ -14,7 +14,7 @@ use crate::repository::Repository;
 use super::cargo::CargoLockfile;
 
 /// A lockfile in one of several supported formats.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, EnumIs, EnumTryAs)]
 pub enum Lockfile {
     /// A `Cargo.lock` lockfile for Rust.
     Cargo(CargoLockfile),


### PR DESCRIPTION
This derives `EnumIs` and `EnumTryAs` for the `Lockfile` type.

The `strum` crate was introduced as a dependency in #139 to simplify enumerating over package kinds. The inclusion of the new dependency also allows for the `Lockfile` implementation to be simplified using other derive macros. The `EnumIs` adds `is_variant` methods and `EnumTryAs` adds `try_as_variant_ref` and `try_as_variant_mut` methods.

This change adds derives for `EnumIs` and `EnumTryAs` from `strum` to reflect the recent changes to the `Manifest` type.