### PR TITLE
Add `Project` builder

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -381,8 +381,23 @@ where
 #[cfg(test)]
 mod tests {
     use crate::repository::memory::Memory;
+    use crate::repository::RepoSpec;
 
     use super::Project;
+
+    #[test]
+    fn test_builder() {
+        let project = Project::new("example")
+            .with_description("An example project.")
+            .with_repository("ploys/example".parse::<RepoSpec>().unwrap());
+
+        assert_eq!(project.name(), "example");
+        assert_eq!(project.description().unwrap(), "An example project.");
+        assert_eq!(
+            project.repository().unwrap(),
+            "ploys/example".parse::<RepoSpec>().unwrap()
+        );
+    }
 
     #[test]
     fn test_project_memory_repository() {

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -40,6 +40,7 @@ mod packages;
 mod release;
 
 use crate::package::{BumpOrVersion, Package};
+use crate::repository::memory::Memory;
 use crate::repository::{Remote, RepoSpec, Repository};
 
 pub use self::config::Config;
@@ -58,9 +59,19 @@ pub use self::release::{ReleaseBuilder, ReleaseRequest, ReleaseRequestBuilder};
 /// description = "{project-description}"
 /// repository = "https://github.com/{project-owner}/{project-name}"
 /// ```
-pub struct Project<T> {
+pub struct Project<T = Memory> {
     pub(crate) repository: T,
     config: Config,
+}
+
+impl Project {
+    /// Creates a new project.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            repository: Memory::new(),
+            config: Config::new(name),
+        }
+    }
 }
 
 impl<T> Project<T>
@@ -284,12 +295,36 @@ impl<T> Project<T> {
 
     /// Gets the project description.
     pub fn description(&self) -> Option<&str> {
-        self.config.project().description()
+        self.config.description()
+    }
+
+    /// Sets the project description.
+    pub fn set_description(&mut self, description: impl Into<String>) -> &mut Self {
+        self.config.set_description(description);
+        self
+    }
+
+    /// Builds the project with the given description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.set_description(description);
+        self
     }
 
     /// Gets the project repository.
     pub fn repository(&self) -> Option<RepoSpec> {
-        self.config.project().repository()
+        self.config.repository()
+    }
+
+    /// Sets the project repository.
+    pub fn set_repository(&mut self, repository: impl Into<RepoSpec>) -> &mut Self {
+        self.config.set_repository(repository);
+        self
+    }
+
+    /// Builds the project with the given repository.
+    pub fn with_repository(mut self, repository: impl Into<RepoSpec>) -> Self {
+        self.set_repository(repository);
+        self
     }
 }
 


### PR DESCRIPTION
Closes #180.

This adds a `Project::new` constructor and builder methods.

The goal of #180 was to facilitate #38 but plans have changed and the steps involved have been broken down. The first step is to allow a project to be created and configured without manually passing in a `Memory` repository.

This change updates the `Project` generic with a default of `Memory`, adds a `new` constructor, and adds builder methods to configure the description and repository specification.