### PR TITLE
Move project bump and not found error variants to package

### DIFF
--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -94,7 +94,8 @@ async fn create_release(
             let package = project
                 .packages()
                 .find(|package| package.name() == project.name())
-                .ok_or_else(|| ploys::project::Error::PackageNotFound(project.name().to_owned()))?;
+                .ok_or_else(|| ploys::package::Error::NotFound(project.name().to_owned()))
+                .map_err(ploys::project::Error::Package)?;
 
             (
                 package.name().to_owned(),
@@ -202,7 +203,8 @@ fn create_release_request(token: String, payload: RepositoryDispatchPayload) -> 
 
     let release_request = project
         .get_package(&package)
-        .ok_or_else(|| ploys::project::Error::PackageNotFound(package))?
+        .ok_or(ploys::package::Error::NotFound(package))
+        .map_err(ploys::project::Error::Package)?
         .create_release_request(version)
         .finish()?;
 

--- a/packages/ploys/src/package/error.rs
+++ b/packages/ploys/src/package/error.rs
@@ -7,6 +7,10 @@ pub enum Error {
     Manifest(super::manifest::Error),
     /// A package lockfile error.
     Lockfile(super::lockfile::Error),
+    /// A package bump error.
+    Bump(super::bump::Error),
+    /// A package not found error.
+    NotFound(String),
 }
 
 impl Display for Error {
@@ -14,6 +18,8 @@ impl Display for Error {
         match self {
             Self::Manifest(err) => Display::fmt(err, f),
             Self::Lockfile(err) => Display::fmt(err, f),
+            Self::Bump(err) => Display::fmt(err, f),
+            Self::NotFound(name) => write!(f, "Package not found: `{name}`."),
         }
     }
 }
@@ -23,6 +29,8 @@ impl std::error::Error for Error {
         match self {
             Self::Manifest(err) => Some(err),
             Self::Lockfile(err) => Some(err),
+            Self::Bump(err) => Some(err),
+            Self::NotFound(_) => None,
         }
     }
 }
@@ -36,5 +44,11 @@ impl From<super::manifest::Error> for Error {
 impl From<super::lockfile::Error> for Error {
     fn from(err: super::lockfile::Error) -> Self {
         Self::Lockfile(err)
+    }
+}
+
+impl From<super::bump::Error> for Error {
+    fn from(err: super::bump::Error) -> Self {
+        Self::Bump(err)
     }
 }

--- a/packages/ploys/src/project/error.rs
+++ b/packages/ploys/src/project/error.rs
@@ -8,10 +8,6 @@ pub enum Error {
     Repository(crate::repository::Error),
     /// The package error.
     Package(crate::package::Error),
-    /// The package bump error.
-    Bump(crate::package::BumpError),
-    /// The package not found error.
-    PackageNotFound(String),
     /// The action is not supported.
     Unsupported,
 }
@@ -21,8 +17,6 @@ impl Display for Error {
         match self {
             Self::Repository(err) => Display::fmt(err, f),
             Self::Package(err) => Display::fmt(err, f),
-            Self::Bump(err) => Display::fmt(err, f),
-            Self::PackageNotFound(name) => write!(f, "Package not found: `{name}`."),
             Self::Unsupported => write!(f, "Action not supported"),
         }
     }
@@ -44,7 +38,7 @@ impl From<crate::package::Error> for Error {
 
 impl From<crate::package::BumpError> for Error {
     fn from(err: crate::package::BumpError) -> Self {
-        Self::Bump(err)
+        Self::Package(err.into())
     }
 }
 


### PR DESCRIPTION
This moves the `Error::Bump` and `Error::PackageNotFound` variants from the project error to the package error.

The `Bump` and `PackageNotFound` errors are specific to packages and so it makes sense to move them to the package error type instead.

This change moves the error variants, renames `PackageNotFound` to `NotFound`, and updates `ploys-api` to map the error type.

The `ReleaseRequestBuilder` type is still using the project error instead of the package error because it needs the `Unsupported` variant but this could be replaced in the future with a release request error type that is either unsupported or a package error.