### PR TITLE
Refactor `Project` internals and helper methods

### DIFF
--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -100,6 +100,7 @@ impl<'a> Package<'a> {
     /// Gets the package changelog.
     pub fn changelog(&self) -> Option<&'a Changelog> {
         self.project
+            .repository
             .get_file(self.path().parent()?.join("CHANGELOG.md"))
             .ok()
             .flatten()
@@ -192,7 +193,8 @@ impl Package<'_> {
         );
 
         self.project
-            .get_remote()
+            .repository
+            .as_remote()
             .ok_or(crate::project::Error::Unsupported)?
             .request_package_release(self.name(), version)?;
 
@@ -213,7 +215,8 @@ impl Package<'_> {
     ) -> Result<crate::changelog::Release, crate::project::Error> {
         let release = self
             .project
-            .get_remote()
+            .repository
+            .as_remote()
             .ok_or(crate::project::Error::Unsupported)?
             .get_changelog_release(self.name(), version.borrow(), self.is_primary())?;
 

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -39,13 +39,10 @@ mod error;
 mod packages;
 mod release;
 
-use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::file::File;
 use crate::package::{BumpOrVersion, Package};
-use crate::repository::{Remote, RepoSpec, Repository};
+use crate::repository::{RepoSpec, Repository};
 
 pub use self::config::Config;
 pub use self::error::Error;
@@ -64,7 +61,7 @@ pub use self::release::{ReleaseBuilder, ReleaseRequest, ReleaseRequestBuilder};
 /// repository = "https://github.com/{project-owner}/{project-name}"
 /// ```
 pub struct Project {
-    repository: Arc<Repository>,
+    pub(crate) repository: Arc<Repository>,
 }
 
 impl Project {
@@ -236,30 +233,10 @@ impl Project {
 }
 
 impl Project {
-    /// Gets the remote repository.
-    pub(crate) fn get_remote(&self) -> Option<&dyn Remote> {
-        #[cfg(feature = "github")]
-        #[allow(irrefutable_let_patterns)]
-        if let Repository::GitHub(github) = &*self.repository {
-            return Some(github);
-        }
-
-        None
-    }
-
-    /// Gets a file at the given path.
-    pub(crate) fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<&File>, Error> {
-        self.repository.get_file(path)
-    }
-
-    /// Gets the file index.
-    pub(crate) fn get_file_index(&self) -> &BTreeSet<PathBuf> {
-        self.repository.get_file_index()
-    }
-
     /// Gets the config.
     pub(crate) fn config(&self) -> &Config {
-        self.get_file("Ploys.toml")
+        self.repository
+            .get_file("Ploys.toml")
             .ok()
             .flatten()
             .expect("loaded on open")

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -41,6 +41,7 @@ mod release;
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use crate::file::File;
 use crate::package::{BumpOrVersion, Package};
@@ -63,7 +64,7 @@ pub use self::release::{ReleaseBuilder, ReleaseRequest, ReleaseRequestBuilder};
 /// repository = "https://github.com/{project-owner}/{project-name}"
 /// ```
 pub struct Project {
-    repository: Repository,
+    repository: Arc<Repository>,
 }
 
 impl Project {
@@ -77,7 +78,9 @@ impl Project {
             .try_as_config_ref()
             .ok_or(self::config::Error::Invalid)?;
 
-        Ok(Self { repository })
+        Ok(Self {
+            repository: Arc::new(repository),
+        })
     }
 }
 
@@ -237,7 +240,7 @@ impl Project {
     pub(crate) fn get_remote(&self) -> Option<&dyn Remote> {
         #[cfg(feature = "github")]
         #[allow(irrefutable_let_patterns)]
-        if let Repository::GitHub(github) = &self.repository {
+        if let Repository::GitHub(github) = &*self.repository {
             return Some(github);
         }
 

--- a/packages/ploys/src/project/packages.rs
+++ b/packages/ploys/src/project/packages.rs
@@ -34,14 +34,16 @@ impl<'a> Iterator for Packages<'a> {
                 State::Initial { project } => {
                     let kind = self.kinds.next()?;
 
-                    if let Ok(Some(File::Manifest(manifest))) = project.get_file(kind.file_name()) {
+                    if let Ok(Some(File::Manifest(manifest))) =
+                        project.repository.get_file(kind.file_name())
+                    {
                         if let Ok(members) = manifest.members() {
                             self.state = State::Manifest {
                                 packages: ManifestPackages {
                                     project,
                                     manifest,
                                     members,
-                                    files: project.get_file_index().iter(),
+                                    files: project.repository.get_file_index().iter(),
                                 },
                             };
                         }
@@ -53,12 +55,13 @@ impl<'a> Iterator for Packages<'a> {
                         let kind = self.kinds.next()?;
 
                         if let Ok(Some(File::Manifest(manifest))) =
-                            packages.project.get_file(kind.file_name())
+                            packages.project.repository.get_file(kind.file_name())
                         {
                             if let Ok(members) = manifest.members() {
                                 packages.manifest = manifest;
                                 packages.members = members;
-                                packages.files = packages.project.get_file_index().iter();
+                                packages.files =
+                                    packages.project.repository.get_file_index().iter();
                             }
                         }
                     }
@@ -103,7 +106,7 @@ impl<'a> Iterator for ManifestPackages<'a> {
                 continue;
             }
 
-            let Ok(Some(File::Manifest(manifest))) = self.project.get_file(path) else {
+            let Ok(Some(File::Manifest(manifest))) = self.project.repository.get_file(path) else {
                 continue;
             };
 

--- a/packages/ploys/src/project/release/mod.rs
+++ b/packages/ploys/src/project/release/mod.rs
@@ -45,7 +45,7 @@ impl<'a> ReleaseBuilder<'a> {
 
     /// Finishes the release.
     pub fn finish(self) -> Result<Release<'a>, crate::project::Error> {
-        let Some(remote) = self.package.project.get_remote() else {
+        let Some(remote) = self.package.project.repository.as_remote() else {
             return Err(crate::project::Error::Unsupported);
         };
 

--- a/packages/ploys/src/project/release/request.rs
+++ b/packages/ploys/src/project/release/request.rs
@@ -83,7 +83,7 @@ impl<'a> ReleaseRequestBuilder<'a> {
 
     /// Finishes the release request.
     pub fn finish(mut self) -> Result<ReleaseRequest<'a>, crate::project::Error> {
-        let Some(remote) = self.package.project.get_remote() else {
+        let Some(remote) = self.package.project.repository.as_remote() else {
             return Err(crate::project::Error::Unsupported);
         };
 
@@ -141,7 +141,9 @@ impl<'a> ReleaseRequestBuilder<'a> {
 
         if self.options.update_lockfile {
             if let Some(path) = self.package.kind().lockfile_name() {
-                if let Ok(Some(File::Lockfile(lockfile))) = self.package.project.get_file(path) {
+                if let Ok(Some(File::Lockfile(lockfile))) =
+                    self.package.project.repository.get_file(path)
+                {
                     let mut lockfile = lockfile.clone();
 
                     lockfile.set_package_version(self.package.name(), version.clone());

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -92,6 +92,18 @@ impl Repository {
     }
 }
 
+impl Repository {
+    /// Gets the repository as a remote.
+    pub(crate) fn as_remote(&self) -> Option<&dyn Remote> {
+        match self {
+            #[cfg(feature = "git")]
+            Self::Git(_) => None,
+            #[cfg(feature = "github")]
+            Self::GitHub(github) => Some(github),
+        }
+    }
+}
+
 #[cfg(feature = "git")]
 impl From<self::git::Git> for Repository {
     fn from(git: self::git::Git) -> Self {


### PR DESCRIPTION
This refactors the `Project` type to wrap the repository in `Arc` and moves the helper methods to the `Repository` type.

The `Project` type is currently just a wrapper for a `Repository` type with helper methods to forward calls on to the inner repository. The short-term goal is to redesign the project and package types for #38 and this includes removing the project from the `Package` type in favour of using the repository directly.

This change facilitates the planned changes by moving logic necessary for the package to the `Repository` type so it can use that instead. It also wraps the repository in an `Arc` so that it can easily be cloned. This has no public API changes.

The benefit of the `Arc` here will not be used until the next few changes and should eventually allow the `Project` type to implement `Clone`.