### PR TITLE
Add `tracing` integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,6 +2721,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4361,9 +4362,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-verbosity-flag"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2678fade3b77aa3a8ff3aae87e9c008d3fb00473a41c71fbf74e91c8c7b37e84"
+dependencies = [
+ "clap",
+ "tracing-core",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,6 +2693,7 @@ dependencies = [
  "strum 0.26.3",
  "time",
  "toml_edit",
+ "tracing",
  "url",
 ]
 
@@ -2709,6 +2720,7 @@ dependencies = [
  "time",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2718,9 +2730,12 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "clap-verbosity-flag",
  "console",
  "ploys",
  "predicates",
+ "tracing",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -4100,9 +4115,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.39"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2ef2af84856a50c1d430afce2fdded0a4ec7eda868db86409b4543df0797f9"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -4112,9 +4127,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4123,23 +4138,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
 ]
 
 [[package]]
@@ -4166,16 +4170,16 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
  "tracing-core",
@@ -4183,9 +4187,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4198,7 +4202,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.1.3",
+ "tracing-log",
  "tracing-serde",
 ]
 

--- a/packages/ploys-api/Cargo.toml
+++ b/packages/ploys-api/Cargo.toml
@@ -29,6 +29,7 @@ time = { version = "0.3.36", features = ["serde", "formatting", "parsing"] }
 tokio = { version = "1.33.0", features = ["rt", "macros"] }
 tower-service = "0.3.3"
 tracing = "0.1.41"
+uuid = "1.11.0"
 
 [dependencies.ploys]
 version = "0.3.0"

--- a/packages/ploys-api/Cargo.toml
+++ b/packages/ploys-api/Cargo.toml
@@ -28,6 +28,7 @@ shuttle-runtime = "0.49.0"
 time = { version = "0.3.36", features = ["serde", "formatting", "parsing"] }
 tokio = { version = "1.33.0", features = ["rt", "macros"] }
 tower-service = "0.3.3"
+tracing = "0.1.41"
 
 [dependencies.ploys]
 version = "0.3.0"

--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -235,6 +235,7 @@ mod tests {
             .uri("/github/webhook")
             .header("Content-Type", "application/json")
             .header("X-GitHub-Event", "issues")
+            .header("X-GitHub-Delivery", "00000000-0000-0000-0000-000000000000")
             .header("X-Hub-Signature-256", format!("sha256={hex}"))
             .body(Body::from(payload))
             .unwrap();
@@ -260,6 +261,7 @@ mod tests {
             .uri("/github/webhook")
             .header("Content-Type", "application/json")
             .header("X-GitHub-Event", "issues")
+            .header("X-GitHub-Delivery", "00000000-0000-0000-0000-000000000000")
             .header("X-Hub-Signature-256", format!("sha256={hex}"))
             .body(Body::from(payload))
             .unwrap();

--- a/packages/ploys-api/src/github/webhook/payload.rs
+++ b/packages/ploys-api/src/github/webhook/payload.rs
@@ -20,9 +20,11 @@ use super::header::{XGitHubEvent, XHubSignature256};
 use super::secret::WebhookSecret;
 
 /// The GitHub event payload.
+#[derive(Debug)]
 pub enum Payload {
     PullRequest(PullRequestPayload),
     RepositoryDispatch(RepositoryDispatchPayload),
+    #[allow(dead_code)]
     Other(String, Value),
 }
 

--- a/packages/ploys-api/src/github/webhook/payload.rs
+++ b/packages/ploys-api/src/github/webhook/payload.rs
@@ -28,6 +28,17 @@ pub enum Payload {
     Other(String, Value),
 }
 
+impl Payload {
+    /// Gets the event name.
+    pub fn event_name(&self) -> &str {
+        match self {
+            Payload::PullRequest(_) => "pull_request",
+            Payload::RepositoryDispatch(_) => "repository_dispatch",
+            Payload::Other(name, _) => name,
+        }
+    }
+}
+
 #[async_trait]
 impl<S> FromRequest<S> for Payload
 where

--- a/packages/ploys-cli/Cargo.toml
+++ b/packages/ploys-cli/Cargo.toml
@@ -13,7 +13,14 @@ anyhow = "1.0.72"
 clap = { version = "4.3.21", features = ["derive", "env"] }
 console = "0.15.7"
 ploys = { version = "0.3.0", path = "../ploys" }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"
 url = "2.4.0"
+
+[dependencies.clap-verbosity-flag]
+version = "3.0.2"
+features = ["tracing"]
+default-features = false
 
 [dev-dependencies]
 assert_cmd = "2.0.12"

--- a/packages/ploys-cli/src/main.rs
+++ b/packages/ploys-cli/src/main.rs
@@ -3,6 +3,7 @@ mod project;
 
 use anyhow::Error;
 use clap::{Parser, Subcommand};
+use clap_verbosity_flag::Verbosity;
 
 use self::package::Package;
 use self::project::Project;
@@ -13,6 +14,8 @@ use self::project::Project;
 struct Args {
     #[clap(subcommand)]
     command: Command,
+    #[command(flatten)]
+    verbose: Verbosity,
 }
 
 impl Args {
@@ -35,5 +38,12 @@ enum Command {
 }
 
 fn main() -> Result<(), Error> {
-    Args::parse().exec()
+    let args = Args::parse();
+
+    tracing_subscriber::fmt()
+        .with_max_level(args.verbose.tracing_level_filter())
+        .pretty()
+        .init();
+
+    args.exec()
 }

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0.185", features = ["derive"] }
 strum = { version = "0.26.3", features = ["derive"] }
 time = { version = "0.3.36", features = ["serde", "formatting", "parsing"] }
 toml_edit = { version = "0.22.14", features = ["serde"] }
+tracing = "0.1.41"
 url = "2.4.0"
 
 [dependencies.reqwest]

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -200,9 +200,10 @@ impl<'a> Package<'a> {
         let version = version.into();
 
         info!(
-            "Requesting release `{version}` for `{}@{}`",
-            self.name(),
-            self.version()
+            package = self.name(),
+            version = %self.version(),
+            request = %version,
+            "Requesting release"
         );
 
         self.project

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -16,6 +16,7 @@ use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 
 use semver::Version;
+use tracing::info;
 
 use crate::changelog::Changelog;
 use crate::file::File;
@@ -196,10 +197,18 @@ impl<'a> Package<'a> {
         &self,
         version: impl Into<BumpOrVersion>,
     ) -> Result<(), crate::project::Error> {
+        let version = version.into();
+
+        info!(
+            "Requesting release `{version}` for `{}@{}`",
+            self.name(),
+            self.version()
+        );
+
         self.project
             .get_remote()
             .ok_or(crate::project::Error::Unsupported)?
-            .request_package_release(self.name(), version.into())?;
+            .request_package_release(self.name(), version)?;
 
         Ok(())
     }

--- a/packages/ploys/src/package/release/mod.rs
+++ b/packages/ploys/src/package/release/mod.rs
@@ -1,5 +1,7 @@
 mod request;
 
+use tracing::info;
+
 pub use self::request::{ReleaseRequest, ReleaseRequestBuilder};
 
 use super::Package;
@@ -50,6 +52,9 @@ impl<'a> ReleaseBuilder<'a> {
         let sha = remote.sha()?;
 
         let version = self.package.version();
+
+        info!("Creating release for `{}@{version}`", self.package.name());
+
         let prerelease = !version.pre.is_empty();
         let latest = self.package.is_primary() && !prerelease;
 
@@ -80,6 +85,11 @@ impl<'a> ReleaseBuilder<'a> {
             .join("\n");
 
         let id = remote.create_release(&tag, &sha, &name, &body, prerelease, latest)?;
+
+        info!(
+            "Created release `{id}` for `{}@{version}`",
+            self.package.name()
+        );
 
         Ok(Release {
             package: self.package,

--- a/packages/ploys/src/package/release/mod.rs
+++ b/packages/ploys/src/package/release/mod.rs
@@ -1,6 +1,6 @@
 mod request;
 
-use tracing::info;
+use tracing::{info, info_span};
 
 pub use self::request::{ReleaseRequest, ReleaseRequestBuilder};
 
@@ -53,7 +53,10 @@ impl<'a> ReleaseBuilder<'a> {
 
         let version = self.package.version();
 
-        info!("Creating release for `{}@{version}`", self.package.name());
+        let span = info_span!("release", package = self.package.name(), %version);
+        let _enter = span.enter();
+
+        info!("Creating release");
 
         let prerelease = !version.pre.is_empty();
         let latest = self.package.is_primary() && !prerelease;
@@ -86,10 +89,7 @@ impl<'a> ReleaseBuilder<'a> {
 
         let id = remote.create_release(&tag, &sha, &name, &body, prerelease, latest)?;
 
-        info!(
-            "Created release `{id}` for `{}@{version}`",
-            self.package.name()
-        );
+        info!(id, "Created release");
 
         Ok(Release {
             package: self.package,

--- a/packages/ploys/src/package/release/request.rs
+++ b/packages/ploys/src/package/release/request.rs
@@ -1,4 +1,5 @@
 use semver::Version;
+use tracing::info;
 
 use crate::changelog::Release;
 use crate::file::File;
@@ -99,6 +100,11 @@ impl<'a> ReleaseRequestBuilder<'a> {
             }
         };
 
+        info!(
+            "Creating release request for `{}@{version}`",
+            self.package.name()
+        );
+
         if self.options.update_package_manifest {
             files.push((self.package.path().to_owned(), self.package.to_string()));
         }
@@ -188,6 +194,11 @@ impl<'a> ReleaseRequestBuilder<'a> {
         remote.update_branch(&branch, &sha)?;
 
         let id = remote.create_pull_request(&branch, &default_branch, &title, &body)?;
+
+        info!(
+            "Created release request `{id}` for `{}@{version}`",
+            self.package.name()
+        );
 
         Ok(ReleaseRequest {
             package: self.package,

--- a/packages/ploys/src/package/release/request.rs
+++ b/packages/ploys/src/package/release/request.rs
@@ -1,5 +1,5 @@
 use semver::Version;
-use tracing::info;
+use tracing::{info, info_span};
 
 use crate::changelog::Release;
 use crate::file::File;
@@ -100,10 +100,10 @@ impl<'a> ReleaseRequestBuilder<'a> {
             }
         };
 
-        info!(
-            "Creating release request for `{}@{version}`",
-            self.package.name()
-        );
+        let span = info_span!("release_request", package = self.package.name(), %version);
+        let _enter = span.enter();
+
+        info!("Creating release request");
 
         if self.options.update_package_manifest {
             files.push((self.package.path().to_owned(), self.package.to_string()));
@@ -195,10 +195,7 @@ impl<'a> ReleaseRequestBuilder<'a> {
 
         let id = remote.create_pull_request(&branch, &default_branch, &title, &body)?;
 
-        info!(
-            "Created release request `{id}` for `{}@{version}`",
-            self.package.name()
-        );
+        info!(id, "Created release request");
 
         Ok(ReleaseRequest {
             package: self.package,


### PR DESCRIPTION
Closes #55.

This adds the initial `tracing` integration to the `ploys`, `ploys-api`, and `ploys-cli` packages.

The `tracing` crate is an evolution of the `log` crate and is a powerful tool to help debug projects. It is also supported by the *Shuttle* platform and so is useful for analysing how the server operates and what data gets sent to it.

This change adds logging to the `ploys` package for the various release flows, updates the `ploys-api` package to instrument the webhook handler, and updates the CLI to support verbose logging via the `clap-verbosity-flag` crate. This removes all usages of the `println` macro except for the output of the `project info` command.

The `ploys-api` package should no longer log webhook events in production as the log level for the instrumentation is set to *debug* and the *Shuttle* platform defaults to *info*. This means that running the API locally using `shuttle run --debug` should print debugging information.