### PR TITLE
Add `Memory` repository type

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -255,3 +255,20 @@ impl TryFrom<crate::repository::github::GitHub> for Project {
         Self::open(repository)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::project::Config;
+    use crate::repository::memory::Memory;
+
+    use super::Project;
+
+    #[test]
+    fn test_project_memory_repository() {
+        let config = Config::from_bytes(b"[project]\nname = \"example\"").unwrap();
+        let repository = Memory::new().with_file("Ploys.toml", config);
+        let project = Project::open(repository).unwrap();
+
+        assert_eq!(project.name(), "example");
+    }
+}

--- a/packages/ploys/src/repository/memory/mod.rs
+++ b/packages/ploys/src/repository/memory/mod.rs
@@ -1,0 +1,55 @@
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::file::File;
+
+/// An in-memory repository.
+#[derive(Clone)]
+pub struct Memory {
+    files: BTreeMap<PathBuf, File>,
+}
+
+impl Memory {
+    /// Creates a new in-memory repository.
+    pub fn new() -> Self {
+        Self {
+            files: BTreeMap::new(),
+        }
+    }
+
+    /// Inserts a file into the repository.
+    pub fn insert_file(&mut self, path: impl Into<PathBuf>, file: impl Into<File>) -> &mut Self {
+        self.files.insert(path.into(), file.into());
+        self
+    }
+
+    /// Builds the repository with the given file.
+    pub fn with_file(mut self, path: impl Into<PathBuf>, file: impl Into<File>) -> Self {
+        self.insert_file(path, file);
+        self
+    }
+}
+
+impl Memory {
+    /// Gets the file at the given path.
+    pub fn get_file(
+        &self,
+        path: impl AsRef<Path>,
+    ) -> Result<Option<Cow<'_, File>>, crate::project::Error> {
+        Ok(self.files.get(path.as_ref()).map(Cow::Borrowed))
+    }
+
+    /// Gets the file index.
+    pub fn get_file_index(
+        &self,
+    ) -> Result<impl Iterator<Item = Cow<'_, Path>>, crate::project::Error> {
+        Ok(self.files.keys().map(|path| Cow::Borrowed(path.as_path())))
+    }
+}
+
+impl Default for Memory {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
This adds a new `Memory` repository type with the ability to add files as a first step towards #180.

The `Project` type currently requires either a `Git` or `GitHub` repository to work and this means that a new empty project cannot be created without manually creating an external repository. There is a need to build a project from scratch for the `project init` command and this is best achieved by a new repository type that would enable the ability to add files.

This change introduces a new `Memory` repository type that can be used to construct a new project using the associated `open` constructor function. This does not provide a way to add or edit files through the project but that can be added later.

This also updates the `Package` type to replace the `Option<Repository>` with just `Repository` to simplify some of the methods now that it can default to using an empty `Memory` repository. This has no external change to the package.

Unfortunately this does not resolve compilation with no default features as the new repository type does not provide its own error type so the error enums would still end up empty even if the repository enum does not.