### PR TITLE
Move `Arc` wrapper from repository to file cache

### DIFF
--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -11,7 +11,6 @@ pub mod manifest;
 
 use std::borrow::{Borrow, Cow};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use semver::Version;
 use tracing::info;
@@ -31,7 +30,7 @@ use self::manifest::{Dependencies, DependenciesMut, Dependency, DependencyMut};
 /// A project package.
 #[derive(Clone)]
 pub struct Package {
-    repository: Option<Arc<Repository>>,
+    repository: Option<Repository>,
     manifest: Manifest,
     path: PathBuf,
     primary: bool,

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -39,8 +39,6 @@ mod error;
 mod packages;
 mod release;
 
-use std::sync::Arc;
-
 use crate::package::{BumpOrVersion, Package};
 use crate::repository::{RepoSpec, Repository};
 
@@ -61,7 +59,7 @@ pub use self::release::{ReleaseBuilder, ReleaseRequest, ReleaseRequestBuilder};
 /// repository = "https://github.com/{project-owner}/{project-name}"
 /// ```
 pub struct Project {
-    pub(crate) repository: Arc<Repository>,
+    pub(crate) repository: Repository,
     config: Config,
 }
 
@@ -77,10 +75,7 @@ impl Project {
             .ok_or(self::config::Error::Invalid)?
             .clone();
 
-        Ok(Self {
-            repository: Arc::new(repository),
-            config,
-        })
+        Ok(Self { repository, config })
     }
 }
 

--- a/packages/ploys/src/repository/git/mod.rs
+++ b/packages/ploys/src/repository/git/mod.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use gix::remote::Direction;
 use gix::traverse::tree::Recorder;
@@ -21,10 +22,11 @@ pub use self::error::Error;
 use super::revision::Revision;
 
 /// The local Git repository.
+#[derive(Clone)]
 pub struct Git {
     repository: ThreadSafeRepository,
     revision: Revision,
-    file_cache: FileCache,
+    file_cache: Arc<FileCache>,
 }
 
 impl Git {
@@ -33,7 +35,7 @@ impl Git {
         Ok(Self {
             repository: ThreadSafeRepository::open(path)?,
             revision: Revision::Head,
-            file_cache: FileCache::new(),
+            file_cache: Arc::new(FileCache::new()),
         })
     }
 }

--- a/packages/ploys/src/repository/github/mod.rs
+++ b/packages/ploys/src/repository/github/mod.rs
@@ -12,6 +12,7 @@ use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use reqwest::header::CONTENT_TYPE;
 use reqwest::StatusCode;
@@ -36,7 +37,7 @@ pub struct GitHub {
     repository: Repository,
     revision: Revision,
     token: Option<String>,
-    file_cache: FileCache,
+    file_cache: Arc<FileCache>,
 }
 
 impl GitHub {
@@ -53,7 +54,7 @@ impl GitHub {
             repository: Repository::new(repo.try_into().map_err(Into::into)?)?,
             revision: Revision::head(),
             token: None,
-            file_cache: FileCache::new(),
+            file_cache: Arc::new(FileCache::new()),
         })
     }
 }

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -28,6 +28,7 @@ pub(crate) use self::remote::Remote;
 pub use self::spec::{Error as RepoSpecError, RepoSpec, ShortRepoSpec};
 
 /// A source code repository.
+#[derive(Clone)]
 pub enum Repository {
     #[cfg(feature = "git")]
     Git(self::git::Git),


### PR DESCRIPTION
This refactors the project to move the `Arc` wrapper from the repository to the file cache.

Both the `Project` and `Package` types store a shared `Arc<Repository>` so that they have access to the same repository and file cache to prevent additional HTTP requests where possible. However, this means that the repository is immutable and there is no way to detach the package from the project. In the future it may be useful to update an existing package to point to a different release tag.

This change simply removes the `Arc` from the repository in the `Project` and `Package` types and adds it to the `Git` and `GitHub` types around the file cache. The `ThreadSafeRepository` should not be too expensive to clone and the HTTP `Client` should already use an interior `Arc`.