### PR TITLE
Add `CargoManifest` workspace constructor

### DIFF
--- a/packages/ploys/src/package/manifest/cargo/mod.rs
+++ b/packages/ploys/src/package/manifest/cargo/mod.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use globset::{Glob, GlobSetBuilder};
-use toml_edit::{DocumentMut, Item, Table, Value};
+use toml_edit::{value, Array, DocumentMut, Item, Table, Value};
 
 use crate::package::manifest::Members;
 
@@ -37,6 +37,25 @@ impl CargoManifest {
                     let mut table = Table::new();
 
                     table.insert("name", Item::Value(Value::from(name.into())));
+                    table
+                }),
+            );
+            document
+        })
+    }
+
+    /// Constructs a new cargo workspace manifest.
+    pub fn new_workspace() -> Self {
+        Self({
+            let mut document = DocumentMut::new();
+
+            document.insert(
+                "workspace",
+                Item::Table({
+                    let mut table = Table::new();
+
+                    table.insert("resolver", value(2));
+                    table.insert("members", Item::Value(Value::Array(Array::new())));
                     table
                 }),
             );
@@ -215,6 +234,12 @@ impl CargoManifest {
     /// Gets the mutable build dependencies table.
     pub fn build_dependencies_mut(&mut self) -> DependenciesMut<'_> {
         DependenciesMut::new(self.0.entry("build-dependencies"))
+    }
+}
+
+impl Default for CargoManifest {
+    fn default() -> Self {
+        Self::new_workspace()
     }
 }
 


### PR DESCRIPTION
This adds a `new_workspace` constructor to the `CargoManifest` type.

The `CargoManifest` type represents a *Cargo* manifest that can represent a package, a workspace, or both. This type already has a constructor to create a package but there is a need to create a workspace constructor for adding packages to a project.

This change introduces the `new_workspace` constructor for the `CargoManifest` type that sets the resolver version and adds an empty members array. This also includes a `Default` implementation that uses the new constructor.