### PR TITLE
Fix invalid `CargoManifest` workspace resolver

### DIFF
--- a/packages/ploys/src/package/manifest/cargo/mod.rs
+++ b/packages/ploys/src/package/manifest/cargo/mod.rs
@@ -54,7 +54,7 @@ impl CargoManifest {
                 Item::Table({
                     let mut table = Table::new();
 
-                    table.insert("resolver", value(2));
+                    table.insert("resolver", value("2"));
                     table.insert("members", Item::Value(Value::Array(Array::new())));
                     table
                 }),
@@ -380,7 +380,7 @@ mod tests {
 
         let expected = indoc::indoc! {r#"
             [workspace]
-            resolver = 2
+            resolver = "2"
             members = ["packages/*", "examples/example"]
         "#};
 


### PR DESCRIPTION
This fixes the invalid `CargoManifest` workspace resolver version.

The `cargo build` command produces a warning whenever the `resolver` field is not added to the workspace manifest under the `workspace` table. For this reason the `new_workspace` constructor included a default resolver version. However, this was created as a number but the version is expected to be a string. This causes `cargo build` to fail.

This change simply fixes the `wokspace.resolver` field by using a string instead of a number.