### PR TITLE
Add `Project::write` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,12 +743,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -759,9 +759,9 @@ checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
@@ -909,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2275,9 +2275,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2673,6 +2673,7 @@ dependencies = [
  "semver",
  "serde",
  "strum 0.26.3",
+ "tempfile",
  "time",
  "toml_edit",
  "tracing",
@@ -3110,15 +3111,15 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3788,14 +3789,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -36,3 +36,4 @@ optional = true
 [dev-dependencies]
 indoc = "2.0.5"
 pretty_assertions = "1.4.1"
+tempfile = "3.15.0"

--- a/packages/ploys/tests/memory.rs
+++ b/packages/ploys/tests/memory.rs
@@ -1,0 +1,25 @@
+use ploys::project::Project;
+use ploys::repository::memory::Memory;
+use tempfile::tempdir;
+
+#[test]
+fn test_project_write() -> Result<(), Box<dyn std::error::Error>> {
+    let memory = Memory::new()
+        .with_file("Ploys.toml", b"[project]\nname = \"example\"")
+        .with_file("Cargo.toml", b"[workspace]\nmembers = [\"packages/*\"]")
+        .with_file(
+            "packages/example/Cargo.toml",
+            b"[package]\nname = \"example\"",
+        );
+
+    let dir = tempdir()?;
+    let project = Project::open(memory)?;
+    let project = project.write(dir.path(), false)?;
+    let package = project.get_package("example").unwrap();
+
+    assert_eq!(package.name(), "example");
+
+    dir.close()?;
+
+    Ok(())
+}


### PR DESCRIPTION
This adds a new `write` method to the `Project` type to persist files to disk.

The aim of the proposed `project init` command in #38 is to allow users to create a new project from scratch. This could be handled by simply cloning a project template from a remote repository but the aim is to be smarter and allow various options to be configured without relying on a templating language. This means that the `Project` type should support different operations to build out the files.

This change adds a new `write` method to the `Project<Memory>` type that simply writes out the configuration and other files in the repository to the file system, upgrading to a `Project<FileSystem>` in the process. This requires an empty directory unless the `force` parameter is set to `true`. This is only implemented for `Memory` repositories to avoid writing from other sources or to the same source.