### PR TITLE
Add `to_owned` method for changelog `ReleaseRef`

### DIFF
--- a/packages/ploys/src/changelog/changeset.rs
+++ b/packages/ploys/src/changelog/changeset.rs
@@ -6,7 +6,7 @@ use markdown::ParseOptions;
 use super::{Change, ChangeRef, MultilineText};
 
 /// A changelog changeset.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Changeset {
     label: String,
     description: Option<String>,
@@ -210,6 +210,15 @@ impl<'a> ChangesetRef<'a> {
                     _ => None,
                 })
             })
+    }
+
+    /// Creates an owned changeset.
+    pub fn to_owned(&self) -> Changeset {
+        Changeset {
+            label: self.label().to_owned(),
+            description: self.description().map(|text| text.to_string()),
+            changes: self.changes().map(|change| change.to_owned()).collect(),
+        }
     }
 }
 

--- a/packages/ploys/src/changelog/reference.rs
+++ b/packages/ploys/src/changelog/reference.rs
@@ -17,6 +17,11 @@ impl ReferenceRef<'_> {
     pub fn url(&self) -> &str {
         &self.definition.url
     }
+
+    /// Creates an owned reference.
+    pub fn to_owned(&self) -> (String, String) {
+        (self.id().to_owned(), self.url().to_owned())
+    }
 }
 
 impl<'a> ReferenceRef<'a> {


### PR DESCRIPTION
This adds a new `to_owned` method to `ReleaseRef` and its component types to create an owned `Release`.

The `Changelog` type is a wrapper around a markdown document and provides various methods to interact with a changelog including adding new release sections. This involves a `ReleaseRef` type which borrows from the changelog to read release information, and a `Release` type that allows building a new release section. These are distinct types with major differences in how they are represented and so conversion between the two is difficult.

Providing this functionality will allow the library to get existing releases and create new releases with release notes that are separate to the changelog release section.

This change introduces a new `to_owned` method for `ReleaseRef`, `ReferenceRef`, `ChangesetRef` and `ChangeRef` to support conversion to the corresponding owned type. This does not use the `ToOwned` trait due to how that API works but instead borrows the method name for similar effect. This also includes a simple test for the new methods which required `PartialEq` and `Eq` to be derived for the owned types.