### PR TITLE
Move project package release methods to package type

### DIFF
--- a/packages/ploys-cli/src/package/release.rs
+++ b/packages/ploys-cli/src/package/release.rs
@@ -41,7 +41,10 @@ impl Release {
 
         let project = Project::github_with_authentication_token(github.to_string(), self.token)?;
 
-        project.request_package_release(self.package, self.version)?;
+        project
+            .get_package(&self.package)
+            .ok_or(ploys::package::Error::NotFound(self.package))?
+            .request_release(self.version)?;
 
         Ok(())
     }

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -192,7 +192,7 @@ impl<'a> Package<'a> {
     /// all development to be on the default branch in the repository settings.
     pub fn request_release(
         &self,
-        version: impl Into<crate::package::BumpOrVersion>,
+        version: impl Into<BumpOrVersion>,
     ) -> Result<(), crate::project::Error> {
         self.project
             .get_remote()

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -10,7 +10,7 @@ pub mod lockfile;
 pub mod manifest;
 mod release;
 
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
 use std::fmt::{self, Display};
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
@@ -184,6 +184,43 @@ impl<'a> Package<'a> {
     /// Constructs a new release builder.
     pub fn create_release(self) -> ReleaseBuilder<'a> {
         ReleaseBuilder::new(self)
+    }
+
+    /// Requests the release of the specified package version.
+    ///
+    /// It does not yet support parallel release or hotfix branches and expects
+    /// all development to be on the default branch in the repository settings.
+    pub fn request_release(
+        &self,
+        version: impl Into<crate::package::BumpOrVersion>,
+    ) -> Result<(), crate::project::Error> {
+        self.project
+            .get_remote()
+            .ok_or(crate::project::Error::Unsupported)?
+            .request_package_release(self.name(), version.into())?;
+
+        Ok(())
+    }
+
+    /// Builds the changelog release for the given package version.
+    ///
+    /// This method queries the GitHub API to generate new release information
+    /// and may differ to the existing release information or changelogs. This
+    /// includes information for new releases as well as existing ones.
+    ///
+    /// It does not yet support parallel release or hotfix branches and expects
+    /// all development to be on the default branch in the repository settings.
+    pub fn build_release_notes(
+        &self,
+        version: impl Borrow<Version>,
+    ) -> Result<crate::changelog::Release, crate::project::Error> {
+        let release = self
+            .project
+            .get_remote()
+            .ok_or(crate::project::Error::Unsupported)?
+            .get_changelog_release(self.name(), version.borrow(), self.is_primary())?;
+
+        Ok(release)
     }
 }
 

--- a/packages/ploys/src/package/release/mod.rs
+++ b/packages/ploys/src/package/release/mod.rs
@@ -70,10 +70,7 @@ impl<'a> ReleaseBuilder<'a> {
 
         let release = match release {
             Some(release) => release.to_owned(),
-            None => self
-                .package
-                .project
-                .get_changelog_release(self.package.name(), &version)?,
+            None => self.package.build_release_notes(&version)?,
         };
 
         let body = format!("{release:#}")

--- a/packages/ploys/src/package/release/request.rs
+++ b/packages/ploys/src/package/release/request.rs
@@ -144,10 +144,7 @@ impl<'a> ReleaseRequestBuilder<'a> {
             }
         }
 
-        let mut release = self
-            .package
-            .project
-            .get_changelog_release(self.package.name(), &version)?;
+        let mut release = self.package.build_release_notes(&version)?;
 
         if self.options.update_changelog {
             let path = self

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -37,11 +37,9 @@
 mod error;
 mod packages;
 
-use std::borrow::Borrow;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-use semver::Version;
 use url::Url;
 
 use crate::file::File;
@@ -182,49 +180,6 @@ impl Project {
     /// Gets an iterator over the project packages.
     pub fn packages(&self) -> Packages<'_> {
         Packages::new(self)
-    }
-}
-
-impl Project {
-    /// Requests the release of the specified package version.
-    ///
-    /// It does not yet support parallel release or hotfix branches and expects
-    /// all development to be on the default branch in the repository settings.
-    pub fn request_package_release(
-        &self,
-        package: impl AsRef<str>,
-        version: impl Into<crate::package::BumpOrVersion>,
-    ) -> Result<(), Error> {
-        self.get_remote()
-            .ok_or(Error::Unsupported)?
-            .request_package_release(package.as_ref(), version.into())?;
-
-        Ok(())
-    }
-
-    /// Gets the changelog release for the given package version.
-    ///
-    /// This method queries the GitHub API to generate new release information
-    /// and may differ to the existing release information or changelogs. This
-    /// includes information for new releases as well as existing ones.
-    ///
-    /// It does not yet support parallel release or hotfix branches and expects
-    /// all development to be on the default branch in the repository settings.
-    pub fn get_changelog_release(
-        &self,
-        package: impl AsRef<str>,
-        version: impl Borrow<Version>,
-    ) -> Result<crate::changelog::Release, Error> {
-        let release = self
-            .get_remote()
-            .ok_or(Error::Unsupported)?
-            .get_changelog_release(
-                package.as_ref(),
-                version.borrow(),
-                package.as_ref() == self.name(),
-            )?;
-
-        Ok(release)
     }
 }
 


### PR DESCRIPTION
This moves the `request_package_release` and `get_changelog_release` methods from the `Project` type to the `Package` type and renames them appropriately.

The `Project::request_package_release` method requests the release of a package by sending a repository dispatch event to the GitHub App in `ploys-api`. This takes a package name and a version but does not validate the existence of the package until the event is received by the server. This means that the `package release` command in `ploys-cli` will always succeed with sufficient permission to create the event even if the package does not exist.

The `Project::get_changelog_release` method builds new release notes for the specified package version but the method name does not suggest that this could be an expensive operation and the implementation does not validate the existence of the package. This means that an invalid package name should generate empty release notes.

This change moves the two methods from the `Project` type to the `Package` type which should allow the package to be locally validated before doing anything. The `request_package_release` method is now `request_release` to remove the redundant `package` and `get_changelog_release` is now `build_release_notes` to better indicate the intent. This means that the `Project` type is now much simpler and package-specific methods go through the package type.

This only moves and renames the methods but does not alter the implementation in any way, other than the implicit validation of the package. There may be ways to also validate the version or expose methods through the package `Release` type instead but that can be left to a future exploration.