### PR TITLE
Add `Project` and `Package` file handling methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,9 +729,9 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encode_unicode"
@@ -2676,6 +2676,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 name = "ploys"
 version = "0.3.0"
 dependencies = [
+ "either",
  "gix",
  "globset",
  "indoc",

--- a/packages/ploys-cli/src/package/release.rs
+++ b/packages/ploys-cli/src/package/release.rs
@@ -1,3 +1,5 @@
+use std::convert::Infallible;
+
 use anyhow::{bail, Context, Error};
 use clap::Args;
 use ploys::package::BumpOrVersion;
@@ -40,7 +42,7 @@ impl Release {
 
         project
             .get_package(&self.package)
-            .ok_or(ploys::package::Error::NotFound(self.package))?
+            .ok_or(ploys::package::Error::<Infallible>::NotFound(self.package))?
             .request_release(self.version)?;
 
         Ok(())

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -15,6 +15,7 @@ git = ["dep:gix"]
 github = ["dep:reqwest"]
 
 [dependencies]
+either = "1.13.0"
 gix = { version = "0.66.0", optional = true }
 globset = "0.4.13"
 markdown = "=1.0.0-alpha.21"

--- a/packages/ploys/src/package/error.rs
+++ b/packages/ploys/src/package/error.rs
@@ -1,54 +1,96 @@
+use std::convert::Infallible;
 use std::fmt::{self, Display};
 
 /// The package error.
 #[derive(Debug)]
-pub enum Error {
+pub enum Error<T> {
+    /// The repository error.
+    Repository(T),
     /// A package manifest error.
     Manifest(super::manifest::Error),
     /// A package lockfile error.
     Lockfile(super::lockfile::Error),
     /// A package bump error.
     Bump(super::bump::Error),
+    /// A UTF-8 error.
+    Utf8(std::str::Utf8Error),
     /// A package not found error.
     NotFound(String),
 }
 
-impl Display for Error {
+impl<T> Display for Error<T>
+where
+    T: Display,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Repository(err) => Display::fmt(err, f),
             Self::Manifest(err) => Display::fmt(err, f),
             Self::Lockfile(err) => Display::fmt(err, f),
             Self::Bump(err) => Display::fmt(err, f),
+            Self::Utf8(err) => Display::fmt(err, f),
             Self::NotFound(name) => write!(f, "Package not found: `{name}`."),
         }
     }
 }
 
-impl std::error::Error for Error {
+impl<T> std::error::Error for Error<T>
+where
+    T: std::error::Error + 'static,
+{
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            Self::Repository(err) => Some(err),
             Self::Manifest(err) => Some(err),
             Self::Lockfile(err) => Some(err),
             Self::Bump(err) => Some(err),
+            Self::Utf8(err) => Some(err),
             Self::NotFound(_) => None,
         }
     }
 }
 
-impl From<super::manifest::Error> for Error {
+impl<T> From<Infallible> for Error<T> {
+    fn from(err: Infallible) -> Self {
+        match err {}
+    }
+}
+
+impl<T> From<super::manifest::Error> for Error<T> {
     fn from(err: super::manifest::Error) -> Self {
         Self::Manifest(err)
     }
 }
 
-impl From<super::lockfile::Error> for Error {
+impl<T> From<super::lockfile::Error> for Error<T> {
     fn from(err: super::lockfile::Error) -> Self {
         Self::Lockfile(err)
     }
 }
 
-impl From<super::bump::Error> for Error {
+impl<T> From<super::bump::Error> for Error<T> {
     fn from(err: super::bump::Error) -> Self {
         Self::Bump(err)
+    }
+}
+
+#[cfg(feature = "fs")]
+impl From<std::io::Error> for Error<std::io::Error> {
+    fn from(err: std::io::Error) -> Self {
+        Self::Repository(err)
+    }
+}
+
+#[cfg(feature = "git")]
+impl From<crate::repository::git::Error> for Error<crate::repository::git::Error> {
+    fn from(err: crate::repository::git::Error) -> Self {
+        Self::Repository(err)
+    }
+}
+
+#[cfg(feature = "github")]
+impl From<crate::repository::github::Error> for Error<crate::repository::github::Error> {
+    fn from(err: crate::repository::github::Error) -> Self {
+        Self::Repository(err)
     }
 }

--- a/packages/ploys/src/project/error.rs
+++ b/packages/ploys/src/project/error.rs
@@ -3,7 +3,6 @@ use std::fmt::{self, Display};
 
 /// The project error.
 #[derive(Debug)]
-#[non_exhaustive]
 pub enum Error<T> {
     /// The configuration error.
     Config(super::config::Error),
@@ -12,7 +11,9 @@ pub enum Error<T> {
     /// The repository error.
     Repository(T),
     /// The package error.
-    Package(crate::package::Error),
+    Package(crate::package::Error<T>),
+    /// A UTF-8 error.
+    Utf8(std::str::Utf8Error),
 }
 
 impl<T> Display for Error<T>
@@ -25,6 +26,7 @@ where
             Self::Config(err) => Display::fmt(err, f),
             Self::Repository(err) => Display::fmt(err, f),
             Self::Package(err) => Display::fmt(err, f),
+            Self::Utf8(err) => Display::fmt(err, f),
         }
     }
 }
@@ -39,6 +41,7 @@ where
             Self::Config(err) => Some(err),
             Self::Repository(err) => Some(err),
             Self::Package(err) => Some(err),
+            Self::Utf8(err) => Some(err),
         }
     }
 }
@@ -61,8 +64,8 @@ impl<T> From<crate::changelog::Error> for Error<T> {
     }
 }
 
-impl<T> From<crate::package::Error> for Error<T> {
-    fn from(err: crate::package::Error) -> Self {
+impl<T> From<crate::package::Error<T>> for Error<T> {
+    fn from(err: crate::package::Error<T>) -> Self {
         Self::Package(err)
     }
 }


### PR DESCRIPTION
This adds new methods and updates existing methods for the `Project` and `Package` types to handle files.

The `Package` type currently provides the `get_file` method to load a file as bytes. This returns an `Option` and discards any errors. The `Project` type does not provide any way to access the files in the interior repository. Both should provide similar APIs to get and insert files.

This change introduces the `add_file`, `with_file`, `get_file` and `get_file_as` methods to both the `Project` and `Package` types. Inserting files requires a `Memory` repository whereas getting a file accepts any repository. The `get_file_as` method uses the `FromStr` trait and the `Either` type from the `either` crate. This required several changes to the project and package error types.

The `get_file` method implementations return the current configuration from the project and current package manifest from the package, bypassing the repository when provided the specific path.