### PR TITLE
Disable repository cache for branch and tag revisions

### DIFF
--- a/packages/ploys/src/project/release/mod.rs
+++ b/packages/ploys/src/project/release/mod.rs
@@ -72,9 +72,9 @@ impl<'a> ReleaseBuilder<'a> {
             false => format!("{} {version}", self.package.name()),
         };
 
-        let release = self
-            .package
-            .changelog()
+        let changelog = self.package.changelog();
+        let release = changelog
+            .as_ref()
             .and_then(|changelog| changelog.get_release(version.to_string()));
 
         let release = match release {

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -15,6 +15,7 @@ pub mod github;
 
 pub mod revision;
 
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
@@ -59,7 +60,7 @@ impl Repository {
     pub(crate) fn get_file(
         &self,
         path: impl AsRef<Path>,
-    ) -> Result<Option<&File>, crate::project::Error> {
+    ) -> Result<Option<Cow<'_, File>>, crate::project::Error> {
         match self {
             #[cfg(feature = "git")]
             Repository::Git(git) => Ok(git.get_file(path)?),


### PR DESCRIPTION
This disables the repository cache for branch and tag (non-SHA) revisions.

The `Git` and `GitHub` repositories store a revision that can be used to target a commit, branch or tag in the repository. This allows the project to specify which files to use. However, both repositories use an internal cache that stores the first version of a file that it loads. This means that if the repository was changed outside of the program then the updates will not be seen unless the file has not yet been loaded.

This change updates the `Git` and `GitHub` repositories to bypass the cache when the internal `Revision` is not a commit SHA. This necessitated changing the method signatures to return a `Cow` and updating the call sites to handle this. A side-effect is that the `Package::changelog` method now always returns an owned value as there is no easy way to map the `Cow` to the inner `File` variant.

An alternative approach may have been to create a layered cache where files are cached per-commit but this would keep growing as new commits are added.