### PR TITLE
Add ability to add packages to projects

### DIFF
--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -32,7 +32,7 @@ use self::manifest::{Dependencies, DependenciesMut, DependencyMut, DependencyRef
 /// A project package.
 #[derive(Clone)]
 pub struct Package<T = Memory> {
-    repository: T,
+    pub(crate) repository: T,
     manifest: Manifest,
     path: PathBuf,
     primary: bool,


### PR DESCRIPTION
This adds the ability to add packages to projects.

The `Project` type contains an interior `Memory` repository that stores files and provides the `write` method to persist these to disk. Currently, files can be manually added to the project but it would be useful to allow entire packages to also be added. This would allow the project to update the various configuration files in addition to copying the repository files.

This change adds new `add_package` and `with_package` methods to the `Project` type to add packages to the project. This adds any files in the package to the `packages/{package-name}` directory in the project, copies the package manifest, and updates the *Cargo* manifest and lockfile to include the new entry.

The implementation is not guaranteed to produce an identical result to *Cargo* but it should be good enough for inclusion in the `project init` command. Perhaps the CLI could invoke `cargo build` to validate the project.