### PR TITLE
Update `get_file_index` to return iterator of paths

### DIFF
--- a/packages/ploys/src/repository/git/mod.rs
+++ b/packages/ploys/src/repository/git/mod.rs
@@ -78,8 +78,11 @@ impl Git {
     }
 
     /// Gets the file index.
-    pub fn get_file_index(&self) -> &BTreeSet<PathBuf> {
-        self.file_cache.get_or_try_index_with(|| self.get_files())
+    pub fn get_file_index(&self) -> impl Iterator<Item = Cow<'_, Path>> {
+        self.file_cache
+            .get_or_try_index_with(|| self.get_files())
+            .iter()
+            .map(|path| Cow::Borrowed(path.as_path()))
     }
 
     pub(crate) fn get_files(&self) -> Result<BTreeSet<PathBuf>, Error> {

--- a/packages/ploys/src/repository/github/mod.rs
+++ b/packages/ploys/src/repository/github/mod.rs
@@ -153,8 +153,11 @@ impl GitHub {
     }
 
     /// Gets the file index.
-    pub fn get_file_index(&self) -> &BTreeSet<PathBuf> {
-        self.file_cache.get_or_try_index_with(|| self.get_files())
+    pub fn get_file_index(&self) -> impl Iterator<Item = Cow<'_, Path>> {
+        self.file_cache
+            .get_or_try_index_with(|| self.get_files())
+            .iter()
+            .map(|path| Cow::Borrowed(path.as_path()))
     }
 
     pub(crate) fn get_files(&self) -> Result<BTreeSet<PathBuf>, Error> {

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -16,8 +16,7 @@ pub mod github;
 pub mod revision;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::file::File;
 
@@ -49,7 +48,7 @@ impl Repository {
     }
 
     /// Gets the file index.
-    pub(crate) fn get_file_index(&self) -> &BTreeSet<PathBuf> {
+    pub(crate) fn get_file_index(&self) -> Box<dyn Iterator<Item = Cow<'_, Path>> + '_> {
         match self {
             #[cfg(feature = "git")]
             Repository::Git(git) => git.get_file_index(),

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -51,9 +51,9 @@ impl Repository {
     pub(crate) fn get_file_index(&self) -> Box<dyn Iterator<Item = Cow<'_, Path>> + '_> {
         match self {
             #[cfg(feature = "git")]
-            Repository::Git(git) => git.get_file_index(),
+            Self::Git(git) => Box::new(git.get_file_index()),
             #[cfg(feature = "github")]
-            Repository::GitHub(github) => github.get_file_index(),
+            Self::GitHub(github) => Box::new(github.get_file_index()),
         }
     }
 


### PR DESCRIPTION
This updates the various `get_file_index` methods to return an iterator of paths.

The `Packages` iterator uses the package manifests to discover packages in a project. However, Cargo package manifests allow for glob patterns to discover packages. For example, this project uses `packages/*`. Therefore the project needed a way to resolve these patterns in a way that worked for both Git and GitHub repositories. The simplest option was to generate a file index and match the file listing against the pattern.

This change updates the `get_file_index` methods to return an iterator of `Cow<'_, Path>` instead of a reference to the `BTreeSet` that is used by the file cache. This will allow for other repository implementations to use different collections or to return uncached paths. The `Repository::get_file_index` method differs slightly as it needs to `Box` the iterators.