### PR TITLE
Add ability to initialize a new `Git` repository

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -559,6 +559,19 @@ mod fs_git {
                 config: self.config,
             })
         }
+
+        /// Initializes a new [`Git`] repository.
+        ///
+        /// This method creates a new a [`Git`] repository at the same path as
+        /// the [`FileSystem`] repository, keeping the project configuration
+        /// from the current repository. This does not stage or commit changes
+        /// so the new repository will appear to be empty.
+        pub fn init_git(self) -> Result<Project<Git>, Error<GitError>> {
+            Ok(Project {
+                repository: Git::init(self.repository.path())?,
+                config: self.config,
+            })
+        }
     }
 
     impl TryFrom<Project<FileSystem>> for Project<Git> {

--- a/packages/ploys/src/repository/git/error.rs
+++ b/packages/ploys/src/repository/git/error.rs
@@ -33,6 +33,12 @@ impl From<gix::open::Error> for Error {
     }
 }
 
+impl From<gix::init::Error> for Error {
+    fn from(err: gix::init::Error) -> Self {
+        Self::Gix(err.into())
+    }
+}
+
 impl From<gix::remote::find::existing::Error> for Error {
     fn from(err: gix::remote::find::existing::Error) -> Self {
         Self::Gix(err.into())
@@ -68,6 +74,8 @@ impl From<gix::traverse::tree::breadthfirst::Error> for Error {
 pub enum GixError {
     /// An open error.
     Open(Box<gix::open::Error>),
+    /// An init error.
+    Init(Box<gix::init::Error>),
     /// A remote lookup error.
     Remote(Box<gix::remote::find::existing::Error>),
     /// A revision parse error.
@@ -84,6 +92,7 @@ impl Display for GixError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Open(err) => Display::fmt(err, f),
+            Self::Init(err) => Display::fmt(err, f),
             Self::Remote(err) => Display::fmt(err, f),
             Self::Revision(err) => Display::fmt(err, f),
             Self::ObjectFind(err) => Display::fmt(err, f),
@@ -98,6 +107,12 @@ impl std::error::Error for GixError {}
 impl From<gix::open::Error> for GixError {
     fn from(err: gix::open::Error) -> Self {
         Self::Open(Box::new(err))
+    }
+}
+
+impl From<gix::init::Error> for GixError {
+    fn from(err: gix::init::Error) -> Self {
+        Self::Init(Box::new(err))
     }
 }
 

--- a/packages/ploys/src/repository/git/mod.rs
+++ b/packages/ploys/src/repository/git/mod.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeSet;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use gix::create::{Kind, Options};
 use gix::traverse::tree::Recorder;
 use gix::ThreadSafeRepository;
 
@@ -31,6 +32,15 @@ impl Git {
     pub fn open(path: impl Into<PathBuf>) -> Result<Self, Error> {
         Ok(Self {
             repository: ThreadSafeRepository::open(path)?,
+            revision: Revision::Head,
+            cache: Cache::new(),
+        })
+    }
+
+    /// Initializes a Git repository.
+    pub fn init(path: impl AsRef<Path>) -> Result<Self, Error> {
+        Ok(Self {
+            repository: ThreadSafeRepository::init(path, Kind::WithWorktree, Options::default())?,
             revision: Revision::Head,
             cache: Cache::new(),
         })


### PR DESCRIPTION
This adds the ability to initialize a new `Git` repository.

The `Git` repository type provides the `open` constructor to open an existing repository and the `Project` type provides the `into_git` method to convert a `Project<FileSystem>` to `Project<Git>` by calling `Git::open`. However, it is not yet possible to initialize a new Git repository. In order for the `project init` command to initialize a new repository there needs to be an API to do so.

This change introduces the `Git::init` constructor to initialize and open a new repository and the `Project::init_git` method to upgrade a `FileSystem` repository to a new `Git` repository. The `Project` type returned from `init_git` will appear to be empty and a `reload` will error as a result. However, with #234 it should be possible to allow the `Git` type to read files that are not committed.