### PR TITLE
Refactor `CargoLockfile` as a newtype

### DIFF
--- a/packages/ploys/src/package/cargo/lockfile.rs
+++ b/packages/ploys/src/package/cargo/lockfile.rs
@@ -6,11 +6,9 @@ use toml_edit::{ArrayOfTables, DocumentMut, Item, TableLike, Value};
 
 use crate::package::cargo::Error;
 
-/// A `Cargo.lock` lockfile for Rust.
+/// The cargo package lockfile.
 #[derive(Clone, Debug)]
-pub struct CargoLockfile {
-    manifest: DocumentMut,
-}
+pub struct CargoLockfile(DocumentMut);
 
 impl CargoLockfile {
     /// Sets the package version.
@@ -26,14 +24,12 @@ impl CargoLockfile {
 
     /// Creates a manifest from the given bytes.
     pub(crate) fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        Ok(Self {
-            manifest: std::str::from_utf8(bytes)?.parse()?,
-        })
+        Ok(Self(std::str::from_utf8(bytes)?.parse()?))
     }
 
     fn packages_mut(&mut self) -> PackagesMut<'_> {
         PackagesMut(
-            self.manifest
+            self.0
                 .get_mut("package")
                 .and_then(Item::as_array_of_tables_mut),
         )
@@ -42,13 +38,13 @@ impl CargoLockfile {
 
 impl Display for CargoLockfile {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Display::fmt(&self.manifest, f)
+        Display::fmt(&self.0, f)
     }
 }
 
 impl PartialEq for CargoLockfile {
     fn eq(&self, other: &Self) -> bool {
-        self.manifest.to_string() == other.manifest.to_string()
+        self.0.to_string() == other.0.to_string()
     }
 }
 

--- a/packages/ploys/src/package/lockfile.rs
+++ b/packages/ploys/src/package/lockfile.rs
@@ -13,10 +13,10 @@ use crate::repository::Repository;
 
 use super::cargo::CargoLockfile;
 
-/// A lockfile in one of several supported formats.
+/// The package lockfile.
 #[derive(Clone, Debug, PartialEq, Eq, EnumIs, EnumTryAs)]
 pub enum Lockfile {
-    /// A `Cargo.lock` lockfile for Rust.
+    /// A cargo package lockfile.
     Cargo(CargoLockfile),
 }
 


### PR DESCRIPTION
This refactors the `CargoLockfile` type using the newtype pattern to remove the inner `manifest` field.

The `CargoLockfile` type is a simple wrapper around the `toml_edit::DocumentMut` type that exposes the ability to treat a TOML document as a Cargo package lockfile. This is similar to the `CargoManifest` type that does the same for Cargo package manifests. However, both types have different internal representations and the name `manifest` is perhaps not the correct term for the inner document. Both types should be consistent and this means either both having an inner `document` field or using the newtype pattern. Now that file paths have been removed in #123 the best option may be the newtype pattern.

This change simply updates the internal representation of the `CargoLockfile` to use the newtype pattern and sneaks in a minor change to the documentation for lockfiles.