### PR TITLE
Add `project init` command default name from path

### DIFF
--- a/packages/ploys-cli/src/project/init.rs
+++ b/packages/ploys-cli/src/project/init.rs
@@ -1,5 +1,5 @@
 use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Error};
 use clap::Args;
@@ -34,6 +34,11 @@ impl Init {
 
         let name = match self.name {
             Some(name) => name,
+            None if self.path != Path::new(".") => match self.path.file_name() {
+                Some(name) => name.to_string_lossy().to_string(),
+                None if !is_terminal => bail!("Expected a project name"),
+                None => Input::<String>::new().with_prompt("Name").interact_text()?,
+            },
             None if !is_terminal => bail!("Expected a project name"),
             None => Input::<String>::new().with_prompt("Name").interact_text()?,
         };


### PR DESCRIPTION
This adds the ability to get the project name from the path in the `project init` command.

The `project init` command includes a `--name` option to allow users to specify the name of the project. If the name is not set and the terminal is interactive then it will instead prompt for the name. However, it should be possible to use the directory name as the default instead.

This change updates the `project init` command to use the directory name when the project name is not set. This only applies when a path is provided, otherwise it will still prompt for the name. This allows the `project init` command to prompt for the name when being created in the current directory but use the directory when called as `project init foo`.

This avoids the need for a second `create` or `new` command to handle directories differently. For example, the `cargo new foo` and `cargo init foo` commands perform the same function but the `new` command requires a path whereas `init` supports the current directory.