### PR TITLE
Add package changelog method

### DIFF
--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -20,6 +20,8 @@ use std::path::{Path, PathBuf};
 
 use semver::Version;
 
+use crate::changelog::Changelog;
+use crate::file::File;
 use crate::project::Project;
 
 pub use self::bump::{Bump, BumpOrVersion, Error as BumpError};
@@ -96,6 +98,15 @@ impl Package<'_> {
     /// are tagged under the version number without the package name prefix.
     pub fn is_primary(&self) -> bool {
         self.name() == self.project.name()
+    }
+}
+
+impl<'a> Package<'a> {
+    /// Gets the package changelog.
+    pub fn changelog(&self) -> Option<&'a Changelog> {
+        self.project
+            .get_file(self.path().parent()?.join("CHANGELOG.md"))
+            .and_then(File::try_as_changelog_ref)
     }
 }
 

--- a/packages/ploys/src/package/release.rs
+++ b/packages/ploys/src/package/release.rs
@@ -1,6 +1,6 @@
 use semver::Version;
 
-use crate::changelog::{Changelog, Release};
+use crate::changelog::Release;
 use crate::file::File;
 
 use super::{BumpOrVersion, Package};
@@ -158,13 +158,7 @@ impl<'a> ReleaseRequestBuilder<'a> {
                 .expect("parent")
                 .join("CHANGELOG.md");
 
-            let mut changelog = match self.package.project.get_file_contents(&path).ok() {
-                Some(bytes) => match String::from_utf8(bytes).ok() {
-                    Some(string) => string.parse::<Changelog>().expect("changelog"),
-                    None => Changelog::new(),
-                },
-                None => Changelog::new(),
-            };
+            let mut changelog = self.package.changelog().cloned().unwrap_or_default();
 
             changelog.add_release(release.clone());
             files.push((path, changelog.to_string()));


### PR DESCRIPTION
This adds a new `Package::changelog` method to get the changelog for the package.

Now that #149 has been merged it is possible to use the file cache to get a reference to the changelog without requesting a new copy each time the method is called. This is because the previous file storage required a mutable reference to the project and so it was not possible to get a reference to the changelog via the package unless it was automatically discovered before obtaining the package.

This change adds the `changelog` method to the `Package` type which lazily loads the changelog, and simplifies the release request builder to no longer have to manually request and parse a changelog.