### PR TITLE
Add internal file loading error handling

### DIFF
--- a/packages/ploys/src/changelog/error.rs
+++ b/packages/ploys/src/changelog/error.rs
@@ -1,0 +1,45 @@
+use std::convert::Infallible;
+use std::fmt::{self, Display};
+
+use crate::file::ParseError;
+
+/// The changelog error.
+#[derive(Debug)]
+pub enum Error {
+    /// A parse error.
+    Parse(ParseError),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Parse(err) => Display::fmt(err, f),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Parse(err) => Some(err),
+        }
+    }
+}
+
+impl From<ParseError> for Error {
+    fn from(err: ParseError) -> Self {
+        Self::Parse(err)
+    }
+}
+
+impl From<Infallible> for Error {
+    fn from(err: Infallible) -> Self {
+        match err {}
+    }
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Self::Parse(err.into())
+    }
+}

--- a/packages/ploys/src/changelog/mod.rs
+++ b/packages/ploys/src/changelog/mod.rs
@@ -1,5 +1,6 @@
 mod change;
 mod changeset;
+mod error;
 mod reference;
 mod release;
 mod text;
@@ -13,6 +14,7 @@ use markdown::ParseOptions;
 
 pub use self::change::{Change, ChangeRef};
 pub use self::changeset::{Changeset, ChangesetRef};
+pub use self::error::Error;
 pub use self::reference::ReferenceRef;
 pub use self::release::{Release, ReleaseRef};
 pub use self::text::{MultilineText, Text};

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -102,6 +102,8 @@ impl<'a> Package<'a> {
     pub fn changelog(&self) -> Option<&'a Changelog> {
         self.project
             .get_file(self.path().parent()?.join("CHANGELOG.md"))
+            .ok()
+            .flatten()
             .and_then(File::try_as_changelog_ref)
     }
 }

--- a/packages/ploys/src/package/release/request.rs
+++ b/packages/ploys/src/package/release/request.rs
@@ -135,7 +135,7 @@ impl<'a> ReleaseRequestBuilder<'a> {
 
         if self.options.update_lockfile {
             if let Some(path) = self.package.kind().lockfile_name() {
-                if let Some(File::Lockfile(lockfile)) = self.package.project.get_file(path) {
+                if let Ok(Some(File::Lockfile(lockfile))) = self.package.project.get_file(path) {
                     let mut lockfile = lockfile.clone();
 
                     lockfile.set_package_version(self.package.name(), version.clone());

--- a/packages/ploys/src/project/error.rs
+++ b/packages/ploys/src/project/error.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::fmt::{self, Display};
 
 /// The project error.
@@ -6,6 +7,8 @@ use std::fmt::{self, Display};
 pub enum Error {
     /// The configuration error.
     Config(super::config::Error),
+    /// The changelog error.
+    Changelog(crate::changelog::Error),
     /// The repository error.
     Repository(crate::repository::Error),
     /// The package error.
@@ -17,6 +20,7 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Changelog(err) => Display::fmt(err, f),
             Self::Config(err) => Display::fmt(err, f),
             Self::Repository(err) => Display::fmt(err, f),
             Self::Package(err) => Display::fmt(err, f),
@@ -27,9 +31,21 @@ impl Display for Error {
 
 impl std::error::Error for Error {}
 
+impl From<Infallible> for Error {
+    fn from(err: Infallible) -> Self {
+        match err {}
+    }
+}
+
 impl From<super::config::Error> for Error {
     fn from(err: super::config::Error) -> Self {
         Self::Config(err)
+    }
+}
+
+impl From<crate::changelog::Error> for Error {
+    fn from(err: crate::changelog::Error) -> Self {
+        Self::Changelog(err)
     }
 }
 

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -69,7 +69,7 @@ impl Project {
         let repository = repository.into();
 
         repository
-            .get_file("Ploys.toml")
+            .get_file("Ploys.toml")?
             .ok_or(self::config::Error::Missing)?
             .try_as_config_ref()
             .ok_or(self::config::Error::Invalid)?;
@@ -211,7 +211,7 @@ impl Project {
     }
 
     /// Gets a file at the given path.
-    pub(crate) fn get_file(&self, path: impl AsRef<Path>) -> Option<&File> {
+    pub(crate) fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<&File>, Error> {
         self.repository.get_file(path)
     }
 
@@ -223,6 +223,8 @@ impl Project {
     /// Gets the config.
     pub(crate) fn config(&self) -> &Config {
         self.get_file("Ploys.toml")
+            .ok()
+            .flatten()
             .expect("loaded on open")
             .try_as_config_ref()
             .expect("validated on open")

--- a/packages/ploys/src/project/packages.rs
+++ b/packages/ploys/src/project/packages.rs
@@ -34,7 +34,7 @@ impl<'a> Iterator for Packages<'a> {
                 State::Initial { project } => {
                     let kind = self.kinds.next()?;
 
-                    if let Some(File::Manifest(manifest)) = project.get_file(kind.file_name()) {
+                    if let Ok(Some(File::Manifest(manifest))) = project.get_file(kind.file_name()) {
                         if let Ok(members) = manifest.members() {
                             self.state = State::Manifest {
                                 packages: ManifestPackages {
@@ -52,7 +52,7 @@ impl<'a> Iterator for Packages<'a> {
                     None => {
                         let kind = self.kinds.next()?;
 
-                        if let Some(File::Manifest(manifest)) =
+                        if let Ok(Some(File::Manifest(manifest))) =
                             packages.project.get_file(kind.file_name())
                         {
                             if let Ok(members) = manifest.members() {
@@ -103,7 +103,7 @@ impl<'a> Iterator for ManifestPackages<'a> {
                 continue;
             }
 
-            let Some(File::Manifest(manifest)) = self.project.get_file(path) else {
+            let Ok(Some(File::Manifest(manifest))) = self.project.get_file(path) else {
                 continue;
             };
 

--- a/packages/ploys/src/repository/git/mod.rs
+++ b/packages/ploys/src/repository/git/mod.rs
@@ -86,16 +86,13 @@ impl Git {
     }
 
     /// Gets the file at the given path.
-    pub fn get_file(&self, path: impl AsRef<Path>) -> Option<&File> {
+    pub fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<&File>, crate::project::Error> {
         self.file_cache
             .get_or_try_insert_with(path.as_ref(), |path| match self.get_file_contents(path) {
                 Ok(bytes) => Ok(Some(bytes)),
                 Err(Error::Io(err)) if err.kind() == io::ErrorKind::NotFound => Ok(None),
                 Err(err) => Err(err),
             })
-            .inspect_err(|err| println!("Error loading file `{}`: {err}", path.as_ref().display()))
-            .ok()
-            .flatten()
     }
 
     /// Gets the file index.

--- a/packages/ploys/src/repository/github/mod.rs
+++ b/packages/ploys/src/repository/github/mod.rs
@@ -141,7 +141,7 @@ impl GitHub {
     }
 
     /// Gets the file at the given path.
-    pub fn get_file(&self, path: impl AsRef<Path>) -> Option<&File> {
+    pub fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<&File>, crate::project::Error> {
         self.file_cache
             .get_or_try_insert_with(path.as_ref(), |path| match self.get_file_contents(path) {
                 Ok(bytes) => Ok(Some(bytes)),
@@ -149,9 +149,6 @@ impl GitHub {
                 Err(Error::Response(404)) => Ok(None),
                 Err(err) => Err(err),
             })
-            .inspect_err(|err| println!("Error loading file `{}`: {err}", path.as_ref().display()))
-            .ok()
-            .flatten()
     }
 
     /// Gets the file index.

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -56,12 +56,15 @@ impl Repository {
     }
 
     /// Gets a file at the given path.
-    pub(crate) fn get_file(&self, path: impl AsRef<Path>) -> Option<&File> {
+    pub(crate) fn get_file(
+        &self,
+        path: impl AsRef<Path>,
+    ) -> Result<Option<&File>, crate::project::Error> {
         match self {
             #[cfg(feature = "git")]
-            Repository::Git(git) => git.get_file(path),
+            Repository::Git(git) => Ok(git.get_file(path)?),
             #[cfg(feature = "github")]
-            Repository::GitHub(github) => github.get_file(path),
+            Repository::GitHub(github) => Ok(github.get_file(path)?),
         }
     }
 


### PR DESCRIPTION
This updates the file loading to return `Result` instead of `Option` so that errors are not completely ignored.

The implementation of the file cache returned a `Result` but the internal `get_file` methods only returned an `Option` and instead logged out any errors. This meant that loading an invalid file was treated the same as loading a missing file and this caused an incorrect error to be returned when opening a project with invalid configuration.

This change simply updates the methods to return a result, introduces a new changelog error for errors related to changelog parsing, and correctly returns the error when opening a project. This does not improve the configuration errors which are entirely unhelpful and ignores the error outside of project opening.