### PR TITLE
Add `Package` and `Error` generic defaults

### DIFF
--- a/packages/ploys/src/package/error.rs
+++ b/packages/ploys/src/package/error.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display};
 
 /// The package error.
 #[derive(Debug)]
-pub enum Error<T> {
+pub enum Error<T = Infallible> {
     /// The repository error.
     Repository(T),
     /// A package manifest error.

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -31,14 +31,14 @@ use self::manifest::{Dependencies, DependenciesMut, Dependency, DependencyMut};
 
 /// A project package.
 #[derive(Clone)]
-pub struct Package<T> {
+pub struct Package<T = Memory> {
     repository: T,
     manifest: Manifest,
     path: PathBuf,
     primary: bool,
 }
 
-impl Package<Memory> {
+impl Package {
     /// Constructs a new cargo package.
     pub fn new_cargo(name: impl Into<String>) -> Self {
         Self {
@@ -167,7 +167,7 @@ where
     }
 }
 
-impl Package<Memory> {
+impl Package {
     /// Adds a file to the package.
     pub fn add_file(
         &mut self,

--- a/packages/ploys/src/project/error.rs
+++ b/packages/ploys/src/project/error.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display};
 
 /// The project error.
 #[derive(Debug)]
-pub enum Error<T> {
+pub enum Error<T = Infallible> {
     /// The configuration error.
     Config(super::config::Error),
     /// The changelog error.

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -141,7 +141,7 @@ impl<T> Project<T> {
     }
 }
 
-impl Project<Memory> {
+impl Project {
     /// Adds a file to the project.
     pub fn add_file(
         &mut self,


### PR DESCRIPTION
This simply adds generic default type parameters to the `Package` and `Error` types.

The `Project` type was updated with a default generic type parameter of `Memory` such that it is possible to refer to a `Project<Memory>` as just `Project`. The `Package` type should also be updated to use the same default.

This change adds a default type parameter of `Memory` to the `Package` type and `Infallible` to the project and package `Error` types. The generic in these errors is the associated `Repository::Error` which is currently set to `Infallible` for the `Memory` repository. This ensures that the types are consistent. It also changes the file method impl block for the `Project` type to remove the reference to `Memory` to be consistent with the implementation in `Package`.