### PR TITLE
Add `project init` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.44",
+ "zeroize",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,8 +2730,10 @@ dependencies = [
  "clap",
  "clap-verbosity-flag",
  "console",
+ "dialoguer",
  "ploys",
  "predicates",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/packages/ploys-cli/Cargo.toml
+++ b/packages/ploys-cli/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 anyhow = "1.0.72"
 clap = { version = "4.3.21", features = ["derive", "env"] }
 console = "0.15.7"
+dialoguer = "0.11.0"
 ploys = { version = "0.3.0", path = "../ploys" }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
@@ -25,6 +26,7 @@ default-features = false
 [dev-dependencies]
 assert_cmd = "2.0.12"
 predicates = { version = "3.0.3", features = ["regex"] }
+tempfile = "3.15.0"
 
 [[bin]]
 name = "ploys"

--- a/packages/ploys-cli/src/project/init.rs
+++ b/packages/ploys-cli/src/project/init.rs
@@ -1,0 +1,87 @@
+use std::io::IsTerminal;
+use std::path::PathBuf;
+
+use anyhow::{bail, Error};
+use clap::Args;
+use dialoguer::Input;
+use ploys::project::Project;
+use ploys::repository::RepoSpec;
+
+/// Initializes a new project.
+#[derive(Args)]
+pub struct Init {
+    /// The target path.
+    #[arg(default_value = ".")]
+    path: PathBuf,
+
+    /// The project name.
+    #[arg(long)]
+    name: Option<String>,
+
+    /// The project description.
+    #[arg(long)]
+    description: Option<String>,
+
+    /// The project repository.
+    #[arg(long)]
+    repository: Option<RepoSpec>,
+}
+
+impl Init {
+    /// Executes the command.
+    pub fn exec(self) -> Result<(), Error> {
+        let is_terminal = std::io::stderr().is_terminal();
+
+        let name = match self.name {
+            Some(name) => name,
+            None if !is_terminal => bail!("Expected a project name"),
+            None => Input::<String>::new().with_prompt("Name").interact_text()?,
+        };
+
+        let description = match self.description {
+            Some(description) => Some(description),
+            None if !is_terminal => None,
+            None => {
+                let description = Input::<String>::new()
+                    .with_prompt("Description")
+                    .allow_empty(true)
+                    .interact_text()?;
+
+                match description.is_empty() {
+                    true => None,
+                    false => Some(description),
+                }
+            }
+        };
+
+        let repository = match self.repository {
+            Some(repository) => Some(repository),
+            None if !is_terminal => None,
+            None => {
+                let repository = Input::<String>::new()
+                    .with_prompt("Repository")
+                    .allow_empty(true)
+                    .interact_text()?;
+
+                match repository.is_empty() {
+                    true => None,
+                    false => Some(repository.parse()?),
+                }
+            }
+        };
+
+        let mut project = Project::new(&name);
+
+        if let Some(description) = description {
+            project.set_description(description);
+        }
+
+        if let Some(repository) = repository {
+            project.set_repository(repository);
+        }
+
+        project.write(self.path, false)?;
+
+        Ok(())
+    }
+}

--- a/packages/ploys-cli/src/project/mod.rs
+++ b/packages/ploys-cli/src/project/mod.rs
@@ -1,9 +1,11 @@
 mod info;
+mod init;
 
 use anyhow::Error;
 use clap::{Args, Subcommand};
 
 use self::info::Info;
+use self::init::Init;
 
 /// The project command.
 #[derive(Args)]
@@ -17,6 +19,7 @@ impl Project {
     pub fn exec(self) -> Result<(), Error> {
         match self.command {
             Command::Info(info) => info.exec(),
+            Command::Init(init) => init.exec(),
         }
     }
 }
@@ -26,4 +29,6 @@ impl Project {
 enum Command {
     /// Gets the project information.
     Info(Info),
+    /// Initializes a new project.
+    Init(Init),
 }

--- a/packages/ploys-cli/tests/info.rs
+++ b/packages/ploys-cli/tests/info.rs
@@ -1,0 +1,48 @@
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+use ploys::project::Project;
+use tempfile::tempdir;
+
+#[test]
+fn test_project_init_cwd() {
+    let dir = tempdir().unwrap();
+
+    Command::cargo_bin("ploys")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("project")
+        .arg("init")
+        .arg("--name")
+        .arg("example")
+        .assert()
+        .success();
+
+    let project = Project::fs(dir.path()).unwrap();
+
+    assert_eq!(project.name(), "example");
+
+    dir.close().unwrap();
+}
+
+#[test]
+fn test_project_init_path() {
+    let dir = tempdir().unwrap();
+
+    Command::cargo_bin("ploys")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("project")
+        .arg("init")
+        .arg(dir.path())
+        .arg("--name")
+        .arg("example")
+        .assert()
+        .success();
+
+    let project = Project::fs(dir.path()).unwrap();
+
+    assert_eq!(project.name(), "example");
+
+    dir.close().unwrap();
+}


### PR DESCRIPTION
Closes #38.

This adds a new `project init` command to initialise a new project.

Various projects exist to generate new projects but those typically use templating languages and often cannot be tested in continuous integration environments due to placeholder variables without creating a separate repository or a CI workflow that will be discarded on generation. A smarter design would be to understand the file formats that are being used and to generate files programatically.

The `project init` command should therefore support creating new projects without needing to clone a template repository and make manual changes to configuration.

This change introduces the initial version of the `project init` command that simply generates the project configuration file using the name, description and repository provided via the CLI. This uses the `dialoguer` crate to prompt for missing information in interactive environments. The implementation manually checks that *stderr* is interactive and does not prompt if it is not so that the tests pass correctly.

This expects an empty directory and does not create any other files other than the configuration. This lays the groundwork for supporting additional configuration options to initialise other files. Unfortunately, the `project info` command does not yet support the file system repository type so it is not technically a valid project at this time.