### PR TITLE
Fix `clippy::double_ended_iterator_last` and other lints

### DIFF
--- a/packages/ploys/src/repository/github/changelog.rs
+++ b/packages/ploys/src/repository/github/changelog.rs
@@ -172,7 +172,7 @@ fn get_previous_version(
         .iter()
         .filter(|previous_version| *previous_version < version)
         .filter(|previous_version| version.pre.is_empty() || previous_version.pre.is_empty())
-        .last();
+        .next_back();
 
     match previous_version {
         Some(previous_version) => Some(previous_version.clone()),

--- a/packages/ploys/src/repository/github/spec.rs
+++ b/packages/ploys/src/repository/github/spec.rs
@@ -46,7 +46,7 @@ impl GitHubRepoSpec {
 
     /// Gets the repository URL.
     pub fn to_url(&self) -> Url {
-        Url::parse(&format!("https://github.com/{}", self))
+        Url::parse(&format!("https://github.com/{self}"))
             .expect("constructor ensures valid path components")
     }
 


### PR DESCRIPTION
This fixes the `clippy::uninlined_format_args` and `clippy::double_ended_iterator_last` lints.

The project has been on hiatus for some time and the current stable Rust version is now `1.88.0`. Since the previous work on the project, new lints have been introduced and existing lints have been updated.

The `uninlined_format_args` lint introduced in `1.66.0` appears to have been updated to support warning about not inlining `self` in the `format!` macro.

As of version `1.86.0` the `double_ended_iterator_last` lint has provided a warning about using `last` over `next_back` on a double-ended iterator. The previous behaviour caused the entire iterator to be iterated instead of skipping to the end. This would not initially be a problem but as the number of versions grows it could cause a slowdown.

This change simply fixes the two lints by applying the suggested changes, with the first being a minor refactor and the latter being a potential performance fix.