### PR TITLE
Add ability to add `CargoManifest` workspace members

### DIFF
--- a/packages/ploys/src/package/manifest/cargo/workspace.rs
+++ b/packages/ploys/src/package/manifest/cargo/workspace.rs
@@ -1,4 +1,8 @@
-use toml_edit::{Array, TableLike, Value};
+use std::path::Path;
+
+use either::Either;
+use globset::Glob;
+use toml_edit::{Array, Entry, Item, Table, TableLike, Value};
 
 /// The workspace table.
 pub struct Workspace<'a>(pub(super) &'a dyn TableLike);
@@ -17,6 +21,88 @@ impl<'a> Workspace<'a> {
         match self.0.get("exclude") {
             Some(item) => WorkspaceExclude(item.as_array()),
             None => WorkspaceExclude(None),
+        }
+    }
+}
+
+/// The mutable workspace table.
+pub struct WorkspaceMut<'a> {
+    table: Either<&'a mut dyn TableLike, Option<Entry<'a>>>,
+}
+
+impl<'a> WorkspaceMut<'a> {
+    pub(super) fn new(entry: Entry<'a>) -> Self {
+        Self {
+            table: Either::Right(Some(entry)),
+        }
+    }
+}
+
+impl WorkspaceMut<'_> {
+    /// Adds a member to the workspace.
+    pub fn add_member(&mut self, path: impl AsRef<Path>) {
+        let table = self.table(true).expect("table");
+        let members = table
+            .entry("members")
+            .or_insert_with(|| Item::Value(Value::Array(Array::new())));
+
+        if let Some(members) = members.as_array_mut() {
+            for member in members.iter() {
+                if let Some(member) = member.as_str() {
+                    if path.as_ref() == Path::new(member) {
+                        return;
+                    }
+
+                    if let Ok(glob) = Glob::new(member.trim_start_matches("./")) {
+                        if glob.compile_matcher().is_match(path.as_ref()) {
+                            return;
+                        }
+                    }
+                }
+            }
+
+            members.push(path.as_ref().to_string_lossy().to_string());
+        }
+    }
+}
+
+impl WorkspaceMut<'_> {
+    fn init_table(&mut self, overwrite: bool) -> Option<()> {
+        if let Either::Right(option) = &mut self.table {
+            match option.take().expect("some") {
+                Entry::Occupied(entry) if entry.get().as_table_like().is_some() => {
+                    self.table = Either::Left(entry.into_mut().as_table_like_mut().expect("table"));
+                }
+                Entry::Occupied(mut entry) if overwrite => {
+                    *entry.get_mut() = Item::Table(Table::new());
+
+                    self.table = Either::Left(entry.into_mut().as_table_like_mut().expect("table"));
+                }
+                Entry::Vacant(entry) if overwrite => {
+                    self.table = Either::Left(
+                        entry
+                            .insert(Item::Table(Table::new()))
+                            .as_table_like_mut()
+                            .expect("table"),
+                    );
+                }
+                entry => {
+                    option.replace(entry);
+
+                    return None;
+                }
+            }
+        }
+
+        Some(())
+    }
+
+    fn table(&mut self, overwrite: bool) -> Option<&mut dyn TableLike> {
+        self.init_table(overwrite)?;
+
+        match self.table.as_mut().left() {
+            Some(table) => Some(*table),
+            None => None,
         }
     }
 }


### PR DESCRIPTION
This adds the ability to add new workspace members to the `CargoManifest` type.

The `CargoManifest` type represents either a cargo package, a workspace, or both. In order to support adding new packages to the project there is a need to ensure that the package is included in the workspace member list.

This change adds new `add_workspace_member` and `with_workspace_member` methods to the `CargoManifest` type to allow new members to be added. The implementation checks whether the given path is already covered by a glob pattern and skips it.

This required adding a new `WorkspaceMut` struct with duplicate logic for creating the table if it does not exist. This means that the various types should be refactored to deduplicate this logic.