### PR TITLE
Add ability to configure `Package` manifest repository field

### DIFF
--- a/packages/ploys/src/package/manifest/cargo/package.rs
+++ b/packages/ploys/src/package/manifest/cargo/package.rs
@@ -1,5 +1,6 @@
 use semver::Version;
 use toml_edit::{Item, TableLike, Value};
+use url::Url;
 
 /// The package table.
 pub struct Package<'a>(pub(super) &'a dyn TableLike);
@@ -28,6 +29,11 @@ impl<'a> Package<'a> {
             .unwrap_or("0.0.0")
             .parse()
             .expect("version should be valid semver")
+    }
+
+    /// Gets the package repository.
+    pub fn repository(&self) -> Option<Url> {
+        self.0.get("repository")?.as_str()?.parse().ok()
     }
 }
 
@@ -74,6 +80,20 @@ impl PackageMut<'_> {
         let item = self.0.entry("version").or_insert_with(Item::default);
 
         *item = Item::Value(Value::from(version.into().to_string()));
+
+        self
+    }
+
+    /// Gets the package repository.
+    pub fn repository(&self) -> Option<Url> {
+        self.0.get("repository")?.as_str()?.parse().ok()
+    }
+
+    /// Sets the package repository.
+    pub fn set_repository(&mut self, repository: impl Into<Url>) -> &mut Self {
+        let item = self.0.entry("repository").or_insert_with(Item::default);
+
+        *item = Item::Value(Value::from(repository.into().to_string()));
 
         self
     }

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -16,6 +16,7 @@ use std::str::FromStr;
 use either::Either;
 use semver::Version;
 use tracing::info;
+use url::Url;
 
 use crate::changelog::Changelog;
 use crate::project::Project;
@@ -114,6 +115,33 @@ impl<T> Package<T> {
     /// Builds the package with the given version.
     pub fn with_version(mut self, version: impl Into<Version>) -> Self {
         self.set_version(version);
+        self
+    }
+
+    /// Gets the package repository.
+    pub fn repository(&self) -> Option<Url> {
+        match self.manifest() {
+            Manifest::Cargo(cargo) => cargo.package().expect("package").repository(),
+        }
+    }
+
+    /// Sets the package repository.
+    pub fn set_repository(&mut self, repository: impl Into<Url>) -> &mut Self {
+        match self.manifest_mut() {
+            Manifest::Cargo(cargo) => {
+                cargo
+                    .package_mut()
+                    .expect("package")
+                    .set_repository(repository);
+            }
+        }
+
+        self
+    }
+
+    /// Builds the package with the given repository.
+    pub fn with_repository(mut self, repository: impl Into<Url>) -> Self {
+        self.set_repository(repository);
         self
     }
 


### PR DESCRIPTION
This adds the ability to get and set the package manifest repository field.

The *Cargo* package manifest supports the `repository` field to specify the repository URL of the package. There is currently no way to configure this but it would be useful to include in new packages as it is featured on [crates.io](https://crates.io) and used by packages in this repository. This is separate to the `Repository` type used by a package to access files.

This change simply adds new getters and setters to the main `Package` and manifest `Package` and `PackageMut` table types that allow users to get and set the repository URL.