### PR TITLE
Add `GitLike` trait split from `Remote`

### DIFF
--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -20,7 +20,7 @@ pub mod revision;
 use std::borrow::Cow;
 use std::path::Path;
 
-pub(crate) use self::remote::Remote;
+pub use self::remote::Remote;
 pub use self::spec::{Error as RepoSpecError, RepoSpec, ShortRepoSpec};
 pub use self::vcs::GitLike;
 

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -6,6 +6,7 @@
 mod cache;
 mod remote;
 mod spec;
+mod vcs;
 
 #[cfg(feature = "git")]
 pub mod git;
@@ -21,6 +22,7 @@ use std::path::Path;
 
 pub(crate) use self::remote::Remote;
 pub use self::spec::{Error as RepoSpecError, RepoSpec, ShortRepoSpec};
+pub use self::vcs::GitLike;
 
 /// Defines a file repository.
 pub trait Repository {

--- a/packages/ploys/src/repository/remote.rs
+++ b/packages/ploys/src/repository/remote.rs
@@ -1,23 +1,15 @@
-use std::path::PathBuf;
-
 use semver::Version;
 
 use crate::changelog::Release;
 use crate::package::BumpOrVersion;
 
-use super::Repository;
+use super::GitLike;
 
 /// A remote repository.
 ///
 /// This defines the shared API of a remote repository to simplify feature flag
 /// handling.
-pub trait Remote: Repository {
-    /// Gets the commit SHA.
-    fn sha(&self) -> Result<String, Self::Error>;
-
-    /// Commits the changes to the repository.
-    fn commit(&self, message: &str, files: Vec<(PathBuf, String)>) -> Result<String, Self::Error>;
-
+pub trait Remote: GitLike {
     /// Requests a package release.
     fn request_package_release(
         &self,
@@ -32,15 +24,6 @@ pub trait Remote: Repository {
         version: &Version,
         is_primary: bool,
     ) -> Result<Release, Self::Error>;
-
-    /// Gets the default branch.
-    fn get_default_branch(&self) -> Result<String, Self::Error>;
-
-    /// Creates a new branch.
-    fn create_branch(&self, name: &str) -> Result<(), Self::Error>;
-
-    /// Updates the branch to point to the given SHA.
-    fn update_branch(&self, name: &str, sha: &str) -> Result<(), Self::Error>;
 
     /// Creates a pull request.
     fn create_pull_request(
@@ -67,14 +50,6 @@ impl<T> Remote for &T
 where
     T: Remote,
 {
-    fn sha(&self) -> Result<String, Self::Error> {
-        (*self).sha()
-    }
-
-    fn commit(&self, message: &str, files: Vec<(PathBuf, String)>) -> Result<String, Self::Error> {
-        (*self).commit(message, files)
-    }
-
     fn request_package_release(
         &self,
         package: &str,
@@ -90,18 +65,6 @@ where
         is_primary: bool,
     ) -> Result<Release, Self::Error> {
         (*self).get_changelog_release(package, version, is_primary)
-    }
-
-    fn get_default_branch(&self) -> Result<String, Self::Error> {
-        (*self).get_default_branch()
-    }
-
-    fn create_branch(&self, name: &str) -> Result<(), Self::Error> {
-        (*self).create_branch(name)
-    }
-
-    fn update_branch(&self, name: &str, sha: &str) -> Result<(), Self::Error> {
-        (*self).update_branch(name, sha)
     }
 
     fn create_pull_request(

--- a/packages/ploys/src/repository/vcs.rs
+++ b/packages/ploys/src/repository/vcs.rs
@@ -1,0 +1,46 @@
+use std::path::PathBuf;
+
+use super::Repository;
+
+/// Defines a git-like version control system.
+pub trait GitLike: Repository {
+    /// Gets the commit SHA.
+    fn sha(&self) -> Result<String, Self::Error>;
+
+    /// Commits the changes to the repository.
+    fn commit(&self, message: &str, files: Vec<(PathBuf, String)>) -> Result<String, Self::Error>;
+
+    /// Gets the default branch.
+    fn get_default_branch(&self) -> Result<String, Self::Error>;
+
+    /// Creates a new branch.
+    fn create_branch(&self, name: &str) -> Result<(), Self::Error>;
+
+    /// Updates the branch to point to the given SHA.
+    fn update_branch(&self, name: &str, sha: &str) -> Result<(), Self::Error>;
+}
+
+impl<T> GitLike for &T
+where
+    T: GitLike,
+{
+    fn sha(&self) -> Result<String, Self::Error> {
+        (*self).sha()
+    }
+
+    fn commit(&self, message: &str, files: Vec<(PathBuf, String)>) -> Result<String, Self::Error> {
+        (*self).commit(message, files)
+    }
+
+    fn get_default_branch(&self) -> Result<String, Self::Error> {
+        (*self).get_default_branch()
+    }
+
+    fn create_branch(&self, name: &str) -> Result<(), Self::Error> {
+        (*self).create_branch(name)
+    }
+
+    fn update_branch(&self, name: &str, sha: &str) -> Result<(), Self::Error> {
+        (*self).update_branch(name, sha)
+    }
+}


### PR DESCRIPTION
This adds a new `GitLike` trait by splitting off git-specific functionality from the `Remote` trait.

The introduction of the `Repository` trait and generics in #204 allows for an improved design where different repositories support different functionality. This was previously handled via the `Remote` trait that was implemented only for the `GitHub` repository type. However, this trait includes functionality that may also apply to the `Git` repository so it makes sense to split these out to a separate trait.

This change introduces a new `GitLike` trait using methods from the `Remote` trait related to Git-like repositories. This was initially envisioned to be a `Vcs` trait for any version control system but that might rule out some systems that do not use the same terminology. It is also unlikely that other systems will be supported any time soon.

The new trait is only implemented on the `GitHub` repository type and the `Remote` trait now depends on the `GitLike` trait instead of being separate. This means that there is no effect on the external API as the `Remote` trait was never exported.

The `Remote` trait is now exported but may be replaced in a future update by an `Execute<Flow>` trait implementation instead to allow different repositories to handle flows differently.

The trait is not yet implemented on the `Git` repository type because the `gix` crate does not yet support commit signing and that would likely require bringing back the `git2` crate.