### PR TITLE
Update version methods to use `Version` type

### DIFF
--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -121,7 +121,7 @@ async fn create_release(
     let body = match changelog.get_release(version.to_string()) {
         Some(release) => format!("{release:#}"),
         None => {
-            let release = project.get_changelog_release(&package, version.clone())?;
+            let release = project.get_changelog_release(&package, &version)?;
 
             format!("{release:#}")
         }

--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -121,7 +121,7 @@ async fn create_release(
     let body = match changelog.get_release(version.to_string()) {
         Some(release) => format!("{release:#}"),
         None => {
-            let release = project.get_changelog_release(&package, version.to_string())?;
+            let release = project.get_changelog_release(&package, version.clone())?;
 
             format!("{release:#}")
         }

--- a/packages/ploys/src/package/cargo/lockfile.rs
+++ b/packages/ploys/src/package/cargo/lockfile.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::{self, Display};
 
+use semver::Version;
 use toml_edit::{ArrayOfTables, DocumentMut, Item, TableLike, Value};
 
 use crate::package::cargo::Error;
@@ -11,12 +12,13 @@ use crate::package::cargo::Error;
 pub struct CargoLockfile(DocumentMut);
 
 impl CargoLockfile {
+    /// Gets the package version.
+    pub fn get_package_version(&self, package: impl AsRef<str>) -> Option<Version> {
+        Some(self.packages().get(package.as_ref())?.version())
+    }
+
     /// Sets the package version.
-    pub fn set_package_version<P, V>(&mut self, package: P, version: V)
-    where
-        P: AsRef<str>,
-        V: Into<String>,
-    {
+    pub fn set_package_version(&mut self, package: impl AsRef<str>, version: impl Into<Version>) {
         if let Some(mut package) = self.packages_mut().get_mut(package.as_ref()) {
             package.set_version(version);
         }
@@ -25,6 +27,10 @@ impl CargoLockfile {
     /// Creates a manifest from the given bytes.
     pub(crate) fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         Ok(Self(std::str::from_utf8(bytes)?.parse()?))
+    }
+
+    fn packages(&self) -> Packages<'_> {
+        Packages(self.0.get("package").and_then(Item::as_array_of_tables))
     }
 
     fn packages_mut(&mut self) -> PackagesMut<'_> {
@@ -50,6 +56,36 @@ impl PartialEq for CargoLockfile {
 
 impl Eq for CargoLockfile {}
 
+/// The packages table.
+struct Packages<'a>(Option<&'a ArrayOfTables>);
+
+impl<'a> Packages<'a> {
+    fn get(&'a self, package: &'a str) -> Option<Package<'a>> {
+        match &self.0 {
+            Some(arr) => arr
+                .iter()
+                .find(|table| table.get("name").and_then(Item::as_str) == Some(package))
+                .map(|table| Package(table)),
+            None => None,
+        }
+    }
+}
+
+/// The package table.
+struct Package<'a>(&'a dyn TableLike);
+
+impl<'a> Package<'a> {
+    /// Gets the package version.
+    pub fn version(&self) -> Version {
+        self.0
+            .get("version")
+            .and_then(Item::as_str)
+            .unwrap_or("0.0.0")
+            .parse()
+            .expect("version should be valid semver")
+    }
+}
+
 /// The mutable packages table.
 struct PackagesMut<'a>(Option<&'a mut ArrayOfTables>);
 
@@ -70,11 +106,51 @@ struct PackageMut<'a>(&'a mut dyn TableLike);
 
 impl<'a> PackageMut<'a> {
     /// Sets the package version.
-    fn set_version<V>(&mut self, version: V) -> &mut Self
-    where
-        V: Into<String>,
-    {
-        *self.0.get_mut("version").expect("version") = Item::Value(Value::from(version.into()));
+    pub fn set_version(&mut self, version: impl Into<Version>) -> &mut Self {
+        let item = self.0.entry("version").or_insert_with(Item::default);
+
+        *item = Item::Value(Value::from(version.into().to_string()));
+
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use semver::Version;
+    use toml_edit::{value, ArrayOfTables, DocumentMut, Item, Table};
+
+    use super::CargoLockfile;
+
+    #[test]
+    fn test_package_version() {
+        let mut document = DocumentMut::new();
+
+        document["version"] = value(3);
+        document["package"] = {
+            let mut tables = ArrayOfTables::new();
+            let mut table = Table::new();
+
+            table["name"] = value("example");
+            table["version"] = value("0.0.0");
+
+            tables.push(table);
+
+            Item::ArrayOfTables(tables)
+        };
+
+        let mut lockfile = CargoLockfile(document);
+
+        assert_eq!(
+            lockfile.get_package_version("example"),
+            Some(Version::new(0, 0, 0))
+        );
+
+        lockfile.set_package_version("example", Version::new(0, 1, 0));
+
+        assert_eq!(
+            lockfile.get_package_version("example"),
+            Some(Version::new(0, 1, 0))
+        );
     }
 }

--- a/packages/ploys/src/package/cargo/mod.rs
+++ b/packages/ploys/src/package/cargo/mod.rs
@@ -7,6 +7,8 @@ mod manifest;
 
 use std::fmt::{self, Display};
 
+use semver::Version;
+
 pub use self::dependency::{Dependencies, DependenciesMut, Dependency, DependencyMut};
 pub use self::error::Error;
 pub use self::lockfile::CargoLockfile;
@@ -37,15 +39,12 @@ impl Cargo {
     }
 
     /// Gets the package version.
-    pub fn version(&self) -> &str {
+    pub fn version(&self) -> Version {
         self.manifest.package().expect("package").version()
     }
 
     /// Sets the package version.
-    pub fn set_version<V>(&mut self, version: V) -> &mut Self
-    where
-        V: Into<String>,
-    {
+    pub fn set_version(&mut self, version: impl Into<Version>) -> &mut Self {
         self.manifest
             .package_mut()
             .expect("package")
@@ -55,7 +54,10 @@ impl Cargo {
 
     /// Bumps the package version.
     pub fn bump(&mut self, bump: Bump) -> Result<(), BumpError> {
-        self.set_version(bump.bump_str(self.version())?.to_string());
+        let mut version = self.version();
+
+        bump.bump(&mut version)?;
+        self.set_version(version);
 
         Ok(())
     }

--- a/packages/ploys/src/package/dependency.rs
+++ b/packages/ploys/src/package/dependency.rs
@@ -1,3 +1,5 @@
+use semver::Version;
+
 use super::cargo::{
     Dependencies as CargoDependencies, DependenciesMut as CargoDependenciesMut,
     Dependency as CargoDependency, DependencyMut as CargoDependencyMut,
@@ -75,14 +77,14 @@ impl<'a> DependencyMut<'a> {
     }
 
     /// Gets the dependency version if it has been set.
-    pub fn version(&self) -> Option<&str> {
+    pub fn version(&self) -> Option<Version> {
         match self {
             Self::Cargo(dependency) => dependency.version(),
         }
     }
 
     /// Sets the dependency version.
-    pub fn set_version(&mut self, version: impl Into<String>) {
+    pub fn set_version(&mut self, version: impl Into<Version>) {
         match self {
             Self::Cargo(dependency) => dependency.set_version(version),
         }

--- a/packages/ploys/src/package/lockfile.rs
+++ b/packages/ploys/src/package/lockfile.rs
@@ -6,6 +6,7 @@
 use std::fmt::{self, Display};
 use std::path::PathBuf;
 
+use semver::Version;
 use strum::{EnumIs, EnumTryAs, IntoEnumIterator};
 
 use crate::package::{Error, PackageKind};
@@ -29,11 +30,7 @@ impl Lockfile {
     }
 
     /// Sets the package version.
-    pub fn set_package_version<P, V>(&mut self, package: P, version: V)
-    where
-        P: AsRef<str>,
-        V: Into<String>,
-    {
+    pub fn set_package_version(&mut self, package: impl AsRef<str>, version: impl Into<Version>) {
         match self {
             Self::Cargo(cargo) => cargo.set_package_version(package, version),
         }

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -53,7 +53,7 @@ impl<'a> PackageRef<'a> {
 
     /// Gets the package version.
     pub fn version(&self) -> Version {
-        self.package.version().parse().expect("version")
+        self.package.version()
     }
 
     /// Gets the package path.
@@ -111,7 +111,7 @@ impl Package {
     }
 
     /// Gets the package version.
-    pub fn version(&self) -> &str {
+    pub fn version(&self) -> Version {
         match self {
             Self::Cargo(cargo) => cargo.version(),
         }
@@ -125,9 +125,9 @@ impl Package {
     }
 
     /// Sets the package version.
-    pub fn set_version(&mut self, version: Version) {
+    pub fn set_version(&mut self, version: impl Into<Version>) {
         match self {
-            Self::Cargo(cargo) => cargo.set_version(version.to_string()),
+            Self::Cargo(cargo) => cargo.set_version(version),
         };
     }
 

--- a/packages/ploys/src/package/release.rs
+++ b/packages/ploys/src/package/release.rs
@@ -92,7 +92,7 @@ impl<'a> ReleaseRequestBuilder<'a> {
         let version = match self.version {
             BumpOrVersion::Bump(bump) => {
                 package.bump(bump).expect("bump");
-                package.version().parse().expect("version")
+                package.version()
             }
             BumpOrVersion::Version(version) => {
                 package.set_version(version.clone());
@@ -143,7 +143,7 @@ impl<'a> ReleaseRequestBuilder<'a> {
             {
                 let mut lockfile = lockfile.clone();
 
-                lockfile.set_package_version(self.package.name(), version.to_string());
+                lockfile.set_package_version(self.package.name(), version.clone());
                 files.push((path.to_owned(), lockfile.to_string()));
             }
         }
@@ -151,7 +151,7 @@ impl<'a> ReleaseRequestBuilder<'a> {
         let mut release = self
             .package
             .project
-            .get_changelog_release(self.package.name(), version.to_string())?;
+            .get_changelog_release(self.package.name(), version.clone())?;
 
         if self.options.update_changelog {
             let path = self

--- a/packages/ploys/src/package/release.rs
+++ b/packages/ploys/src/package/release.rs
@@ -151,7 +151,7 @@ impl<'a> ReleaseRequestBuilder<'a> {
         let mut release = self
             .package
             .project
-            .get_changelog_release(self.package.name(), version.clone())?;
+            .get_changelog_release(self.package.name(), &version)?;
 
         if self.options.update_changelog {
             let path = self

--- a/packages/ploys/src/package/release.rs
+++ b/packages/ploys/src/package/release.rs
@@ -114,17 +114,17 @@ impl<'a> ReleaseRequestBuilder<'a> {
                 let mut changed = false;
 
                 if let Some(mut dependency) = pkg.get_dependency_mut(self.package.name()) {
-                    dependency.set_version(version.to_string());
+                    dependency.set_version(version.clone());
                     changed = true;
                 }
 
                 if let Some(mut dependency) = pkg.get_dev_dependency_mut(self.package.name()) {
-                    dependency.set_version(version.to_string());
+                    dependency.set_version(version.clone());
                     changed = true;
                 }
 
                 if let Some(mut dependency) = pkg.get_build_dependency_mut(self.package.name()) {
-                    dependency.set_version(version.to_string());
+                    dependency.set_version(version.clone());
                     changed = true;
                 }
 

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -36,6 +36,7 @@
 
 mod error;
 
+use std::borrow::Borrow;
 use std::path::Path;
 
 use semver::Version;
@@ -265,14 +266,14 @@ impl Project {
     pub fn get_changelog_release(
         &self,
         package: impl AsRef<str>,
-        version: impl Into<Version>,
+        version: impl Borrow<Version>,
     ) -> Result<crate::changelog::Release, Error> {
         let release = self
             .get_remote()
             .ok_or(Error::Unsupported)?
             .get_changelog_release(
                 package.as_ref(),
-                version.into(),
+                version.borrow(),
                 package.as_ref() == self.name(),
             )?;
 

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -265,17 +265,14 @@ impl Project {
     pub fn get_changelog_release(
         &self,
         package: impl AsRef<str>,
-        version: impl AsRef<str>,
+        version: impl Into<Version>,
     ) -> Result<crate::changelog::Release, Error> {
         let release = self
             .get_remote()
             .ok_or(Error::Unsupported)?
             .get_changelog_release(
                 package.as_ref(),
-                version
-                    .as_ref()
-                    .parse::<Version>()
-                    .map_err(super::package::BumpError::Semver)?,
+                version.into(),
                 package.as_ref() == self.name(),
             )?;
 

--- a/packages/ploys/src/repository/github/mod.rs
+++ b/packages/ploys/src/repository/github/mod.rs
@@ -311,13 +311,13 @@ impl Remote for GitHub {
     fn get_changelog_release(
         &self,
         package: &str,
-        version: Version,
+        version: &Version,
         is_primary: bool,
     ) -> Result<Release, super::Error> {
         Ok(self::changelog::get_release(
             &self.repository,
             package,
-            &version,
+            version,
             is_primary,
             self.token.as_deref(),
         )?)

--- a/packages/ploys/src/repository/remote.rs
+++ b/packages/ploys/src/repository/remote.rs
@@ -22,7 +22,7 @@ pub trait Remote {
     fn get_changelog_release(
         &self,
         package: &str,
-        version: Version,
+        version: &Version,
         is_primary: bool,
     ) -> Result<Release, Error>;
 


### PR DESCRIPTION
This updates the various version methods to take or return the `Version` type from the `semver` crate.

The `semver` crate provides the `Version` type which is used internally in various places but not as part of the API for getting and setting the package and lockfile version fields. Instead, the methods take a string slice which may or may not be valid SemVer. Using this type may restrict supported package types because the `semver` crate is designed for Cargo versioning but for now would avoid any invalid strings. If another package type supports a different versioning scheme then a custom `Version` can be introduced at that point.

This change updates the `set_version` methods to take a `Version`, updates `version` methods to return a new `Version`, introduces new internal types to support a new `Lockfile::get_package_version` method, and adds tests to validate the functionality for cargo manifests and lockfiles.