### PR TITLE
Elide needless lifetimes to resolve `clippy` lint

### DIFF
--- a/packages/ploys/src/changelog/change.rs
+++ b/packages/ploys/src/changelog/change.rs
@@ -109,7 +109,7 @@ pub struct ChangeRef<'a> {
     text: Text<'a>,
 }
 
-impl<'a> ChangeRef<'a> {
+impl ChangeRef<'_> {
     /// Gets the change message.
     pub fn message(&self) -> String {
         format!("{:#}", self.text)
@@ -137,7 +137,7 @@ impl<'a> ChangeRef<'a> {
     }
 }
 
-impl<'a> Display for ChangeRef<'a> {
+impl Display for ChangeRef<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
             write!(f, "- {:#}", self.text)

--- a/packages/ploys/src/changelog/changeset.rs
+++ b/packages/ploys/src/changelog/changeset.rs
@@ -236,7 +236,7 @@ impl<'a> ChangesetRef<'a> {
     }
 }
 
-impl<'a> Display for ChangesetRef<'a> {
+impl Display for ChangesetRef<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "### {}", self.label())?;
 

--- a/packages/ploys/src/changelog/reference.rs
+++ b/packages/ploys/src/changelog/reference.rs
@@ -7,7 +7,7 @@ pub struct ReferenceRef<'a> {
     definition: &'a Definition,
 }
 
-impl<'a> ReferenceRef<'a> {
+impl ReferenceRef<'_> {
     /// Gets the reference ID.
     pub fn id(&self) -> &str {
         &self.definition.identifier
@@ -26,7 +26,7 @@ impl<'a> ReferenceRef<'a> {
     }
 }
 
-impl<'a> Display for ReferenceRef<'a> {
+impl Display for ReferenceRef<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,

--- a/packages/ploys/src/changelog/release.rs
+++ b/packages/ploys/src/changelog/release.rs
@@ -330,7 +330,7 @@ impl<'a> ReleaseRef<'a> {
     }
 }
 
-impl<'a> Display for ReleaseRef<'a> {
+impl Display for ReleaseRef<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.date {
             Some(date) => write!(f, "## [{}] - {date}", self.version)?,

--- a/packages/ploys/src/changelog/text.rs
+++ b/packages/ploys/src/changelog/text.rs
@@ -15,7 +15,7 @@ impl<'a> Text<'a> {
     }
 }
 
-impl<'a> Display for Text<'a> {
+impl Display for Text<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for node in self.nodes {
             write_node(f, node)?;
@@ -44,7 +44,7 @@ impl<'a> MultilineText<'a> {
     }
 }
 
-impl<'a> Display for MultilineText<'a> {
+impl Display for MultilineText<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut nodes = self.nodes.iter().peekable();
 

--- a/packages/ploys/src/package/cargo/dependency.rs
+++ b/packages/ploys/src/package/cargo/dependency.rs
@@ -43,7 +43,7 @@ impl<'a> Dependency<'a> {
     }
 }
 
-impl<'a> Debug for Dependency<'a> {
+impl Debug for Dependency<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Dependency")
             .field("name", &self.name())
@@ -90,7 +90,7 @@ impl<'a> IntoIterator for Dependencies<'a> {
     }
 }
 
-impl<'a> Debug for Dependencies<'a> {
+impl Debug for Dependencies<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
@@ -110,7 +110,7 @@ pub struct DependencyMut<'a> {
     item: &'a mut Item,
 }
 
-impl<'a> DependencyMut<'a> {
+impl DependencyMut<'_> {
     /// Gets the dependency name.
     pub fn name(&self) -> &str {
         self.name.get()
@@ -147,7 +147,7 @@ impl<'a> DependencyMut<'a> {
     }
 }
 
-impl<'a> Debug for DependencyMut<'a> {
+impl Debug for DependencyMut<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DependencyMut")
             .field("name", &self.name())
@@ -169,7 +169,7 @@ pub struct DependenciesMut<'a> {
     pub(super) table: Option<&'a mut dyn TableLike>,
 }
 
-impl<'a> DependenciesMut<'a> {
+impl DependenciesMut<'_> {
     /// Gets the mutable dependency with the given name.
     pub fn get_mut(&mut self, name: impl AsRef<str>) -> Option<DependencyMut<'_>> {
         self.table
@@ -192,7 +192,7 @@ impl<'a> IntoIterator for DependenciesMut<'a> {
     }
 }
 
-impl<'a> Debug for DependenciesMut<'a> {
+impl Debug for DependenciesMut<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.table {
             Some(table) => f

--- a/packages/ploys/src/package/cargo/lockfile.rs
+++ b/packages/ploys/src/package/cargo/lockfile.rs
@@ -74,7 +74,7 @@ impl<'a> Packages<'a> {
 /// The package table.
 struct Package<'a>(&'a dyn TableLike);
 
-impl<'a> Package<'a> {
+impl Package<'_> {
     /// Gets the package version.
     pub fn version(&self) -> Version {
         self.0
@@ -104,7 +104,7 @@ impl<'a> PackagesMut<'a> {
 /// The mutable package table.
 struct PackageMut<'a>(&'a mut dyn TableLike);
 
-impl<'a> PackageMut<'a> {
+impl PackageMut<'_> {
     /// Sets the package version.
     pub fn set_version(&mut self, version: impl Into<Version>) -> &mut Self {
         let item = self.0.entry("version").or_insert_with(Item::default);

--- a/packages/ploys/src/package/cargo/manifest.rs
+++ b/packages/ploys/src/package/cargo/manifest.rs
@@ -236,7 +236,7 @@ impl<'a> Package<'a> {
 /// The mutable package table.
 pub struct PackageMut<'a>(&'a mut dyn TableLike);
 
-impl<'a> PackageMut<'a> {
+impl PackageMut<'_> {
     /// Sets the package version.
     pub fn set_version(&mut self, version: impl Into<Version>) -> &mut Self {
         let item = self.0.entry("version").or_insert_with(Item::default);

--- a/packages/ploys/src/package/dependency.rs
+++ b/packages/ploys/src/package/dependency.rs
@@ -68,7 +68,7 @@ pub enum DependencyMut<'a> {
     Cargo(CargoDependencyMut<'a>),
 }
 
-impl<'a> DependencyMut<'a> {
+impl DependencyMut<'_> {
     /// Gets the dependency name.
     pub fn name(&self) -> &str {
         match self {
@@ -104,7 +104,7 @@ pub enum DependenciesMut<'a> {
     Cargo(CargoDependenciesMut<'a>),
 }
 
-impl<'a> DependenciesMut<'a> {
+impl DependenciesMut<'_> {
     /// Gets the mutable dependency with the given name.
     pub fn get_mut(&mut self, name: impl AsRef<str>) -> Option<DependencyMut<'_>> {
         match self {

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -80,7 +80,7 @@ impl<'a> PackageRef<'a> {
     }
 }
 
-impl<'a> Deref for PackageRef<'a> {
+impl Deref for PackageRef<'_> {
     type Target = Package;
 
     fn deref(&self) -> &Self::Target {

--- a/packages/ploys/src/package/release.rs
+++ b/packages/ploys/src/package/release.rs
@@ -14,7 +14,7 @@ pub struct ReleaseRequest<'a> {
     version: Version,
 }
 
-impl<'a> ReleaseRequest<'a> {
+impl ReleaseRequest<'_> {
     /// Gets the release request id.
     pub fn id(&self) -> u64 {
         self.id


### PR DESCRIPTION
This resolves the `clippy::needless_lifetimes` lint warning by eliding needless lifetimes.

The latest `1.83.0` version of Rust triggered the `clippy::needless_lifetimes` lint across the codebase and caused the continuous integration workflow in #146 to fail. In retrospect the version should have been upgraded on the local machine sooner to catch the issue. A long-term goal of this project is to prevent such an issue from ever being a problem again.

This change simply elides the needless lifetimes according to the lint. This should prevent future CI workflows from failing, at least until another lint is triggered in a future Rust update.