### PR TITLE
Implement `FromStr` for `CargoManifest` and `CargoLockfile`

### DIFF
--- a/packages/ploys/src/package/lockfile/cargo/mod.rs
+++ b/packages/ploys/src/package/lockfile/cargo/mod.rs
@@ -3,6 +3,7 @@
 mod package;
 
 use std::fmt::{self, Display};
+use std::str::FromStr;
 
 use semver::Version;
 use toml_edit::{DocumentMut, Item};
@@ -46,7 +47,7 @@ impl CargoLockfile {
 impl CargoLockfile {
     /// Creates a manifest from the given bytes.
     pub(crate) fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        Ok(Self(std::str::from_utf8(bytes)?.parse()?))
+        std::str::from_utf8(bytes)?.parse()
     }
 }
 
@@ -63,6 +64,14 @@ impl PartialEq for CargoLockfile {
 }
 
 impl Eq for CargoLockfile {}
+
+impl FromStr for CargoLockfile {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.parse()?))
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/packages/ploys/src/package/manifest/cargo/mod.rs
+++ b/packages/ploys/src/package/manifest/cargo/mod.rs
@@ -6,6 +6,7 @@ mod workspace;
 
 use std::fmt::{self, Display};
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use globset::{Glob, GlobSetBuilder};
 use toml_edit::{DocumentMut, Item, Table, Value};
@@ -100,7 +101,7 @@ impl CargoManifest {
 
     /// Creates a manifest from the given bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        Ok(Self(std::str::from_utf8(bytes)?.parse()?))
+        std::str::from_utf8(bytes)?.parse()
     }
 }
 
@@ -201,6 +202,14 @@ impl PartialEq for CargoManifest {
 }
 
 impl Eq for CargoManifest {}
+
+impl FromStr for CargoManifest {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.parse()?))
+    }
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This simply implements the `FromStr` trait for the `CargoManifest` and `CargoLockfile` types.

The addition of the `get_file_as` method on the `Project` and `Package` types allows users to get files in a specific format but this requires the `FromStr` trait to be implemented. This means that it isn't particularly useful without implementing the trait on the types in the library.

This change implements `FromStr` for Cargo manifests and Cargo lockfiles, and tweaks the `from_bytes` methods to use this implementation. This trait cannot easily be implemented on the parent `Manifest` and `Lockfile` types as that would require trying to parse each variant and it is possible in the future that one format will be a superset of another.