### PR TITLE
Set project repository config field to be optional

### DIFF
--- a/packages/ploys-cli/src/package/release.rs
+++ b/packages/ploys-cli/src/package/release.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Error};
+use anyhow::{bail, Context, Error};
 use clap::Args;
 use ploys::package::BumpOrVersion;
 use ploys::project::Project;
@@ -27,7 +27,9 @@ impl Release {
     pub fn exec(self) -> Result<(), Error> {
         let remote = match self.remote {
             Some(remote) => remote,
-            None => Project::git(".")?.repository(),
+            None => Project::git(".")?
+                .repository()
+                .context("Missing remote repository")?,
         };
 
         let Some(github) = remote.to_github() else {

--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -75,7 +75,9 @@ impl Info {
             println!("Description: {description}");
         }
 
-        println!("Repository:  {}", project.repository().to_url());
+        if let Some(repository) = project.repository() {
+            println!("Repository:  {}", repository.to_url());
+        }
 
         println!("\n{}:\n", style("Packages").underlined().bold());
 

--- a/packages/ploys/src/project/config/project.rs
+++ b/packages/ploys/src/project/config/project.rs
@@ -17,13 +17,8 @@ impl<'a> Project<'a> {
     }
 
     /// Gets the project repository.
-    pub fn repository(&self) -> RepoSpec {
-        self.0
-            .get("repository")
-            .and_then(Item::as_str)
-            .expect("repository")
-            .parse()
-            .expect("repository specification")
+    pub fn repository(&self) -> Option<RepoSpec> {
+        self.0.get("repository")?.as_str()?.parse().ok()
     }
 }
 
@@ -31,11 +26,6 @@ impl<'a> Project<'a> {
     /// Constructs the project section from a table.
     pub(super) fn from_table(table: &'a dyn TableLike) -> Option<Self> {
         table.get("name").and_then(Item::as_str)?;
-        table
-            .get("repository")
-            .and_then(Item::as_str)?
-            .parse::<RepoSpec>()
-            .ok()?;
 
         Some(Self(table))
     }
@@ -74,13 +64,8 @@ impl ProjectMut<'_> {
     }
 
     /// Gets the project repository.
-    pub fn repository(&self) -> RepoSpec {
-        self.0
-            .get("repository")
-            .and_then(Item::as_str)
-            .expect("repository")
-            .parse()
-            .expect("repository specification")
+    pub fn repository(&self) -> Option<RepoSpec> {
+        self.0.get("repository")?.as_str()?.parse().ok()
     }
 
     /// Sets the project repository.
@@ -97,11 +82,6 @@ impl<'a> ProjectMut<'a> {
     /// Constructs the mutable project section from a mutable table.
     pub(super) fn from_table(table: &'a mut dyn TableLike) -> Option<Self> {
         table.get("name").and_then(Item::as_str)?;
-        table
-            .get("repository")
-            .and_then(Item::as_str)?
-            .parse::<RepoSpec>()
-            .ok()?;
 
         Some(Self(table))
     }

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -16,7 +16,7 @@
 //! let project = Project::git(".").unwrap();
 //!
 //! println!("Name:       {}", project.name());
-//! println!("Repository: {}", project.repository());
+//! println!("Repository: {}", project.repository().unwrap());
 //! ```
 //!
 //! ## GitHub
@@ -31,7 +31,7 @@
 //! let project = Project::github("ploys/ploys").unwrap();
 //!
 //! println!("Name:       {}", project.name());
-//! println!("Repository: {}", project.repository());
+//! println!("Repository: {}", project.repository().unwrap());
 //! ```
 
 pub mod config;
@@ -51,12 +51,13 @@ pub use self::packages::Packages;
 
 /// A project from one of several supported repositories.
 ///
-/// A valid project contains a `Ploys.toml` configuration file with the
-/// following fields:
+/// A valid project contains a `Ploys.toml` configuration file in the following
+/// format. Note that only the `project.name` field is required.
 ///
 /// ```toml
 /// [project]
 /// name = "{project-name}"
+/// description = "{project-description}"
 /// repository = "https://github.com/{project-owner}/{project-name}"
 /// ```
 pub struct Project {
@@ -182,7 +183,7 @@ impl Project {
     }
 
     /// Gets the project repository.
-    pub fn repository(&self) -> RepoSpec {
+    pub fn repository(&self) -> Option<RepoSpec> {
         self.config().project().repository()
     }
 

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -8,7 +8,7 @@ fn test_valid_local_project() -> Result<(), Error> {
 
     assert_eq!(project.name(), "ploys");
     assert_eq!(
-        project.repository().to_url(),
+        project.repository().unwrap().to_url(),
         "https://github.com/ploys/ploys".parse().unwrap()
     );
 
@@ -34,7 +34,7 @@ fn test_valid_remote_project() -> Result<(), Error> {
 
     assert_eq!(project.name(), "ploys");
     assert_eq!(
-        project.repository().to_url(),
+        project.repository().unwrap().to_url(),
         "https://github.com/ploys/ploys".parse().unwrap()
     );
 


### PR DESCRIPTION
Closes #182.

This sets the project configuration `repository` field to be optional.

The project configuration has a repository field that is used by `ploys-cli` to upgrade from a local Git project to a remote GitHub project. This project should support other projects without a repository so that they can be built with only a name.

This change updates the various `repository` methods to return an `Option` and removes the requirement for project configuration to contain a `project.repository` field.