### PR TITLE
Add `Package` builder

### DIFF
--- a/packages/ploys/src/lib.rs
+++ b/packages/ploys/src/lib.rs
@@ -3,3 +3,5 @@ pub mod file;
 pub mod package;
 pub mod project;
 pub mod repository;
+
+pub(crate) mod util;

--- a/packages/ploys/src/package/manifest/cargo/mod.rs
+++ b/packages/ploys/src/package/manifest/cargo/mod.rs
@@ -8,7 +8,7 @@ use std::fmt::{self, Display};
 use std::path::PathBuf;
 
 use globset::{Glob, GlobSetBuilder};
-use toml_edit::DocumentMut;
+use toml_edit::{DocumentMut, Item, Table, Value};
 
 use crate::package::manifest::Members;
 
@@ -23,6 +23,24 @@ use super::Error;
 pub struct CargoManifest(DocumentMut);
 
 impl CargoManifest {
+    /// Constructs a new cargo package manifest.
+    pub fn new_package(name: impl Into<String>) -> Self {
+        Self({
+            let mut document = DocumentMut::new();
+
+            document.insert(
+                "package",
+                Item::Table({
+                    let mut table = Table::new();
+
+                    table.insert("name", Item::Value(Value::from(name.into())));
+                    table
+                }),
+            );
+            document
+        })
+    }
+
     /// Gets the workspace table.
     pub fn workspace(&self) -> Option<Workspace<'_>> {
         match self.0.get("workspace") {

--- a/packages/ploys/src/package/manifest/cargo/package.rs
+++ b/packages/ploys/src/package/manifest/cargo/package.rs
@@ -12,10 +12,7 @@ impl<'a> Package<'a> {
 
     /// Gets the package description.
     pub fn description(&self) -> Option<&'a str> {
-        match self.0.get("description") {
-            Some(description) => Some(description.as_str().expect("description")),
-            None => None,
-        }
+        self.0.get("description").and_then(Item::as_str)
     }
 
     /// Gets the package version.
@@ -45,10 +42,7 @@ impl PackageMut<'_> {
 
     /// Gets the package description.
     pub fn description(&self) -> Option<&str> {
-        match self.0.get("description") {
-            Some(description) => Some(description.as_str().expect("description")),
-            None => None,
-        }
+        self.0.get("description").and_then(Item::as_str)
     }
 
     /// Sets the package description.

--- a/packages/ploys/src/package/manifest/cargo/package.rs
+++ b/packages/ploys/src/package/manifest/cargo/package.rs
@@ -38,6 +38,43 @@ impl<'a> Package<'a> {
 pub struct PackageMut<'a>(pub(super) &'a mut dyn TableLike);
 
 impl PackageMut<'_> {
+    /// Gets the package name.
+    pub fn name(&self) -> &str {
+        self.0.get("name").expect("name").as_str().expect("name")
+    }
+
+    /// Gets the package description.
+    pub fn description(&self) -> Option<&str> {
+        match self.0.get("description") {
+            Some(description) => Some(description.as_str().expect("description")),
+            None => None,
+        }
+    }
+
+    /// Sets the package description.
+    pub fn set_description(&mut self, description: impl Into<String>) -> &mut Self {
+        let item = self.0.entry("description").or_insert_with(Item::default);
+
+        *item = Item::Value(Value::from(description.into()));
+
+        self
+    }
+
+    /// Gets the package version.
+    ///
+    /// This adheres to the [manifest format reference][1] and defaults to
+    /// `0.0.0` if the `version` field has not been set.
+    ///
+    /// [1]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field
+    pub fn version(&self) -> Version {
+        self.0
+            .get("version")
+            .and_then(Item::as_str)
+            .unwrap_or("0.0.0")
+            .parse()
+            .expect("version should be valid semver")
+    }
+
     /// Sets the package version.
     pub fn set_version(&mut self, version: impl Into<Version>) -> &mut Self {
         let item = self.0.entry("version").or_insert_with(Item::default);

--- a/packages/ploys/src/package/manifest/mod.rs
+++ b/packages/ploys/src/package/manifest/mod.rs
@@ -27,6 +27,11 @@ pub enum Manifest {
 }
 
 impl Manifest {
+    /// Constructs a new cargo manifest.
+    pub fn new_cargo(name: impl Into<String>) -> Self {
+        Self::Cargo(CargoManifest::new_package(name))
+    }
+
     /// Gets the package kind.
     pub fn package_kind(&self) -> PackageKind {
         match self {

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -45,7 +45,7 @@ impl Package {
         Self {
             repository: None,
             manifest: Manifest::new_cargo(name),
-            path: PathBuf::from("."),
+            path: PathBuf::new(),
             primary: false,
         }
     }
@@ -298,7 +298,7 @@ mod tests {
         assert_eq!(package.dev_dependencies().into_iter().count(), 0);
         assert_eq!(package.build_dependencies().into_iter().count(), 0);
         assert_eq!(package.kind(), PackageKind::Cargo);
-        assert_eq!(package.path(), Path::new("."));
+        assert_eq!(package.path(), Path::new(""));
 
         package.set_version("0.1.0".parse::<Version>().unwrap());
 

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -278,3 +278,30 @@ impl Display for Package {
         Display::fmt(&self.manifest, f)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use semver::Version;
+
+    use super::{Package, PackageKind};
+
+    #[test]
+    fn test_package_builder() {
+        let mut package = Package::new_cargo("example");
+
+        assert_eq!(package.name(), "example");
+        assert_eq!(package.description(), None);
+        assert_eq!(package.version().to_string(), "0.0.0");
+        assert_eq!(package.dependencies().into_iter().count(), 0);
+        assert_eq!(package.dev_dependencies().into_iter().count(), 0);
+        assert_eq!(package.build_dependencies().into_iter().count(), 0);
+        assert_eq!(package.kind(), PackageKind::Cargo);
+        assert_eq!(package.path(), Path::new("."));
+
+        package.set_version("0.1.0".parse::<Version>().unwrap());
+
+        assert_eq!(package.version().to_string(), "0.1.0");
+    }
+}

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -40,6 +40,18 @@ pub struct Package {
 }
 
 impl Package {
+    /// Constructs a new cargo package.
+    pub fn new_cargo(name: impl Into<String>) -> Self {
+        Self {
+            repository: None,
+            manifest: Manifest::new_cargo(name),
+            path: PathBuf::from("."),
+            primary: false,
+        }
+    }
+}
+
+impl Package {
     /// Gets the package name.
     pub fn name(&self) -> &str {
         match &self.manifest {

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -10,7 +10,6 @@ pub mod lockfile;
 pub mod manifest;
 
 use std::borrow::Borrow;
-use std::fmt::{self, Display};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -308,12 +307,6 @@ impl Package {
             kind,
             primary,
         })
-    }
-}
-
-impl Display for Package {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Display::fmt(self.manifest(), f)
     }
 }
 

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -98,6 +98,11 @@ impl Package {
         &self.path
     }
 
+    /// Gets the package manifest path.
+    pub fn manifest_path(&self) -> PathBuf {
+        self.path().join(self.kind().file_name())
+    }
+
     /// Gets the package kind.
     pub fn kind(&self) -> PackageKind {
         self.kind
@@ -135,7 +140,7 @@ impl Package {
     pub fn changelog(&self) -> Option<&Changelog> {
         self.repository
             .as_ref()?
-            .get_file(self.path().parent()?.join("CHANGELOG.md"))
+            .get_file(self.path().join("CHANGELOG.md"))
             .ok()
             .flatten()
             .and_then(File::try_as_changelog_ref)

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -128,6 +128,10 @@ impl Package {
     }
 
     /// Gets the mutable package manifest.
+    ///
+    /// Note that replacing the manifest with another kind is a logic error and
+    /// the behavior is not specified. This will likely lead to incorrect
+    /// results and panics.
     pub fn manifest_mut(&mut self) -> &mut Manifest {
         self.files
             .get_mut(self.kind().file_name())
@@ -165,6 +169,10 @@ impl Package {
     }
 
     /// Gets the mutable file at the given path.
+    ///
+    /// Note that replacing the file with another kind is a logic error and the
+    /// behavior is not specified. This will likely lead to incorrect results
+    /// and panics.
     pub fn get_file_mut(&mut self, path: impl AsRef<Path>) -> Option<&mut File> {
         self.files
             .get_mut_or_try_insert_with(path.as_ref().to_owned(), |path| match &self.repository {

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -144,6 +144,30 @@ impl Package {
 }
 
 impl Package {
+    /// Gets the file at the given path.
+    pub fn get_file(&self, path: impl AsRef<Path>) -> Option<&File> {
+        self.files.get(path.as_ref())
+    }
+
+    /// Gets the mutable file at the given path.
+    pub fn get_file_mut(&mut self, path: impl AsRef<Path>) -> Option<&mut File> {
+        self.files.get_mut(path.as_ref())
+    }
+
+    /// Inserts the given file.
+    pub fn insert_file(&mut self, path: impl AsRef<Path>, file: impl Into<File>) -> &mut Self {
+        self.files.insert(path.as_ref(), file.into());
+        self
+    }
+
+    /// Builds the package with the given file.
+    pub fn with_file(mut self, path: impl AsRef<Path>, file: impl Into<File>) -> Self {
+        self.insert_file(path, file);
+        self
+    }
+}
+
+impl Package {
     /// Gets the dependency with the given name.
     pub fn get_dependency(&self, name: impl AsRef<str>) -> Option<Dependency<'_>> {
         self.manifest().get_dependency(name)

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -214,7 +214,7 @@ impl Project {
             ))
         })?;
 
-        Ok(ReleaseRequestBuilder::new(package, version.into()))
+        Ok(ReleaseRequestBuilder::new(self, package, version.into()))
     }
 
     /// Constructs a new package release builder.
@@ -228,7 +228,7 @@ impl Project {
             ))
         })?;
 
-        Ok(ReleaseBuilder::new(package))
+        Ok(ReleaseBuilder::new(self, package))
     }
 }
 

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -190,7 +190,7 @@ impl Project {
     }
 
     /// Gets a package with the given name.
-    pub fn get_package(&self, name: impl AsRef<str>) -> Option<Package<'_>> {
+    pub fn get_package(&self, name: impl AsRef<str>) -> Option<Package> {
         self.packages()
             .find(|package| package.name() == name.as_ref())
     }

--- a/packages/ploys/src/project/packages.rs
+++ b/packages/ploys/src/project/packages.rs
@@ -25,8 +25,8 @@ impl<'a> Packages<'a> {
     }
 }
 
-impl<'a> Iterator for Packages<'a> {
-    type Item = Package<'a>;
+impl Iterator for Packages<'_> {
+    type Item = Package;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -86,8 +86,8 @@ struct ManifestPackages<'a> {
     files: std::collections::btree_set::Iter<'a, PathBuf>,
 }
 
-impl<'a> Iterator for ManifestPackages<'a> {
-    type Item = Package<'a>;
+impl Iterator for ManifestPackages<'_> {
+    type Item = Package;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {

--- a/packages/ploys/src/project/packages.rs
+++ b/packages/ploys/src/project/packages.rs
@@ -110,7 +110,7 @@ impl Iterator for ManifestPackages<'_> {
                 continue;
             };
 
-            let Some(package) = Package::from_manifest(self.project, path, manifest) else {
+            let Some(package) = Package::from_manifest(self.project, parent, manifest) else {
                 continue;
             };
 

--- a/packages/ploys/src/project/release/mod.rs
+++ b/packages/ploys/src/project/release/mod.rs
@@ -4,7 +4,7 @@ use tracing::{info, info_span};
 
 pub use self::request::{ReleaseRequest, ReleaseRequestBuilder};
 
-use super::Package;
+use super::{Package, Project};
 
 /// The package release.
 pub struct Release<'a> {
@@ -34,18 +34,19 @@ impl Release<'_> {
 
 /// The package release builder.
 pub struct ReleaseBuilder<'a> {
+    project: &'a Project,
     package: Package<'a>,
 }
 
 impl<'a> ReleaseBuilder<'a> {
     /// Constructs a new release builder.
-    pub(crate) fn new(package: Package<'a>) -> Self {
-        Self { package }
+    pub(crate) fn new(project: &'a Project, package: Package<'a>) -> Self {
+        Self { project, package }
     }
 
     /// Finishes the release.
     pub fn finish(self) -> Result<Release<'a>, crate::project::Error> {
-        let Some(remote) = self.package.project.repository.as_remote() else {
+        let Some(remote) = self.project.repository.as_remote() else {
             return Err(crate::project::Error::Unsupported);
         };
 

--- a/packages/ploys/src/project/release/mod.rs
+++ b/packages/ploys/src/project/release/mod.rs
@@ -7,15 +7,15 @@ pub use self::request::{ReleaseRequest, ReleaseRequestBuilder};
 use super::{Package, Project};
 
 /// The package release.
-pub struct Release<'a> {
+pub struct Release {
     #[allow(dead_code)]
-    package: Package<'a>,
+    package: Package,
     id: u64,
     name: String,
     notes: crate::changelog::Release,
 }
 
-impl Release<'_> {
+impl Release {
     /// Gets the release id.
     pub fn id(&self) -> u64 {
         self.id
@@ -35,17 +35,17 @@ impl Release<'_> {
 /// The package release builder.
 pub struct ReleaseBuilder<'a> {
     project: &'a Project,
-    package: Package<'a>,
+    package: Package,
 }
 
 impl<'a> ReleaseBuilder<'a> {
     /// Constructs a new release builder.
-    pub(crate) fn new(project: &'a Project, package: Package<'a>) -> Self {
+    pub(crate) fn new(project: &'a Project, package: Package) -> Self {
         Self { project, package }
     }
 
     /// Finishes the release.
-    pub fn finish(self) -> Result<Release<'a>, crate::project::Error> {
+    pub fn finish(self) -> Result<Release, crate::project::Error> {
         let Some(remote) = self.project.repository.as_remote() else {
             return Err(crate::project::Error::Unsupported);
         };

--- a/packages/ploys/src/project/release/request.rs
+++ b/packages/ploys/src/project/release/request.rs
@@ -110,7 +110,7 @@ impl<'a> ReleaseRequestBuilder<'a> {
 
         if self.options.update_package_manifest {
             files.push((
-                self.package.path().to_owned(),
+                self.package.manifest_path().to_owned(),
                 self.package.manifest().to_string(),
             ));
         }
@@ -140,7 +140,10 @@ impl<'a> ReleaseRequestBuilder<'a> {
                 }
 
                 if changed {
-                    files.push((package.path().to_owned(), package.manifest().to_string()));
+                    files.push((
+                        package.manifest_path().to_owned(),
+                        package.manifest().to_string(),
+                    ));
                 }
             }
         }
@@ -159,12 +162,7 @@ impl<'a> ReleaseRequestBuilder<'a> {
         let mut release = self.package.build_release_notes(&version)?;
 
         if self.options.update_changelog {
-            let path = self
-                .package
-                .path()
-                .parent()
-                .expect("parent")
-                .join("CHANGELOG.md");
+            let path = self.package.path().join("CHANGELOG.md");
 
             let mut changelog = self.package.changelog().cloned().unwrap_or_default();
 

--- a/packages/ploys/src/project/release/request.rs
+++ b/packages/ploys/src/project/release/request.rs
@@ -109,7 +109,10 @@ impl<'a> ReleaseRequestBuilder<'a> {
         info!("Creating release request");
 
         if self.options.update_package_manifest {
-            files.push((self.package.path().to_owned(), self.package.to_string()));
+            files.push((
+                self.package.path().to_owned(),
+                self.package.manifest().to_string(),
+            ));
         }
 
         if self.options.update_dependent_package_manifests {
@@ -137,7 +140,7 @@ impl<'a> ReleaseRequestBuilder<'a> {
                 }
 
                 if changed {
-                    files.push((package.path().to_owned(), package.to_string()));
+                    files.push((package.path().to_owned(), package.manifest().to_string()));
                 }
             }
         }

--- a/packages/ploys/src/project/release/request.rs
+++ b/packages/ploys/src/project/release/request.rs
@@ -7,16 +7,16 @@ use crate::package::{BumpOrVersion, Package};
 use crate::project::Project;
 
 /// The release request.
-pub struct ReleaseRequest<'a> {
+pub struct ReleaseRequest {
     #[allow(dead_code)]
-    package: Package<'a>,
+    package: Package,
     id: u64,
     title: String,
     notes: Release,
     version: Version,
 }
 
-impl ReleaseRequest<'_> {
+impl ReleaseRequest {
     /// Gets the release request id.
     pub fn id(&self) -> u64 {
         self.id
@@ -44,14 +44,14 @@ impl ReleaseRequest<'_> {
 /// repository.
 pub struct ReleaseRequestBuilder<'a> {
     project: &'a Project,
-    package: Package<'a>,
+    package: Package,
     version: BumpOrVersion,
     options: Options,
 }
 
 impl<'a> ReleaseRequestBuilder<'a> {
     /// Constructs a new release request builder.
-    pub(crate) fn new(project: &'a Project, package: Package<'a>, version: BumpOrVersion) -> Self {
+    pub(crate) fn new(project: &'a Project, package: Package, version: BumpOrVersion) -> Self {
         Self {
             project,
             package,
@@ -85,7 +85,7 @@ impl<'a> ReleaseRequestBuilder<'a> {
     }
 
     /// Finishes the release request.
-    pub fn finish(mut self) -> Result<ReleaseRequest<'a>, crate::project::Error> {
+    pub fn finish(mut self) -> Result<ReleaseRequest, crate::project::Error> {
         let Some(remote) = self.project.repository.as_remote() else {
             return Err(crate::project::Error::Unsupported);
         };

--- a/packages/ploys/src/util/cache.rs
+++ b/packages/ploys/src/util/cache.rs
@@ -1,0 +1,83 @@
+use std::hash::Hash;
+
+use once_map::{Equivalent, OnceMap};
+
+/// A key-value cache supporting writes via shared references.
+pub struct Cache<K, V> {
+    inner: OnceMap<K, Box<Option<V>>>,
+}
+
+impl<K, V> Cache<K, V> {
+    /// Constructs a new cache.
+    pub fn new() -> Self {
+        Self {
+            inner: OnceMap::new(),
+        }
+    }
+}
+
+impl<K, V> Cache<K, V>
+where
+    K: Eq + Hash,
+{
+    /// Gets the value for the given key.
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        Q: Hash + Eq + Equivalent<K> + ?Sized,
+    {
+        self.inner.get(key)?.as_ref()
+    }
+
+    /// Gets the mutable value for the given key.
+    pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+    where
+        Q: Hash + Eq + Equivalent<K> + ?Sized,
+    {
+        self.inner
+            .iter_mut()
+            .find(|(k, _)| key.equivalent(*k))
+            .map(|(_, val)| (**val).as_mut())?
+    }
+}
+
+impl<K, V> Default for Cache<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> Clone for Cache<K, V>
+where
+    K: Clone + Eq + Hash,
+    V: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self
+                .inner
+                .read_only_view()
+                .iter()
+                .map(|(key, val)| (key.clone(), val.clone()))
+                .collect(),
+        }
+    }
+}
+
+impl<K, V, K2, V2> FromIterator<(K2, V2)> for Cache<K, V>
+where
+    K: Eq + Hash,
+    K2: Into<K>,
+    V2: Into<V>,
+{
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = (K2, V2)>,
+    {
+        Self {
+            inner: iter
+                .into_iter()
+                .map(|(key, val)| (key.into(), Box::new(Some(val.into()))))
+                .collect(),
+        }
+    }
+}

--- a/packages/ploys/src/util/cache.rs
+++ b/packages/ploys/src/util/cache.rs
@@ -38,6 +38,14 @@ where
             .find(|(k, _)| key.equivalent(*k))
             .map(|(_, val)| (**val).as_mut())?
     }
+
+    /// Inserts the given key-value pair.
+    pub fn insert(&mut self, key: impl Into<K>, val: impl Into<V>) {
+        let key = key.into();
+
+        self.inner.remove(&key);
+        self.inner.insert(key, |_| Box::new(Some(val.into())));
+    }
 }
 
 impl<K, V> Default for Cache<K, V> {

--- a/packages/ploys/src/util/mod.rs
+++ b/packages/ploys/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod cache;

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -25,6 +25,10 @@ fn test_valid_local_project() -> Result<(), Error> {
         Path::new("packages/ploys/Cargo.toml")
     );
 
+    let changelog = ploys.changelog().unwrap();
+
+    assert!(changelog.get_release("0.1.0").is_some());
+
     Ok(())
 }
 
@@ -58,6 +62,10 @@ fn test_valid_remote_project() -> Result<(), Error> {
         ploys.manifest_path(),
         Path::new("packages/ploys/Cargo.toml")
     );
+
+    let changelog = ploys.changelog().unwrap();
+
+    assert!(changelog.get_release("0.1.0").is_some());
 
     Ok(())
 }

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use ploys::project::{Error, Project};
 use ploys::repository::revision::Revision;
 
@@ -14,6 +16,14 @@ fn test_valid_local_project() -> Result<(), Error> {
 
     assert!(project.packages().any(|pkg| pkg.name() == "ploys"));
     assert!(project.packages().any(|pkg| pkg.name() == "ploys-cli"));
+
+    let ploys = project.get_package("ploys").unwrap();
+
+    assert_eq!(ploys.path(), Path::new("packages/ploys"));
+    assert_eq!(
+        ploys.manifest_path(),
+        Path::new("packages/ploys/Cargo.toml")
+    );
 
     Ok(())
 }
@@ -40,6 +50,14 @@ fn test_valid_remote_project() -> Result<(), Error> {
 
     assert!(project.packages().any(|pkg| pkg.name() == "ploys"));
     assert!(project.packages().any(|pkg| pkg.name() == "ploys-cli"));
+
+    let ploys = project.get_package("ploys").unwrap();
+
+    assert_eq!(ploys.path(), Path::new("packages/ploys"));
+    assert_eq!(
+        ploys.manifest_path(),
+        Path::new("packages/ploys/Cargo.toml")
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Closes #181.

This updates the `Package` type to allow construction outside of a `Project`.

The `Package` type represents a combination of the package manifest and its path from a `Project` type. It does so by storing a shared reference to the package manifest file and the project it came from. It uses the project reference to look up files and release notes from the backing repository. This means that it is tightly linked to the project. However, it is also possible to update the package to set the version independently. This can cause the package to become out of sync with the state of the project.

The short-term goal is to support the `project init` command in #38 and this requires either using template files, adding new builder types for packages and projects, or updating the existing types to support and persist changes. This opts for the latter option as it should be most flexible.

This change updates the `Package` type to remove its dependence on the `Project` type and adds various builder methods to allow it to be manually constructed. A short summary of the changes are as follows:

- The internal reference to the project has been replaced with an optional atomically reference counted repository from #186.
- The reference to the manifest file has been replaced with an owned manifest file.
- The lifetime has been removed.
- Various builder methods have been added to construct the package.
- The package path has been updated from the manifest file to the directory.
- A new `manifest_path` method has been introduced to get the previous path.
- Packages now store and cache files.

These changes should support creating a project builder in #180 by allowing packages to be stored inside the project.

The downside of these changes is that they enable the project to be put in an invalid state using the mutation methods such as `manifest_mut`. This would allow a package manifest to be swapped with another and invalidate the logic, causing panics when the data is not as expected. This may potentially be solved at a later date by introducing mutation guards to restrict how types can be mutated.