### PR TITLE
Add default `version` and `edition` to `CargoManifest`

### DIFF
--- a/packages/ploys/src/package/manifest/cargo/mod.rs
+++ b/packages/ploys/src/package/manifest/cargo/mod.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use globset::{Glob, GlobSetBuilder};
-use toml_edit::{value, Array, DocumentMut, Item, Table, Value};
+use toml_edit::{value, Array, DocumentMut, Item, Table};
 
 use crate::package::manifest::Members;
 
@@ -36,7 +36,9 @@ impl CargoManifest {
                 Item::Table({
                     let mut table = Table::new();
 
-                    table.insert("name", Item::Value(Value::from(name.into())));
+                    table.insert("name", value(name.into()));
+                    table.insert("version", value("0.0.0"));
+                    table.insert("edition", value("2021"));
                     table
                 }),
             );
@@ -55,7 +57,7 @@ impl CargoManifest {
                     let mut table = Table::new();
 
                     table.insert("resolver", value("2"));
-                    table.insert("members", Item::Value(Value::Array(Array::new())));
+                    table.insert("members", value(Array::new()));
                     table
                 }),
             );


### PR DESCRIPTION
This adds default `version` and `edition` fields to `CargoManifest` packages.

The `cargo init` command creates a `Cargo.toml` package containing the `name`, `version` and `edition` fields. These should also be included in the default package created from calling `CargoManifest::new_package` so that they can be present when a package is created from the `project init` command.

This change simply adds the new `version` and `edition` fields to new packages. It also refactors the other fields to be consistent with using the `value` function from `toml_edit` rather than constructing a full `Item`.