### PR TITLE
Add `FileSystem` repository type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,6 +2677,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "url",
+ "walkdir",
 ]
 
 [[package]]
@@ -4375,9 +4376,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -9,7 +9,8 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [features]
-default = ["git", "github"]
+default = ["fs", "git", "github"]
+fs = ["dep:walkdir"]
 git = ["dep:gix"]
 github = ["dep:reqwest"]
 
@@ -25,6 +26,7 @@ time = { version = "0.3.36", features = ["serde", "formatting", "parsing"] }
 toml_edit = { version = "0.22.14", features = ["serde"] }
 tracing = "0.1.41"
 url = "2.4.0"
+walkdir = { version = "2.5.0", optional = true }
 
 [dependencies.reqwest]
 version = "0.12.9"

--- a/packages/ploys/src/project/error.rs
+++ b/packages/ploys/src/project/error.rs
@@ -73,6 +73,13 @@ impl<T> From<crate::package::BumpError> for Error<T> {
     }
 }
 
+#[cfg(feature = "fs")]
+impl From<std::io::Error> for Error<std::io::Error> {
+    fn from(err: std::io::Error) -> Self {
+        Self::Repository(err)
+    }
+}
+
 #[cfg(feature = "git")]
 impl From<crate::repository::git::Error> for Error<crate::repository::git::Error> {
     fn from(err: crate::repository::git::Error) -> Self {

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -81,6 +81,33 @@ where
     }
 }
 
+#[cfg(feature = "fs")]
+mod fs {
+    use std::io::Error as IoError;
+    use std::path::PathBuf;
+
+    use crate::repository::fs::FileSystem;
+
+    use super::{Error, Project};
+
+    /// The [`FileSystem`] repository constructors.
+    impl Project<FileSystem> {
+        /// Opens a project from a [`FileSystem`] repository.
+        pub fn fs<P>(path: P) -> Result<Self, Error<IoError>>
+        where
+            P: Into<PathBuf>,
+        {
+            Self::open(FileSystem::open(path))
+        }
+
+        /// Opens a project from a [`FileSystem`] repository in the current
+        /// directory.
+        pub fn current_dir() -> Result<Self, Error<IoError>> {
+            Self::open(FileSystem::current_dir()?)
+        }
+    }
+}
+
 #[cfg(feature = "git")]
 mod git {
     use std::path::PathBuf;

--- a/packages/ploys/src/repository/fs/mod.rs
+++ b/packages/ploys/src/repository/fs/mod.rs
@@ -1,0 +1,64 @@
+use std::borrow::Cow;
+use std::io::{Error, ErrorKind};
+use std::path::{Path, PathBuf};
+
+use walkdir::WalkDir;
+
+use super::Repository;
+
+/// A file system repository.
+#[derive(Clone)]
+pub struct FileSystem {
+    path: PathBuf,
+}
+
+impl FileSystem {
+    /// Opens a file system repository.
+    pub fn open(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// Opens a file system repository in the current directory.
+    pub fn current_dir() -> Result<Self, Error> {
+        Ok(Self {
+            path: std::env::current_dir()?,
+        })
+    }
+}
+
+impl Repository for FileSystem {
+    type Error = Error;
+
+    fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Cow<'_, [u8]>>, Self::Error> {
+        match std::fs::read(self.path.join(path.as_ref())) {
+            Ok(bytes) => Ok(Some(Cow::Owned(bytes))),
+            Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn get_index(&self) -> Result<impl Iterator<Item = Cow<'_, Path>>, Self::Error> {
+        let index = WalkDir::new(&self.path)
+            .into_iter()
+            .filter_entry(|entry| {
+                entry.file_name() != ".git"
+                    && entry.path().strip_prefix(&self.path).ok() != Some(Path::new("target"))
+            })
+            .flat_map(|res| match res {
+                Ok(entry) => match entry.file_type().is_dir() {
+                    true => None,
+                    false => Some(Ok(Cow::Owned(
+                        entry
+                            .path()
+                            .strip_prefix(&self.path)
+                            .expect("prefixed")
+                            .to_owned(),
+                    ))),
+                },
+                Err(err) => Some(Err(err)),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(index.into_iter())
+    }
+}

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -8,6 +8,9 @@ mod remote;
 mod spec;
 mod vcs;
 
+#[cfg(feature = "fs")]
+pub mod fs;
+
 #[cfg(feature = "git")]
 pub mod git;
 

--- a/packages/ploys/tests/project.rs
+++ b/packages/ploys/tests/project.rs
@@ -5,7 +5,36 @@ use ploys::repository::revision::Revision;
 
 #[test]
 #[ignore]
-fn test_valid_local_project() -> Result<(), Error<ploys::repository::git::Error>> {
+fn test_valid_project_fs() -> Result<(), Error<std::io::Error>> {
+    let project = Project::fs("../..")?;
+
+    assert_eq!(project.name(), "ploys");
+    assert_eq!(
+        project.repository().unwrap().to_url(),
+        "https://github.com/ploys/ploys".parse().unwrap()
+    );
+
+    assert!(project.packages().any(|pkg| pkg.name() == "ploys"));
+    assert!(project.packages().any(|pkg| pkg.name() == "ploys-cli"));
+
+    let ploys = project.get_package("ploys").unwrap();
+
+    assert_eq!(ploys.path(), Path::new("packages/ploys"));
+    assert_eq!(
+        ploys.manifest_path(),
+        Path::new("packages/ploys/Cargo.toml")
+    );
+
+    let changelog = ploys.changelog().unwrap();
+
+    assert!(changelog.get_release("0.1.0").is_some());
+
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn test_valid_project_git() -> Result<(), Error<ploys::repository::git::Error>> {
     let project = Project::git("../..")?;
 
     assert_eq!(project.name(), "ploys");
@@ -34,7 +63,7 @@ fn test_valid_local_project() -> Result<(), Error<ploys::repository::git::Error>
 
 #[test]
 #[ignore]
-fn test_valid_remote_project() -> Result<(), Error<ploys::repository::github::Error>> {
+fn test_valid_project_github() -> Result<(), Error<ploys::repository::github::Error>> {
     let revision = std::env::var("GITHUB_SHA")
         .map(Revision::Sha)
         .unwrap_or_default();


### PR DESCRIPTION
This adds a new `FileSystem` repository type to read files in the target directory.

The `Git` repository type was introduced to read a local Git repository but this has the limitation of requiring the repository to be initialised and files to be committed. This is not useful for building new projects that do not yet have a Git repository initialised.

This change introduces a new `FileSystem` repository type behind a new `fs` feature flag using the `walkdir` crate to generate the index. This filters out the `.git` and `target` directories but otherwise returns all files on the file system in the specified directory. This is like the `Git` repository type except that files must be on disk and do not need to be committed.