### PR TITLE
Remove unused `get_name` and `get_url` repository methods

### DIFF
--- a/packages/ploys/src/repository/git/error.rs
+++ b/packages/ploys/src/repository/git/error.rs
@@ -10,17 +10,6 @@ pub enum Error {
     Io(io::Error),
 }
 
-impl Error {
-    /// Creates a remote not found error.
-    pub(super) fn remote_not_found() -> Self {
-        Self::Gix(GixError::Remote(Box::new(
-            gix::remote::find::existing::Error::NotFound {
-                name: String::from("origin").into(),
-            },
-        )))
-    }
-}
-
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/packages/ploys/src/repository/git/mod.rs
+++ b/packages/ploys/src/repository/git/mod.rs
@@ -10,10 +10,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use gix::remote::Direction;
 use gix::traverse::tree::Recorder;
 use gix::ThreadSafeRepository;
-use url::Url;
 
 use crate::file::{File, FileCache};
 
@@ -59,35 +57,6 @@ impl Git {
 }
 
 impl Git {
-    pub fn get_name(&self) -> Result<String, Error> {
-        let path = self.repository.path().join("..").canonicalize()?;
-
-        if let Some(file_stem) = path.file_stem() {
-            return Ok(file_stem.to_string_lossy().to_string());
-        }
-
-        Err(Error::Io(io::Error::new(
-            io::ErrorKind::Other,
-            "Invalid directory",
-        )))
-    }
-
-    pub fn get_url(&self) -> Result<Url, Error> {
-        let repo = self.repository.to_thread_local();
-
-        match repo.find_default_remote(Direction::Push).transpose()? {
-            Some(remote) => match remote.url(Direction::Push) {
-                Some(url) => Ok(url
-                    .to_bstring()
-                    .to_string()
-                    .parse()
-                    .expect("A repository URL should be valid")),
-                None => Err(Error::remote_not_found()),
-            },
-            None => Err(Error::remote_not_found()),
-        }
-    }
-
     /// Gets the file at the given path.
     pub fn get_file(
         &self,

--- a/packages/ploys/src/repository/github/mod.rs
+++ b/packages/ploys/src/repository/github/mod.rs
@@ -18,7 +18,6 @@ use reqwest::header::CONTENT_TYPE;
 use reqwest::StatusCode;
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use url::Url;
 
 use crate::changelog::Release;
 use crate::file::{File, FileCache};
@@ -132,20 +131,6 @@ impl GitHub {
 }
 
 impl GitHub {
-    pub fn get_name(&self) -> Result<String, Error> {
-        Ok(self.repository.name().to_owned())
-    }
-
-    pub fn get_url(&self) -> Result<Url, Error> {
-        Ok(format!(
-            "https://github.com/{}/{}",
-            self.repository.owner(),
-            self.repository.name()
-        )
-        .parse()
-        .unwrap())
-    }
-
     /// Gets the file at the given path.
     pub fn get_file(
         &self,
@@ -585,19 +570,4 @@ struct TreeResponseEntry {
 struct RepositoryDispatchEvent<T> {
     event_type: String,
     client_payload: T,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{Error, GitHub};
-
-    #[test]
-    fn test_github_url() -> Result<(), Error> {
-        assert_eq!(
-            GitHub::open("ploys/ploys").unwrap().get_url()?,
-            "https://github.com/ploys/ploys".parse().unwrap()
-        );
-
-        Ok(())
-    }
 }

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -19,8 +19,6 @@ use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-use url::Url;
-
 use crate::file::File;
 
 pub use self::error::Error;
@@ -37,26 +35,6 @@ pub enum Repository {
 }
 
 impl Repository {
-    /// Queries the project name.
-    pub fn get_name(&self) -> Result<String, Error> {
-        match self {
-            #[cfg(feature = "git")]
-            Self::Git(git) => Ok(git.get_name()?),
-            #[cfg(feature = "github")]
-            Self::GitHub(github) => Ok(github.get_name()?),
-        }
-    }
-
-    /// Queries the project URL.
-    pub fn get_url(&self) -> Result<Url, Error> {
-        match self {
-            #[cfg(feature = "git")]
-            Self::Git(git) => Ok(git.get_url()?),
-            #[cfg(feature = "github")]
-            Self::GitHub(github) => Ok(github.get_url()?),
-        }
-    }
-
     /// Gets a file at the given path.
     pub(crate) fn get_file(
         &self,


### PR DESCRIPTION
This removes the unused `get_name` and `get_url` repository methods.

Before the introduction of the project configuration file the project name and URL were queried from the repository using the `get_name` and `get_url` methods respectively. These may be useful for importing an existing repository as a project but at the moment they are not required and hinder further development.

This change simply removes the `get_name` and `get_url` methods from the `Git`, `GitHub` and `Repository` types and removes the unused `remote_not_found` GitHub error constructor.