### PR TITLE
Replace `ureq` with `reqwest` as HTTP client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -839,6 +840,12 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -870,9 +877,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -2668,12 +2677,12 @@ dependencies = [
  "markdown",
  "once_map",
  "pretty_assertions",
+ "reqwest 0.12.9",
  "semver",
  "serde",
  "strum 0.26.3",
  "time",
  "toml_edit",
- "ureq",
  "url",
 ]
 
@@ -2689,7 +2698,7 @@ dependencies = [
  "jsonwebtoken",
  "mime",
  "ploys",
- "reqwest 0.12.8",
+ "reqwest 0.12.9",
  "semver",
  "serde",
  "serde_json",
@@ -2979,19 +2988,20 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.4",
+ "webpki-roots",
  "winreg",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.6",
@@ -3160,16 +3170,6 @@ name = "rustls-pki-types"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.100.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -4001,7 +4001,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.24.1",
  "tungstenite",
- "webpki-roots 0.25.4",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4326,24 +4326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
-dependencies = [
- "base64 0.21.4",
- "flate2",
- "log",
- "once_cell",
- "rustls 0.21.6",
- "rustls-webpki 0.100.1",
- "serde",
- "serde_json",
- "url",
- "webpki-roots 0.23.1",
-]
-
-[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4520,15 +4502,6 @@ checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
-dependencies = [
- "rustls-webpki 0.100.1",
 ]
 
 [[package]]

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [features]
 default = ["git", "github"]
 git = ["dep:gix"]
-github = ["dep:ureq"]
+github = ["dep:reqwest"]
 
 [dependencies]
 gix = { version = "0.66.0", optional = true }
@@ -23,8 +23,12 @@ serde = { version = "1.0.185", features = ["derive"] }
 strum = { version = "0.26.3", features = ["derive"] }
 time = { version = "0.3.36", features = ["serde", "formatting", "parsing"] }
 toml_edit = { version = "0.22.14", features = ["serde"] }
-ureq = { version = "2.7.1", features = ["json"], optional = true }
 url = "2.4.0"
+
+[dependencies.reqwest]
+version = "0.12.9"
+features = ["blocking", "json"]
+optional = true
 
 [dev-dependencies]
 indoc = "2.0.5"

--- a/packages/ploys/src/repository/github/changelog.rs
+++ b/packages/ploys/src/repository/github/changelog.rs
@@ -116,7 +116,7 @@ fn get_all_tags(repository: &Repository, token: Option<&str>) -> Result<Vec<GitT
     loop {
         let response = repository
             .graphql(token)
-            .send_json(Query {
+            .json(&Query {
                 query: ALL_TAGS_QUERY,
                 variables: Variables {
                     owner: repository.owner(),
@@ -125,8 +125,10 @@ fn get_all_tags(repository: &Repository, token: Option<&str>) -> Result<Vec<GitT
                     to: None,
                     cursor: cursor.as_deref(),
                 },
-            })?
-            .into_json::<MatchingTagsResponse>()?;
+            })
+            .send()?
+            .error_for_status()?
+            .json::<MatchingTagsResponse>()?;
 
         tags.extend(response.data.repository.refs.nodes);
 
@@ -224,7 +226,7 @@ fn all(repository: &Repository, token: Option<&str>) -> Result<Vec<PullRequest>,
     loop {
         let response = repository
             .graphql(token)
-            .send_json(Query {
+            .json(&Query {
                 query: ALL_QUERY,
                 variables: Variables {
                     owner: repository.owner(),
@@ -233,8 +235,10 @@ fn all(repository: &Repository, token: Option<&str>) -> Result<Vec<PullRequest>,
                     to: None,
                     cursor: cursor.as_deref(),
                 },
-            })?
-            .into_json::<AllResponse>()?;
+            })
+            .send()?
+            .error_for_status()?
+            .json::<AllResponse>()?;
 
         let commits = response.data.repository.default_branch_ref.target.history;
 
@@ -310,7 +314,7 @@ fn until(
     loop {
         let response = repository
             .graphql(token)
-            .send_json(Query {
+            .json(&Query {
                 query: UNTIL_QUERY,
                 variables: Variables {
                     owner: repository.owner(),
@@ -319,8 +323,10 @@ fn until(
                     to: Some(to),
                     cursor: cursor.as_deref(),
                 },
-            })?
-            .into_json::<UntilResponse>()?;
+            })
+            .send()?
+            .error_for_status()?
+            .json::<UntilResponse>()?;
 
         let commits = response.data.repository.r#ref.target.history;
 
@@ -398,7 +404,7 @@ fn between(
     loop {
         let response = repository
             .graphql(token)
-            .send_json(Query {
+            .json(&Query {
                 query: BETWEEN_QUERY,
                 variables: Variables {
                     owner: repository.owner(),
@@ -407,8 +413,10 @@ fn between(
                     to: Some(to),
                     cursor: cursor.as_deref(),
                 },
-            })?
-            .into_json::<BetweenResponse>()?;
+            })
+            .send()?
+            .error_for_status()?
+            .json::<BetweenResponse>()?;
 
         let commits = response.data.repository.r#ref.compare.commits;
 

--- a/packages/ploys/src/repository/github/repo.rs
+++ b/packages/ploys/src/repository/github/repo.rs
@@ -36,7 +36,7 @@ impl Repository {
 
     /// Validates whether the remote repository exists.
     pub(super) fn validate(&self, token: Option<&str>) -> Result<(), Error> {
-        self.head("", token).send()?;
+        self.head("", token).send()?.error_for_status()?;
 
         Ok(())
     }


### PR DESCRIPTION
This replaces the use of `ureq` as the HTTP client library with `reqwest` in blocking mode.

The `ureq` crate is great for making synchronous requests in the CLI but is inconsistent with making asynchronous requests on the server. Consolidating the project to use a single HTTP client should simplify things and reduce the total number of dependencies. Since there is no plan to swap to a synchronous HTTP server the best option is to use `reqwest` everywhere.

However, there are complications because the library API is not designed to be asynchronous. The `reqwest` crate provide the `blocking` feature but care must be taken to ensure this is spawned in a blocking thread. Fortunately, with #134 and #154 this is already being done so no further changes need to be made in `ploys-api`.

This change removes `ureq`, adds `reqwest` as a dependency to `ploys` with the `blocking` feature enabled, and updates the internal request logic to use the new crate. This stores a `Client` in the internal GItHub repository type and makes sure to call the `error_for_status` method so that error status codes are treated as errors as `ureq` does to not dramatically alter the request handling logic.

With this change it should be possible to update the library to be asynchronous in the future.