### PR TITLE
Redesign project and repository constructors

### DIFF
--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -41,15 +41,12 @@ impl Info {
                 match &self.token {
                     Some(token) => {
                         self.print(Project::github_with_revision_and_authentication_token(
-                            github.to_string(),
+                            github,
                             self.revision(),
                             token,
                         )?)
                     }
-                    None => self.print(Project::github_with_revision(
-                        github.to_string(),
-                        self.revision(),
-                    )?),
+                    None => self.print(Project::github_with_revision(github, self.revision())?),
                 }
             }
             None => self.print(Project::git_with_revision(".", self.revision())?),

--- a/packages/ploys/src/repository/git/mod.rs
+++ b/packages/ploys/src/repository/git/mod.rs
@@ -27,13 +27,10 @@ pub struct Git {
 }
 
 impl Git {
-    /// Creates a Git repository.
-    pub(crate) fn new<P>(path: P) -> Result<Self, Error>
-    where
-        P: AsRef<Path>,
-    {
+    /// Opens a Git repository.
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self, Error> {
         Ok(Self {
-            repository: ThreadSafeRepository::open(path.as_ref())?,
+            repository: ThreadSafeRepository::open(path)?,
             revision: Revision::Head,
             file_cache: FileCache::new(),
         })

--- a/packages/ploys/src/repository/github/error.rs
+++ b/packages/ploys/src/repository/github/error.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::fmt::{self, Display};
 use std::io;
 
@@ -56,5 +57,11 @@ impl From<ureq::Error> for Error {
             ureq::Error::Status(status_code, _) => Self::Response(status_code),
             ureq::Error::Transport(transport) => Self::Transport(Box::new(transport)),
         }
+    }
+}
+
+impl From<Infallible> for Error {
+    fn from(err: Infallible) -> Self {
+        match err {}
     }
 }

--- a/packages/ploys/src/repository/github/mod.rs
+++ b/packages/ploys/src/repository/github/mod.rs
@@ -525,12 +525,7 @@ impl Remote for GitHub {
 
 impl From<GitHubRepoSpec> for GitHub {
     fn from(repo: GitHubRepoSpec) -> Self {
-        Self {
-            repository: Repository::new(repo),
-            revision: Revision::head(),
-            token: None,
-            file_cache: FileCache::new(),
-        }
+        Self::open(repo).expect("valid repo specification")
     }
 }
 

--- a/packages/ploys/src/repository/github/spec.rs
+++ b/packages/ploys/src/repository/github/spec.rs
@@ -5,6 +5,8 @@ use url::Url;
 
 use crate::repository::spec::Error;
 
+use super::GitHub;
+
 /// The GitHub repository specification.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct GitHubRepoSpec {
@@ -47,6 +49,11 @@ impl GitHubRepoSpec {
         Url::parse(&format!("https://github.com/{}", self))
             .expect("constructor ensures valid path components")
     }
+
+    /// Opens the repository.
+    pub fn open(self) -> GitHub {
+        GitHub::from(self)
+    }
 }
 
 impl Display for GitHubRepoSpec {
@@ -63,6 +70,30 @@ impl FromStr for GitHubRepoSpec {
             Some((owner, repo)) => Self::new(owner, repo),
             None => Err(Error::invalid(spec)),
         }
+    }
+}
+
+impl TryFrom<&str> for GitHubRepoSpec {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl TryFrom<&String> for GitHubRepoSpec {
+    type Error = Error;
+
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl TryFrom<String> for GitHubRepoSpec {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -103,6 +103,13 @@ impl From<self::github::GitHub> for Repository {
     }
 }
 
+#[cfg(feature = "github")]
+impl From<self::github::GitHubRepoSpec> for Repository {
+    fn from(github: self::github::GitHubRepoSpec) -> Self {
+        Self::GitHub(github.into())
+    }
+}
+
 impl TryFrom<RepoSpec> for Repository {
     type Error = RepoSpecError;
 
@@ -111,7 +118,7 @@ impl TryFrom<RepoSpec> for Repository {
         if let Some(spec) = spec.to_github() {
             use self::github::GitHub;
 
-            return Ok(Self::GitHub(GitHub::new(spec)));
+            return Ok(Self::GitHub(GitHub::from(spec)));
         }
 
         Err(RepoSpecError::invalid(spec.to_string()))


### PR DESCRIPTION
Closes #159.

This redesigns the existing `Project`, `Git`, and `GitHub` type constructors to simplify the construction of a project.

The design as specified in #159 included merging the various constructors into just two methods: one for constructing from a Git repository, and one for constructing from a GitHub repository. After working through this solution the optional authentication token posed a problem in that under normal usage without a token it would require the user to specify the type of option when providing `None`. This meant that the `Option<impl Into<String>>` would need to be replaced with `Option<String>` and that may require a map outside of the call instead.

This does not solve the original problem but with the introduction of #160 it may no longer be necessary as a GitHub repository can be constructed directly and used to open a project, eliminating the need to consolidate the methods.

This change updates the GitHub constructor methods to take a `TryInto<GitHubRepoSpec>` instead of an `Into<GitHubRepoSpec>`. This removes the need to parse a string outside of the call while allowing an actual `GitHubRepoSpec` to be passed in. The constructors have been moved to private modules to remove the need for fully qualified paths or conditional imports. This has the side-effect of moving the methods to the top of the docs but this is the intended order. The docs have also been updated to link to the repository types. The repository constructors have also been updated with various `From` and `TryFrom` implementations, and some internal builder methods have been made public.