### PR TITLE
Add ability to configure `Package` manifest authors

### DIFF
--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -145,6 +145,30 @@ impl<T> Package<T> {
         self
     }
 
+    /// Gets the package authors.
+    pub fn authors(&self) -> Option<impl IntoIterator<Item = &str>> {
+        match self.manifest() {
+            Manifest::Cargo(cargo) => cargo.package().expect("package").authors(),
+        }
+    }
+
+    /// Adds a package author.
+    pub fn add_author(&mut self, author: impl Into<String>) -> &mut Self {
+        match self.manifest_mut() {
+            Manifest::Cargo(cargo) => {
+                cargo.package_mut().expect("package").add_author(author);
+            }
+        }
+
+        self
+    }
+
+    /// Builds the package with the given author.
+    pub fn with_author(mut self, author: impl Into<String>) -> Self {
+        self.add_author(author);
+        self
+    }
+
     /// Gets the package path.
     pub fn path(&self) -> &Path {
         &self.path


### PR DESCRIPTION
This adds the ability to configure the authors field in a package manifest.

The `Cargo.toml` package manifest format supports the `authors` field to specify the authors of the package. This should be supported by the `project init` command.

This change simply adds new methods to the `Package` types to get and configure the authors.