### PR TITLE
Add project `Config` builder methods

### DIFF
--- a/packages/ploys/src/project/config/mod.rs
+++ b/packages/ploys/src/project/config/mod.rs
@@ -7,8 +7,11 @@ mod error;
 mod project;
 
 use std::fmt::{self, Display};
+use std::str::FromStr;
 
-use toml_edit::{DocumentMut, Item};
+use toml_edit::{value, DocumentMut, Item, Table};
+
+use crate::repository::RepoSpec;
 
 pub use self::error::Error;
 pub use self::project::{Project, ProjectMut};
@@ -18,6 +21,57 @@ pub use self::project::{Project, ProjectMut};
 pub struct Config(DocumentMut);
 
 impl Config {
+    /// Creates a new project config.
+    pub fn new(name: impl Into<String>) -> Self {
+        let mut document = DocumentMut::new();
+
+        document.insert(
+            "project",
+            Item::Table({
+                let mut table = Table::new();
+
+                table.insert("name", value(name.into()));
+                table
+            }),
+        );
+
+        Self(document)
+    }
+
+    /// Gets the project description.
+    pub fn description(&self) -> Option<&str> {
+        self.project().description()
+    }
+
+    /// Sets the project description.
+    pub fn set_description(&mut self, description: impl Into<String>) -> &mut Self {
+        self.project_mut().set_description(description);
+        self
+    }
+
+    /// Builds the config with the given description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.set_description(description);
+        self
+    }
+
+    /// Gets the project repository.
+    pub fn repository(&self) -> Option<RepoSpec> {
+        self.project().repository()
+    }
+
+    /// Sets the project repository.
+    pub fn set_repository(&mut self, repository: impl Into<RepoSpec>) -> &mut Self {
+        self.project_mut().set_repository(repository);
+        self
+    }
+
+    /// Builds the config with the given repository.
+    pub fn with_repository(mut self, repository: impl Into<RepoSpec>) -> Self {
+        self.set_repository(repository);
+        self
+    }
+
     /// The project section.
     pub fn project(&self) -> Project<'_> {
         Project::from_table(
@@ -44,17 +98,7 @@ impl Config {
 impl Config {
     /// Constructs config from the given bytes.
     pub(crate) fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let document: DocumentMut = std::str::from_utf8(bytes)?.parse()?;
-
-        Project::from_table(
-            document
-                .get("project")
-                .and_then(Item::as_table_like)
-                .ok_or(Error::Invalid)?,
-        )
-        .ok_or(Error::Invalid)?;
-
-        Ok(Self(document))
+        std::str::from_utf8(bytes)?.parse()
     }
 }
 
@@ -71,3 +115,54 @@ impl PartialEq for Config {
 }
 
 impl Eq for Config {}
+
+impl FromStr for Config {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let document: DocumentMut = s.parse()?;
+
+        Project::from_table(
+            document
+                .get("project")
+                .and_then(Item::as_table_like)
+                .ok_or(Error::Invalid)?,
+        )
+        .ok_or(Error::Invalid)?;
+
+        Ok(Self(document))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::repository::RepoSpec;
+
+    use super::Config;
+
+    #[test]
+    fn test_builder() {
+        let config = Config::new("example")
+            .with_description("An example repository.")
+            .with_repository("ploys/example".parse::<RepoSpec>().unwrap());
+
+        assert_eq!(config.project().name(), "example");
+        assert_eq!(
+            config.project().description().unwrap(),
+            "An example repository."
+        );
+        assert_eq!(
+            config.project().repository().unwrap(),
+            "ploys/example".parse::<RepoSpec>().unwrap()
+        );
+
+        let expected = indoc::indoc! {r#"
+            [project]
+            name = "example"
+            description = "An example repository."
+            repository = "ploys/example"
+        "#};
+
+        assert_eq!(config.to_string(), expected);
+    }
+}


### PR DESCRIPTION
This adds a number of new methods to build and edit project configuration.

The project `Config` type is used to store project configuration and currently contains the project name, description and repository specification. These properties can be accessed and managed via the `project` and `project_mut` methods but this does not support method chaining from the `Config` type itself. There is also no way to construct the configuration directly.

This change introduces a `new` constructor and includes methods to directly edit the project name, description and repository from the inner `project` table with both `self` and `&mut self` receivers. This also includes a `FromStr` implementation to parse a string to configuration.