### PR TITLE
Remove `Project::get_file_contents` method

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -188,17 +188,6 @@ impl Project {
     pub fn packages(&self) -> Packages<'_> {
         Packages::new(self)
     }
-
-    /// Queries the contents of a project file.
-    ///
-    /// This method may perform file system operations or network requests to
-    /// query the latest project information.
-    pub fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Error>
-    where
-        P: AsRef<Path>,
-    {
-        Ok(self.repository.get_file_contents(path)?)
-    }
 }
 
 impl Project {

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -10,13 +10,6 @@ fn test_valid_local_project() -> Result<(), Error> {
     assert_eq!(url.domain(), Some("github.com"));
     assert_eq!(url.path().trim_end_matches(".git"), "/ploys/ploys");
 
-    let a = String::from_utf8(project.get_file_contents("Cargo.toml")?).unwrap();
-    let b = String::from_utf8(project.get_file_contents("packages/ploys/Cargo.toml")?).unwrap();
-
-    assert!(a.contains("[workspace]"));
-    assert!(b.contains("[package]"));
-    assert!(project.get_file_contents("packages/ploys").is_err());
-
     assert!(project.packages().any(|pkg| pkg.name() == "ploys"));
     assert!(project.packages().any(|pkg| pkg.name() == "ploys-cli"));
 
@@ -36,13 +29,6 @@ fn test_valid_remote_project() -> Result<(), Error> {
         project.get_url()?,
         "https://github.com/ploys/ploys".parse().unwrap()
     );
-
-    let a = String::from_utf8(project.get_file_contents("Cargo.toml")?).unwrap();
-    let b = String::from_utf8(project.get_file_contents("packages/ploys/Cargo.toml")?).unwrap();
-
-    assert!(a.contains("[workspace]"));
-    assert!(b.contains("[package]"));
-    assert!(project.get_file_contents("packages/ploys").is_err());
 
     assert!(project.packages().any(|pkg| pkg.name() == "ploys"));
     assert!(project.packages().any(|pkg| pkg.name() == "ploys-cli"));


### PR DESCRIPTION
This simply removes the `Project::get_file_contents` method.

The `get_file_contents` method on `Project` was introduced as a way to get additional files like changelogs that have not been automatically discovered during construction. This served its purpose well but isn't really an API that the project wants to support. With the inclusion of a file cache in #149, package changelog access in #150, and finally the package release builder in #154 there is no longer any reason to keep this method around.

This change removes the `get_file_contents` method from `Project` but leaves the implementation on repository types because those are still used internally.