### PR TITLE
Remove unused `get_file_contents` repository method

### DIFF
--- a/packages/ploys/src/repository/git/mod.rs
+++ b/packages/ploys/src/repository/git/mod.rs
@@ -112,7 +112,7 @@ impl Git {
         Ok(entries)
     }
 
-    pub fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Error>
+    fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Error>
     where
         P: AsRef<Path>,
     {

--- a/packages/ploys/src/repository/github/mod.rs
+++ b/packages/ploys/src/repository/github/mod.rs
@@ -190,7 +190,7 @@ impl GitHub {
         Ok(entries)
     }
 
-    pub fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Error>
+    fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Error>
     where
         P: AsRef<Path>,
     {

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -58,19 +58,6 @@ impl Repository {
             Self::GitHub(github) => github.get_file_index(),
         }
     }
-
-    /// Queries the contents of a project file.
-    pub fn get_file_contents<P>(&self, path: P) -> Result<Vec<u8>, Error>
-    where
-        P: AsRef<Path>,
-    {
-        match self {
-            #[cfg(feature = "git")]
-            Self::Git(git) => Ok(git.get_file_contents(path)?),
-            #[cfg(feature = "github")]
-            Self::GitHub(github) => Ok(github.get_file_contents(path)?),
-        }
-    }
 }
 
 impl Repository {


### PR DESCRIPTION
This removes the unused `Repository::get_file_contents` method.

The `get_file_contents` method was originally introduced to get the bytes of a file at the given path. This has since been superseded by the `get_file` method to get a parsed file. This method does not use the cache and instead queries the contents directly which would trigger an HTTP request for the GItHub repository.

This change removes the `Repository::get_file_contents` method and updates the `Git::get_file_contents` and `GitHub::get_file_contents` methods to be private. In the future these private methods should be refactored or renamed.