### PR TITLE
Update project `Config` builder methods

### DIFF
--- a/packages/ploys/src/project/config/mod.rs
+++ b/packages/ploys/src/project/config/mod.rs
@@ -151,13 +151,10 @@ mod tests {
             .with_description("An example repository.")
             .with_repository("ploys/example".parse::<RepoSpec>().unwrap());
 
-        assert_eq!(config.project().name(), "example");
+        assert_eq!(config.name(), "example");
+        assert_eq!(config.description().unwrap(), "An example repository.");
         assert_eq!(
-            config.project().description().unwrap(),
-            "An example repository."
-        );
-        assert_eq!(
-            config.project().repository().unwrap(),
+            config.repository().unwrap(),
             "ploys/example".parse::<RepoSpec>().unwrap()
         );
 

--- a/packages/ploys/src/project/config/mod.rs
+++ b/packages/ploys/src/project/config/mod.rs
@@ -39,41 +39,41 @@ impl Config {
     }
 
     /// Gets the project name.
-    pub fn name(&self) -> &str {
+    pub fn project_name(&self) -> &str {
         self.project().name()
     }
 
     /// Gets the project description.
-    pub fn description(&self) -> Option<&str> {
+    pub fn project_description(&self) -> Option<&str> {
         self.project().description()
     }
 
     /// Sets the project description.
-    pub fn set_description(&mut self, description: impl Into<String>) -> &mut Self {
+    pub fn set_project_description(&mut self, description: impl Into<String>) -> &mut Self {
         self.project_mut().set_description(description);
         self
     }
 
-    /// Builds the config with the given description.
-    pub fn with_description(mut self, description: impl Into<String>) -> Self {
-        self.set_description(description);
+    /// Builds the config with the given project description.
+    pub fn with_project_description(mut self, description: impl Into<String>) -> Self {
+        self.set_project_description(description);
         self
     }
 
     /// Gets the project repository.
-    pub fn repository(&self) -> Option<RepoSpec> {
+    pub fn project_repository(&self) -> Option<RepoSpec> {
         self.project().repository()
     }
 
     /// Sets the project repository.
-    pub fn set_repository(&mut self, repository: impl Into<RepoSpec>) -> &mut Self {
+    pub fn set_project_repository(&mut self, repository: impl Into<RepoSpec>) -> &mut Self {
         self.project_mut().set_repository(repository);
         self
     }
 
-    /// Builds the config with the given repository.
-    pub fn with_repository(mut self, repository: impl Into<RepoSpec>) -> Self {
-        self.set_repository(repository);
+    /// Builds the config with the given project repository.
+    pub fn with_project_repository(mut self, repository: impl Into<RepoSpec>) -> Self {
+        self.set_project_repository(repository);
         self
     }
 
@@ -148,13 +148,13 @@ mod tests {
     #[test]
     fn test_builder() {
         let config = Config::new("example")
-            .with_description("An example project.")
-            .with_repository("ploys/example".parse::<RepoSpec>().unwrap());
+            .with_project_description("An example project.")
+            .with_project_repository("ploys/example".parse::<RepoSpec>().unwrap());
 
-        assert_eq!(config.name(), "example");
-        assert_eq!(config.description().unwrap(), "An example project.");
+        assert_eq!(config.project_name(), "example");
+        assert_eq!(config.project_description().unwrap(), "An example project.");
         assert_eq!(
-            config.repository().unwrap(),
+            config.project_repository().unwrap(),
             "ploys/example".parse::<RepoSpec>().unwrap()
         );
 

--- a/packages/ploys/src/project/config/mod.rs
+++ b/packages/ploys/src/project/config/mod.rs
@@ -148,11 +148,11 @@ mod tests {
     #[test]
     fn test_builder() {
         let config = Config::new("example")
-            .with_description("An example repository.")
+            .with_description("An example project.")
             .with_repository("ploys/example".parse::<RepoSpec>().unwrap());
 
         assert_eq!(config.name(), "example");
-        assert_eq!(config.description().unwrap(), "An example repository.");
+        assert_eq!(config.description().unwrap(), "An example project.");
         assert_eq!(
             config.repository().unwrap(),
             "ploys/example".parse::<RepoSpec>().unwrap()

--- a/packages/ploys/src/project/config/mod.rs
+++ b/packages/ploys/src/project/config/mod.rs
@@ -161,7 +161,7 @@ mod tests {
         let expected = indoc::indoc! {r#"
             [project]
             name = "example"
-            description = "An example repository."
+            description = "An example project."
             repository = "ploys/example"
         "#};
 

--- a/packages/ploys/src/project/config/mod.rs
+++ b/packages/ploys/src/project/config/mod.rs
@@ -38,6 +38,11 @@ impl Config {
         Self(document)
     }
 
+    /// Gets the project name.
+    pub fn name(&self) -> &str {
+        self.project().name()
+    }
+
     /// Gets the project description.
     pub fn description(&self) -> Option<&str> {
         self.project().description()

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -295,12 +295,12 @@ impl<T> Project<T> {
 
     /// Gets the project description.
     pub fn description(&self) -> Option<&str> {
-        self.config.description()
+        self.config.project_description()
     }
 
     /// Sets the project description.
     pub fn set_description(&mut self, description: impl Into<String>) -> &mut Self {
-        self.config.set_description(description);
+        self.config.set_project_description(description);
         self
     }
 
@@ -312,12 +312,12 @@ impl<T> Project<T> {
 
     /// Gets the project repository.
     pub fn repository(&self) -> Option<RepoSpec> {
-        self.config.repository()
+        self.config.project_repository()
     }
 
     /// Sets the project repository.
     pub fn set_repository(&mut self, repository: impl Into<RepoSpec>) -> &mut Self {
-        self.config.set_repository(repository);
+        self.config.set_project_repository(repository);
         self
     }
 


### PR DESCRIPTION
This is a follow-up to #210 that tweaks the method names and adds a new `project_name` method.

The `Config` type received new builder methods referencing `name`, `description` and `repository` but after merging #211 it became clear that the names were not entirely clear. Although the `Config` type is related to the `Project` type it is its own distinct thing and therefore the names should relate to the project. This will make future builder methods clearer.

This change updates the `Config` builder methods to prefix them with `project_`, adds a new `project_name` method in the same style, and improves the tests to use these new methods.

It was the tests that prompted this change as the name was only tested via the `project` method and the description mentioned *repository* instead of *project*.