### PR TITLE
Fix GitHub repository file cache on 404 not found

### DIFF
--- a/packages/ploys/src/repository/github/mod.rs
+++ b/packages/ploys/src/repository/github/mod.rs
@@ -139,6 +139,7 @@ impl GitHub {
             .get_or_try_insert_with(path.as_ref(), |path| match self.get_file_contents(path) {
                 Ok(bytes) => Ok(Some(bytes)),
                 Err(Error::Io(err)) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+                Err(Error::Response(404)) => Ok(None),
                 Err(err) => Err(err),
             })
             .inspect_err(|err| println!("Error loading file `{}`: {err}", path.as_ref().display()))


### PR DESCRIPTION
Fixes #162.

This simply fixes the file cache implementation for the `GitHub` repository type to cache `None` on a `404` error. This only handles the error case but a better fix would be to introduce a new error variant when the crate switches to using `reqwest` instead of `req`.