### PR TITLE
Add `project init` command version control system option

### DIFF
--- a/packages/ploys-cli/src/project/init.rs
+++ b/packages/ploys-cli/src/project/init.rs
@@ -208,6 +208,6 @@ enum Template {
 enum Vcs {
     #[strum(to_string = "Git")]
     Git,
-    #[strum(to_string = "Git")]
+    #[strum(to_string = "None")]
     None,
 }


### PR DESCRIPTION
This adds a new version control system option to the `project init` command.

The `project init` command is designed to be used to create a new project similar to the `cargo init` command but more general and opinionated. One of the options of the `cargo init` command is `--vcs` which allows users to specify the version control system. This defaults to `git` but supports various different version control systems. The `project init` command should also support such an option.

This change introduces a new `--vcs` option to the `project init` command that currently supports either `git` or `none` and defaults to `none` despite this project only really supporting *Git* and *GitHub* repositories at the moment. If the `git` option is provided then the command will add the relevant `.gitignore` for the template and initialize an empty repository.

This does not yet support staging or committing any changes. The latter is waiting on further support for `gix` to handle commit signing.