### PR TITLE
Bypass file index cache for branch and tag revisions

### DIFF
--- a/packages/ploys/src/project/packages.rs
+++ b/packages/ploys/src/project/packages.rs
@@ -41,14 +41,16 @@ impl Iterator for Packages<'_> {
                         .map(|file| file.map(Cow::into_owned))
                     {
                         if let Ok(members) = manifest.members() {
-                            self.state = State::Manifest {
-                                packages: ManifestPackages {
-                                    project,
-                                    manifest,
-                                    members,
-                                    files: project.repository.get_file_index(),
-                                },
-                            };
+                            if let Ok(files) = project.repository.get_file_index() {
+                                self.state = State::Manifest {
+                                    packages: ManifestPackages {
+                                        project,
+                                        manifest,
+                                        members,
+                                        files,
+                                    },
+                                };
+                            }
                         }
                     }
                 }
@@ -64,9 +66,11 @@ impl Iterator for Packages<'_> {
                             .map(|file| file.map(Cow::into_owned))
                         {
                             if let Ok(members) = manifest.members() {
-                                packages.manifest = manifest;
-                                packages.members = members;
-                                packages.files = packages.project.repository.get_file_index();
+                                if let Ok(files) = packages.project.repository.get_file_index() {
+                                    packages.manifest = manifest;
+                                    packages.members = members;
+                                    packages.files = files;
+                                }
                             }
                         }
                     }

--- a/packages/ploys/src/repository/github/mod.rs
+++ b/packages/ploys/src/repository/github/mod.rs
@@ -153,11 +153,19 @@ impl GitHub {
     }
 
     /// Gets the file index.
-    pub fn get_file_index(&self) -> impl Iterator<Item = Cow<'_, Path>> {
-        self.file_cache
-            .get_or_try_index_with(|| self.get_files())
-            .iter()
-            .map(|path| Cow::Borrowed(path.as_path()))
+    pub fn get_file_index(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = Cow<'_, Path>> + '_>, crate::project::Error> {
+        if !matches!(&self.revision, Revision::Sha(_)) {
+            return Ok(Box::new(self.get_files()?.into_iter().map(Cow::Owned)));
+        }
+
+        Ok(Box::new(
+            self.file_cache
+                .get_or_try_index_with(|| self.get_files())
+                .iter()
+                .map(|path| Cow::Borrowed(path.as_path())),
+        ))
     }
 
     pub(crate) fn get_files(&self) -> Result<BTreeSet<PathBuf>, Error> {

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -53,9 +53,9 @@ impl Repository {
     ) -> Result<Box<dyn Iterator<Item = Cow<'_, Path>> + '_>, crate::project::Error> {
         match self {
             #[cfg(feature = "git")]
-            Self::Git(git) => Ok(Box::new(git.get_file_index()?)),
+            Self::Git(git) => git.get_file_index(),
             #[cfg(feature = "github")]
-            Self::GitHub(github) => Ok(Box::new(github.get_file_index()?)),
+            Self::GitHub(github) => github.get_file_index(),
         }
     }
 

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -48,12 +48,14 @@ impl Repository {
     }
 
     /// Gets the file index.
-    pub(crate) fn get_file_index(&self) -> Box<dyn Iterator<Item = Cow<'_, Path>> + '_> {
+    pub(crate) fn get_file_index(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = Cow<'_, Path>> + '_>, crate::project::Error> {
         match self {
             #[cfg(feature = "git")]
-            Self::Git(git) => Box::new(git.get_file_index()),
+            Self::Git(git) => Ok(Box::new(git.get_file_index()?)),
             #[cfg(feature = "github")]
-            Self::GitHub(github) => Box::new(github.get_file_index()),
+            Self::GitHub(github) => Ok(Box::new(github.get_file_index()?)),
         }
     }
 


### PR DESCRIPTION
This is a follow-up to #194 and #197 to bypass the file index cache for branch and tag revisions.

The previous updates added the ability to bypass the file cache when the repository was not set to a specific commit SHA and updated the `get_file_index` methods to return an iterator to support additional repository types. However, those changes did not bypass the file index cache and so new files would not be supported during package discovery.

This change completes the upgrade to bypass the repository cache by updating the `get_file_index` methods to return a result and generating a new index if the revision is not set to a specific commit SHA. This required the individual repository methods to also return a `Box` on success to support either loading from the cache or generating a new index as they are different iterators.

In the future the packages iterator should be updated to return results so that any errors generating the index can be returned to the user.