### PR TITLE
Add support for reloading `Project` configuration

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -92,6 +92,31 @@ where
     }
 }
 
+impl<T> Project<T>
+where
+    T: Repository,
+{
+    /// Reloads the project configuration.
+    pub fn reload(&mut self) -> Result<&mut Self, Error<T::Error>> {
+        let config = self
+            .repository
+            .get_file("Ploys.toml")
+            .map_err(Error::Repository)?
+            .ok_or(self::config::Error::Missing)?;
+
+        self.config = Config::from_bytes(&config)?;
+
+        Ok(self)
+    }
+
+    /// Builds the project with reloaded project configuration.
+    pub fn reloaded(mut self) -> Result<Self, Error<T::Error>> {
+        self.reload()?;
+
+        Ok(self)
+    }
+}
+
 #[cfg(feature = "fs")]
 mod fs {
     use std::io::{Error as IoError, ErrorKind};
@@ -402,8 +427,18 @@ mod tests {
     #[test]
     fn test_project_memory_repository() {
         let repository = Memory::new().with_file("Ploys.toml", b"[project]\nname = \"example\"");
-        let project = Project::open(repository).unwrap();
+        let mut project = Project::open(repository).unwrap();
 
         assert_eq!(project.name(), "example");
+        assert_eq!(project.description(), None);
+
+        project.set_description("An example project.");
+
+        assert_eq!(project.description(), Some("An example project."));
+
+        let project = project.reloaded().unwrap();
+
+        assert_eq!(project.name(), "example");
+        assert_eq!(project.description(), None);
     }
 }

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -67,9 +67,11 @@ pub struct Project<T = Memory> {
 impl Project {
     /// Creates a new project.
     pub fn new(name: impl Into<String>) -> Self {
+        let config = Config::new(name);
+
         Self {
-            repository: Memory::new(),
-            config: Config::new(name),
+            repository: Memory::new().with_file("Ploys.toml", config.to_string().into_bytes()),
+            config,
         }
     }
 }
@@ -422,6 +424,12 @@ mod tests {
             project.repository().unwrap(),
             "ploys/example".parse::<RepoSpec>().unwrap()
         );
+
+        let project = project.reloaded().unwrap();
+
+        assert_eq!(project.name(), "example");
+        assert_eq!(project.description(), None);
+        assert_eq!(project.repository(), None);
     }
 
     #[test]


### PR DESCRIPTION
This adds support for reloading project configuration via new `reload` and `reloaded` methods on `Project`.

The `Project` type is a wrapper around a repository that contains the project configuration. This configuration can be updated in the type itself but that does not mean that the changes will be persisted to the repository. It is possible that these changes are no longer desired or the repository has been updated externally. This means that it may be necessary to reload the project configuration from the repository.

This change introduces the `Project::reload` and `Project::reloaded` methods to reload the project configuration from the repository. The `reload` method takes an exclusive reference as the receiver while the `reloaded` method takes ownership.

This also updates the `new` constructor to store the initial configuration in the repository. This means that a `Memory` repository should always support reloading regardless of whether it was constructed via `new` or passed in via `open`.