### PR TITLE
Add ability to upgrade `FileSystem` project to `Git`

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -261,6 +261,14 @@ mod git {
             Self::open(repository)
         }
     }
+
+    impl TryFrom<Project<FileSystem>> for Project<Git> {
+        type Error = Error<GitError>;
+
+        fn try_from(project: Project<FileSystem>) -> Result<Self, Self::Error> {
+            project.into_git(Revision::head())
+        }
+    }
 }
 
 #[cfg(feature = "github")]

--- a/packages/ploys/src/repository/fs/mod.rs
+++ b/packages/ploys/src/repository/fs/mod.rs
@@ -24,6 +24,11 @@ impl FileSystem {
             path: std::env::current_dir()?,
         })
     }
+
+    /// Gets the file system path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
 }
 
 impl Repository for FileSystem {


### PR DESCRIPTION
This adds the ability to upgrade from a `FileSystem` repository to a `Git` repository in a `Project`.

The `Project::<Memory>::write` method was added in #209 to upgrade from a `Memory` repository to a `FileSystem` repository by writing the contents of the repository to the local file system. The upgrade process should also be applied to the `FileSystem` repository to upgrade it to a `Git` repository.

This change introduces a new `Project::<FileSystem>::into_git` method to open a`Git` repository at the same file system location. This uses the same configuration but includes documentation about using `reload` or `reloaded` to update the configuration from the repository. This expects a Git repository to exist but another `commit` method might later be introduced to create a new repository and commit the files.

This change also adds a new `path` method to the `FileSystem` repository type to get the path for the new `into_git` method.