### PR TITLE
Fix implementation of `PartialEq` for `Changelog`

### DIFF
--- a/packages/ploys/src/changelog/mod.rs
+++ b/packages/ploys/src/changelog/mod.rs
@@ -24,7 +24,7 @@ pub use self::text::{MultilineText, Text};
 /// This uses the [keep a changelog](https://keepachangelog.com) format to parse
 /// and generate changelogs. There is very limited support for deviation from
 /// this format so the changelog should not yet be manually edited.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq)]
 pub struct Changelog(Node);
 
 impl Changelog {
@@ -249,6 +249,12 @@ impl Display for Changelog {
         writeln!(f)?;
 
         Ok(())
+    }
+}
+
+impl PartialEq for Changelog {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_string() == other.to_string()
     }
 }
 


### PR DESCRIPTION
This fixes the implementation of `PartialEq` for `Changelog` by comparing the string representations.

The `Changelog` type supports being created from scratch and being parsed from a string. However, a changelog that has been created from scratch, converted to a string, and then parsed back into a `Changelog` will not be equal as the parsed version includes spans.

This change replaces the derived implementation of `PartialEq` with a manual implementation that simply compares the string representations. This is not ideal as it includes the overhead of converting and allocation but it does reflect the package manifest and lockfile implementations that do the same. In the future it would be best to create custom formats that avoid this but those would be better as a separate project.