### PR TITLE
Add project package release builder

### DIFF
--- a/packages/ploys-api/src/github/webhook/error.rs
+++ b/packages/ploys-api/src/github/webhook/error.rs
@@ -8,7 +8,6 @@ use reqwest::StatusCode;
 /// The webhook response error.
 #[derive(Debug)]
 pub enum Error {
-    Payload,
     Jwt(jsonwebtoken::errors::Error),
     Request(reqwest::Error),
     Project(ploys::project::Error),
@@ -19,7 +18,6 @@ pub enum Error {
 impl Error {
     pub fn status(&self) -> StatusCode {
         match self {
-            Self::Payload => StatusCode::UNPROCESSABLE_ENTITY,
             Self::Jwt(_) => StatusCode::FORBIDDEN,
             Self::Request(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Project(_) => StatusCode::INTERNAL_SERVER_ERROR,
@@ -30,7 +28,6 @@ impl Error {
 
     pub fn message(&self) -> Cow<'static, str> {
         match self {
-            Self::Payload => Cow::Borrowed("Unsupported or invalid payload"),
             Self::Jwt(error) => Cow::Owned(format!("JWT: {error}")),
             Self::Request(error) => Cow::Owned(format!("Request: {error}")),
             Self::Project(error) => Cow::Owned(format!("Project: {error}")),
@@ -49,7 +46,6 @@ impl IntoResponse for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::Payload => None,
             Self::Jwt(err) => Some(err),
             Self::Request(err) => Some(err),
             Self::Project(err) => Some(err),

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -27,7 +27,7 @@ pub use self::kind::PackageKind;
 pub use self::lockfile::Lockfile;
 pub use self::manifest::Manifest;
 use self::manifest::{Dependencies, DependenciesMut, Dependency, DependencyMut};
-pub use self::release::{ReleaseRequest, ReleaseRequestBuilder};
+pub use self::release::{ReleaseBuilder, ReleaseRequest, ReleaseRequestBuilder};
 
 /// A project package.
 #[derive(Clone)]
@@ -179,6 +179,11 @@ impl<'a> Package<'a> {
         version: impl Into<BumpOrVersion>,
     ) -> ReleaseRequestBuilder<'a> {
         ReleaseRequestBuilder::new(self, version.into())
+    }
+
+    /// Constructs a new release builder.
+    pub fn create_release(self) -> ReleaseBuilder<'a> {
+        ReleaseBuilder::new(self)
     }
 }
 

--- a/packages/ploys/src/package/release/mod.rs
+++ b/packages/ploys/src/package/release/mod.rs
@@ -1,3 +1,94 @@
 mod request;
 
 pub use self::request::{ReleaseRequest, ReleaseRequestBuilder};
+
+use super::Package;
+
+/// The package release.
+pub struct Release<'a> {
+    #[allow(dead_code)]
+    package: Package<'a>,
+    id: u64,
+    name: String,
+    notes: crate::changelog::Release,
+}
+
+impl Release<'_> {
+    /// Gets the release id.
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    /// Gets the release name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Gets the release notes.
+    pub fn notes(&self) -> &crate::changelog::Release {
+        &self.notes
+    }
+}
+
+/// The package release builder.
+pub struct ReleaseBuilder<'a> {
+    package: Package<'a>,
+}
+
+impl<'a> ReleaseBuilder<'a> {
+    /// Constructs a new release builder.
+    pub(crate) fn new(package: Package<'a>) -> Self {
+        Self { package }
+    }
+
+    /// Finishes the release.
+    pub fn finish(self) -> Result<Release<'a>, crate::project::Error> {
+        let Some(remote) = self.package.project.get_remote() else {
+            return Err(crate::project::Error::Unsupported);
+        };
+
+        let sha = remote.sha()?;
+
+        let version = self.package.version();
+        let prerelease = !version.pre.is_empty();
+        let latest = self.package.is_primary() && !prerelease;
+
+        let tag = match self.package.is_primary() {
+            true => version.to_string(),
+            false => format!("{}-{version}", self.package.name()),
+        };
+
+        let name = match self.package.is_primary() {
+            true => version.to_string(),
+            false => format!("{} {version}", self.package.name()),
+        };
+
+        let release = self
+            .package
+            .changelog()
+            .and_then(|changelog| changelog.get_release(version.to_string()));
+
+        let release = match release {
+            Some(release) => release.to_owned(),
+            None => self
+                .package
+                .project
+                .get_changelog_release(self.package.name(), &version)?,
+        };
+
+        let body = format!("{release:#}")
+            .lines()
+            .skip(2)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let id = remote.create_release(&tag, &sha, &name, &body, prerelease, latest)?;
+
+        Ok(Release {
+            package: self.package,
+            id,
+            name,
+            notes: release,
+        })
+    }
+}

--- a/packages/ploys/src/repository/remote.rs
+++ b/packages/ploys/src/repository/remote.rs
@@ -12,6 +12,9 @@ use super::Error;
 /// This defines the shared API of a remote repository to simplify feature flag
 /// handling.
 pub trait Remote {
+    /// Gets the commit SHA.
+    fn sha(&self) -> Result<String, Error>;
+
     /// Commits the changes to the repository.
     fn commit(&self, message: &str, files: Vec<(PathBuf, String)>) -> Result<String, Error>;
 
@@ -42,5 +45,16 @@ pub trait Remote {
         base: &str,
         title: &str,
         body: &str,
+    ) -> Result<u64, Error>;
+
+    /// Creates a release.
+    fn create_release(
+        &self,
+        tag: &str,
+        sha: &str,
+        name: &str,
+        body: &str,
+        prerelease: bool,
+        latest: bool,
     ) -> Result<u64, Error>;
 }


### PR DESCRIPTION
This moves the logic of creating a release from the backend to a new release builder type.

The `ploys` library and `ploys-api` server are using a mix of blocking and async requests and the logic is split across both packages inconsistently. This is a follow-on to #134 that removes the remaining release logic to the library.

This change introduces a new `Package::create_release` method and `ReleaseBuilder` type that mimics the API of the `ReleaseRequestBuilder`. The key difference is that the release builder does not yet provide any builder methods but the ability to set manual release notes should be added for both release and release request builders at a later date. This includes some new internal trait methods to facilitate creating a release, moves the release creation to a separate blocking thread, and cleans up the unused `Payload` webhook error variant.

The release logic now depends on the internal commit SHA of the project and there are no checks on whether it is valid to create a release at that point. This can be included at a later date once the API is stable.