### PR TITLE
Refactor unnecessary use of `map_or`

### DIFF
--- a/packages/ploys-api/src/github/webhook/payload.rs
+++ b/packages/ploys-api/src/github/webhook/payload.rs
@@ -50,7 +50,7 @@ where
         let content_type = req.extract_parts::<TypedHeader<ContentType>>().await?;
         let mime: Mime = content_type.0.into();
         let is_json = mime.type_() == "application"
-            && (mime.subtype() == "json" || mime.suffix().map_or(false, |name| name == "json"));
+            && (mime.subtype() == "json" || mime.suffix().is_some_and(|name| name == "json"));
 
         if !is_json {
             return Err(PayloadRejection::ContentType);


### PR DESCRIPTION
This change refactors the unnecessary use of `map_or` in `ploys-api`.

The earlier Rust release `1.84.0` appears to have triggered a new lint caused by the use of `map_or`. The code in question was copied from the implementation of the `Json` extractor in `axum`.

This change resolves the warning by replacing the use of `map_or` with `is_some_and` using the automated fix. This is the same as the updated version of the `Json` extractor in the current release of the `axum` crate.