### PR TITLE
Move project `TryFrom` impls to feature modules

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -109,6 +109,14 @@ mod git {
             Self::open(Git::open(path)?.with_revision(revision))
         }
     }
+
+    impl TryFrom<Git> for Project<Git> {
+        type Error = Error<GitError>;
+
+        fn try_from(repository: Git) -> Result<Self, Self::Error> {
+            Self::open(repository)
+        }
+    }
 }
 
 #[cfg(feature = "github")]
@@ -172,6 +180,14 @@ mod github {
                     .with_authentication_token(token)
                     .validated()?,
             )
+        }
+    }
+
+    impl TryFrom<GitHub> for Project<GitHub> {
+        type Error = Error<GitHubError>;
+
+        fn try_from(repository: GitHub) -> Result<Self, Self::Error> {
+            Self::open(repository)
         }
     }
 }
@@ -240,24 +256,6 @@ where
         })?;
 
         Ok(ReleaseBuilder::new(self, package))
-    }
-}
-
-#[cfg(feature = "git")]
-impl TryFrom<crate::repository::git::Git> for Project<crate::repository::git::Git> {
-    type Error = Error<crate::repository::git::Error>;
-
-    fn try_from(repository: crate::repository::git::Git) -> Result<Self, Self::Error> {
-        Self::open(repository)
-    }
-}
-
-#[cfg(feature = "github")]
-impl TryFrom<crate::repository::github::GitHub> for Project<crate::repository::github::GitHub> {
-    type Error = Error<crate::repository::github::Error>;
-
-    fn try_from(repository: crate::repository::github::GitHub) -> Result<Self, Self::Error> {
-        Self::open(repository)
     }
 }
 


### PR DESCRIPTION
This simply refactors the project `TryFrom` implementations by moving them to the feature modules.

The `Project` type implements `TryFrom` for both `Git` and `GitHub` repositories and these implementations are at the bottom of the `project` module. Each is behind their respective feature flag. However, in the same file there are separate submodules to contain the constructors to avoid putting feature flags on each of the imports. This has the side-effect of altering the documentation order for inherent impl blocks but this does not apply to trait impls.

This change refactors the project module to move the `TryFrom<Git>` and `TryFrom<GitHub>` trait impls to the feature modules used for the constructors. This makes sense because these traits are like constructors and it shouldn't affect the documentation order. It means that there is a single feature flag for each repository feature in the module instead of multiple scattered about. The implementation is also cleaner because it no longer needs to use the fully qualified paths.