### PR TITLE
Fix missing `Project::github` repository validation

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -122,7 +122,7 @@ mod github {
         where
             R: TryInto<GitHubRepoSpec, Error: Into<GitHubError>>,
         {
-            Self::open(GitHub::open(repo)?)
+            Self::open(GitHub::open(repo)?.validated()?)
         }
 
         /// Opens a project from a [`GitHub`] repository and revision.


### PR DESCRIPTION
This fixes the `Project::github` constructor to correctly validate the repository.

The various `Project` constructors for the `GitHub` repository type call the `validated` method to ensure that the repository exists. This prevents a missing configuration file error from being returned on a 404 when the repository does not exist rather than the configuration file not existing. However, one of the constructors skipped the validation step and this was not caught in the tests because of the possibility of being rate limited without authentication.

This change simply adds the missing call to `validated` in the `Project::github` constructor.