### PR TITLE
Add `project init` command initial package template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,6 +2734,7 @@ dependencies = [
  "dialoguer",
  "ploys",
  "predicates",
+ "strum 0.26.3",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/packages/ploys-cli/Cargo.toml
+++ b/packages/ploys-cli/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "4.3.21", features = ["derive", "env"] }
 console = "0.15.7"
 dialoguer = "0.11.0"
 ploys = { version = "0.3.0", path = "../ploys" }
+strum = { version = "0.26.3", features = ["derive"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 url = "2.4.0"


### PR DESCRIPTION
This adds the ability to select the initial package template for the `project init` command.

The `project init` command currently creates a project but does not provide the ability to create the initial package. The command should provide a way to create a new package at the same time without having to immediately introduce a new `package init` command.

This change adds a new `--template` option to the `project init` command that allows users to select to create a cargo binary, a cargo library, or no package. Selecting either the `cargo-bin` or `cargo-lib` options creates a new package with the same name as the project with a basic `src/main.rs` or `src/lib.rs` file and a changelog. This also uses the same description and sets the repository.

The output has been manually verified to ensure that it compiles and the next steps are to create a Git repository and support other files such as the `README.md` and licenses.