### PR TITLE
Remove unused `GitHub` repository error variant

### DIFF
--- a/packages/ploys/src/repository/github/error.rs
+++ b/packages/ploys/src/repository/github/error.rs
@@ -9,8 +9,6 @@ use crate::repository::RepoSpecError;
 pub enum Error {
     /// A request error.
     Request(reqwest::Error),
-    /// A parse error.
-    Parse(String),
     /// An I/O error.
     Io(io::Error),
     /// A specification error.
@@ -21,7 +19,6 @@ impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Request(transport) => Display::fmt(transport, f),
-            Self::Parse(message) => write!(f, "Parse error: {message}"),
             Self::Io(err) => Display::fmt(err, f),
             Self::Spec(err) => Display::fmt(err, f),
         }
@@ -34,7 +31,6 @@ impl std::error::Error for Error {
             Self::Request(err) => Some(err),
             Self::Io(err) => Some(err),
             Self::Spec(err) => Some(err),
-            Self::Parse(_) => None,
         }
     }
 }


### PR DESCRIPTION
This removes the unused `Parse` error variant for `GitHub` repositories.

The `GitHub` repository error type has gone through several iterations and it appears that an unused `Parse` error variant has been left in that should be removed.

This change simply removes the error variant.