### PR TITLE
Fix changelog `Change::to_owned` text trimming

### DIFF
--- a/packages/ploys/src/changelog/change.rs
+++ b/packages/ploys/src/changelog/change.rs
@@ -155,7 +155,7 @@ impl ChangeRef<'_> {
                     Some(open.clone())
                         .into_iter()
                         .map(|mut text| {
-                            text.value = text.value.trim_end_matches("(").trim().to_owned();
+                            text.value = text.value.trim_end_matches("(").trim_end().to_owned();
                             text
                         })
                         .map(Node::Text),

--- a/packages/ploys/src/changelog/release.rs
+++ b/packages/ploys/src/changelog/release.rs
@@ -463,7 +463,7 @@ mod tests {
             Fixed some things.
 
             - Fixed `one` ([#1](https://github.com/ploys/example/pull/1))
-            - Fixed `two` ([#2](https://github.com/ploys/example/pull/2))
+            - Fixed `two` ok ([#2](https://github.com/ploys/example/pull/2))
 
             [0.1.0]: https://github.com/ploys/example/releases/tag/0.1.0\
         "};
@@ -481,7 +481,7 @@ mod tests {
                             .with_url("#1", "https://github.com/ploys/example/pull/1"),
                     )
                     .with_change(
-                        Change::new("Fixed `two`")
+                        Change::new("Fixed `two` ok")
                             .with_url("#2", "https://github.com/ploys/example/pull/2"),
                     ),
             )

--- a/packages/ploys/src/changelog/release.rs
+++ b/packages/ploys/src/changelog/release.rs
@@ -464,6 +464,7 @@ mod tests {
 
             - Fixed `one` ([#1](https://github.com/ploys/example/pull/1))
             - Fixed `two` ok ([#2](https://github.com/ploys/example/pull/2))
+            - Fixed three ([#3](https://github.com/ploys/example/pull/3))
 
             [0.1.0]: https://github.com/ploys/example/releases/tag/0.1.0\
         "};
@@ -483,6 +484,10 @@ mod tests {
                     .with_change(
                         Change::new("Fixed `two` ok")
                             .with_url("#2", "https://github.com/ploys/example/pull/2"),
+                    )
+                    .with_change(
+                        Change::new("Fixed three")
+                            .with_url("#3", "https://github.com/ploys/example/pull/3"),
                     ),
             )
             .with_reference(


### PR DESCRIPTION
This simply fixes an issue where the `Change::to_owned` implementation incorrectly trimmed whitespace off the left side of the last text section before the link.

The implementation of the `Change::to_owned` method in #153 included basic logic to extract the message without the final pull request link. This used the `trim` method on a markdown text section and this worked well with a simple message or a message ending in an inline code block. This is because the first text block has no whitespace at the start and an inline code block before the link causes the final text section to be ` (` where the whitespace at the start should be trimmed. However, including any additional text after an inline code block would require leading whitespace to separate it from the code block.

This change replaces the `trim` call with `trim_end` and updates the tests to cover this case.