### PR TITLE
Hide `project info` command `token` argument env

### DIFF
--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -25,7 +25,7 @@ pub struct Info {
     sha: Option<String>,
 
     /// The authentication token for GitHub API access.
-    #[clap(long, env = "GITHUB_TOKEN")]
+    #[clap(long, env = "GITHUB_TOKEN", hide_env_values = true)]
     token: Option<String>,
 }
 


### PR DESCRIPTION
This simply hides the `GITHUB_TOKEN` environment variable value in the `project info` command.

The `GITHUB_TOKEN` environment variable is a secret and should not be displayed on screen if possible. The `package release` command already obscures the token but the `project info` command does not.

This change sets the `hide_env_values` property to `true` for the `token` argument in the `project info` command.