### PR TITLE
Upgrade packages to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
 [workspace]
-resolver = "2"
-members = [
-  "packages/*",
-]
+resolver = "3"
+members = ["packages/*"]

--- a/packages/ploys-api/Cargo.toml
+++ b/packages/ploys-api/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
 homepage = "https://ploys.dev"
 repository = "https://github.com/ploys/ploys"
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -11,7 +11,7 @@ use ploys::project::Project;
 use ploys::repository::revision::Revision;
 use semver::Version;
 use serde::Deserialize;
-use serde_with::{serde_as, DisplayFromStr};
+use serde_with::{DisplayFromStr, serde_as};
 use tracing::{debug, error, instrument};
 
 use crate::state::AppState;
@@ -180,7 +180,7 @@ mod tests {
     use axum::routing::post;
     use axum::{Extension, Router};
     use hmac::{Hmac, Mac};
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
     use sha2::Sha256;
     use tower_service::Service;
 

--- a/packages/ploys-api/src/github/webhook/payload.rs
+++ b/packages/ploys-api/src/github/webhook/payload.rs
@@ -5,15 +5,15 @@ use axum::extract::rejection::{BytesRejection, ExtensionRejection};
 use axum::extract::{FromRequest, Request};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::{async_trait, Extension, RequestExt};
+use axum::{Extension, RequestExt, async_trait};
+use axum_extra::TypedHeader;
 use axum_extra::headers::ContentType;
 use axum_extra::typed_header::TypedHeaderRejection;
-use axum_extra::TypedHeader;
 use hmac::{Hmac, Mac};
 use mime::Mime;
 use serde::Deserialize;
-use serde_json::error::Category;
 use serde_json::Value;
+use serde_json::error::Category;
 use sha2::Sha256;
 
 use super::header::{XGitHubEvent, XHubSignature256};

--- a/packages/ploys-api/src/github/webhook/secret.rs
+++ b/packages/ploys-api/src/github/webhook/secret.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Error};
+use anyhow::{Error, anyhow};
 use shuttle_runtime::SecretStore;
 
 #[derive(Clone)]

--- a/packages/ploys-cli/Cargo.toml
+++ b/packages/ploys-cli/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
 homepage = "https://ploys.dev"
 repository = "https://github.com/ploys/ploys"
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.72"

--- a/packages/ploys-cli/src/package/release.rs
+++ b/packages/ploys-cli/src/package/release.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use anyhow::{bail, Context, Error};
+use anyhow::{Context, Error, bail};
 use clap::Args;
 use ploys::package::BumpOrVersion;
 use ploys::project::Project;

--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::{bail, Error};
+use anyhow::{Error, bail};
 use clap::Args;
 use console::style;
 use ploys::project::Project;

--- a/packages/ploys-cli/src/project/init.rs
+++ b/packages/ploys-cli/src/project/init.rs
@@ -1,14 +1,14 @@
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Context, Error};
+use anyhow::{Context, Error, bail};
 use clap::{Args, ValueEnum};
 use dialoguer::{Input, Select};
 use ploys::changelog::Changelog;
 use ploys::package::Package;
 use ploys::project::Project;
-use ploys::repository::git::Git;
 use ploys::repository::RepoSpec;
+use ploys::repository::git::Git;
 use strum::{Display, VariantArray};
 
 /// Initializes a new project.

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
 homepage = "https://ploys.dev"
 repository = "https://github.com/ploys/ploys"
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 default = ["fs", "git", "github"]

--- a/packages/ploys/src/changelog/change.rs
+++ b/packages/ploys/src/changelog/change.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
 
-use markdown::mdast::Node;
 use markdown::ParseOptions;
+use markdown::mdast::Node;
 
 use super::Text;
 

--- a/packages/ploys/src/changelog/changeset.rs
+++ b/packages/ploys/src/changelog/changeset.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
 
-use markdown::mdast::Node;
 use markdown::ParseOptions;
+use markdown::mdast::Node;
 
 use super::{Change, ChangeRef, MultilineText};
 
@@ -197,7 +197,7 @@ impl<'a> ChangesetRef<'a> {
     }
 
     /// Gets an iterator over the changes.
-    pub fn changes(&self) -> impl Iterator<Item = ChangeRef<'a>> {
+    pub fn changes(&self) -> impl Iterator<Item = ChangeRef<'a>> + use<'a> {
         self.nodes
             .iter()
             .filter_map(|node| match node {

--- a/packages/ploys/src/changelog/mod.rs
+++ b/packages/ploys/src/changelog/mod.rs
@@ -9,8 +9,8 @@ use std::convert::Infallible;
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
-use markdown::mdast::{Node, Root};
 use markdown::ParseOptions;
+use markdown::mdast::{Node, Root};
 
 pub use self::change::{Change, ChangeRef};
 pub use self::changeset::{Changeset, ChangesetRef};

--- a/packages/ploys/src/changelog/release.rs
+++ b/packages/ploys/src/changelog/release.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
 
-use markdown::mdast::Node;
 use markdown::ParseOptions;
+use markdown::mdast::Node;
 
 use super::{Changeset, ChangesetRef, MultilineText, ReferenceRef};
 
@@ -276,12 +276,12 @@ impl<'a> ReleaseRef<'a> {
     }
 
     /// Gets an iterator over the changesets.
-    pub fn changesets(&self) -> impl Iterator<Item = ChangesetRef<'a>> {
+    pub fn changesets(&self) -> impl Iterator<Item = ChangesetRef<'a>> + use<'a> {
         self.get_sections().filter_map(ChangesetRef::from_nodes)
     }
 
     /// Gets an iterator over the references.
-    pub fn references(&self) -> impl Iterator<Item = ReferenceRef<'a>> {
+    pub fn references(&self) -> impl Iterator<Item = ReferenceRef<'a>> + use<'a> {
         self.nodes
             .chunk_by(|node, _| matches!(node, Node::Definition(_)))
             .last()
@@ -342,7 +342,7 @@ impl<'a> ReleaseRef<'a> {
     }
 
     /// Gets the sections separated by a third-level heading.
-    fn get_sections(&self) -> impl Iterator<Item = &'a [Node]> {
+    fn get_sections(&self) -> impl Iterator<Item = &'a [Node]> + use<'a> {
         self.nodes
             .chunk_by(|_, node| !matches!(node, Node::Heading(heading) if heading.depth == 3))
     }

--- a/packages/ploys/src/package/lockfile/cargo/mod.rs
+++ b/packages/ploys/src/package/lockfile/cargo/mod.rs
@@ -6,7 +6,7 @@ use std::fmt::{self, Display};
 use std::str::FromStr;
 
 use semver::Version;
-use toml_edit::{value, Decor, DocumentMut, Item, Key};
+use toml_edit::{Decor, DocumentMut, Item, Key, value};
 
 use crate::package::manifest::CargoManifest;
 
@@ -105,10 +105,10 @@ impl FromStr for CargoLockfile {
 #[cfg(test)]
 mod tests {
     use semver::Version;
-    use toml_edit::{value, ArrayOfTables, DocumentMut, Item, Table};
+    use toml_edit::{ArrayOfTables, DocumentMut, Item, Table, value};
 
-    use crate::package::manifest::cargo::Dependency;
     use crate::package::manifest::CargoManifest;
+    use crate::package::manifest::cargo::Dependency;
 
     use super::CargoLockfile;
 

--- a/packages/ploys/src/package/lockfile/cargo/package.rs
+++ b/packages/ploys/src/package/lockfile/cargo/package.rs
@@ -1,6 +1,6 @@
 use either::Either;
 use semver::Version;
-use toml_edit::{value, Array, ArrayOfTables, Entry, Formatted, Item, Table, TableLike, Value};
+use toml_edit::{Array, ArrayOfTables, Entry, Formatted, Item, Table, TableLike, Value, value};
 
 use crate::package::manifest::CargoManifest;
 

--- a/packages/ploys/src/package/manifest/cargo/dependency.rs
+++ b/packages/ploys/src/package/manifest/cargo/dependency.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use either::Either;
 use semver::Version;
-use toml_edit::{value, Entry, InlineTable, Item, KeyMut, Table, TableLike, Value};
+use toml_edit::{Entry, InlineTable, Item, KeyMut, Table, TableLike, Value, value};
 
 /// A *Cargo* package dependency.
 pub struct Dependency {

--- a/packages/ploys/src/package/manifest/cargo/mod.rs
+++ b/packages/ploys/src/package/manifest/cargo/mod.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use globset::{Glob, GlobSetBuilder};
-use toml_edit::{value, Array, DocumentMut, Item, Table};
+use toml_edit::{Array, DocumentMut, Item, Table, value};
 
 use crate::package::manifest::Members;
 
@@ -289,7 +289,7 @@ mod tests {
     use std::path::Path;
 
     use semver::Version;
-    use toml_edit::{value, DocumentMut};
+    use toml_edit::{DocumentMut, value};
 
     use crate::package::manifest::cargo::Dependency;
 

--- a/packages/ploys/src/package/manifest/cargo/package.rs
+++ b/packages/ploys/src/package/manifest/cargo/package.rs
@@ -1,5 +1,5 @@
 use semver::Version;
-use toml_edit::{value, Array, Entry, Item, TableLike, Value};
+use toml_edit::{Array, Entry, Item, TableLike, Value, value};
 use url::Url;
 
 /// The package table.
@@ -37,7 +37,7 @@ impl<'a> Package<'a> {
     }
 
     /// Gets the package authors.
-    pub fn authors(&self) -> Option<impl IntoIterator<Item = &'a str>> {
+    pub fn authors(&self) -> Option<impl IntoIterator<Item = &'a str> + use<'a>> {
         Some(
             self.0
                 .get("authors")?

--- a/packages/ploys/src/project/config/mod.rs
+++ b/packages/ploys/src/project/config/mod.rs
@@ -9,7 +9,7 @@ mod project;
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
-use toml_edit::{value, DocumentMut, Item, Table};
+use toml_edit::{DocumentMut, Item, Table, value};
 
 use crate::repository::RepoSpec;
 

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -342,9 +342,9 @@ mod fs {
     use std::io::{Error as IoError, ErrorKind};
     use std::path::PathBuf;
 
+    use crate::repository::Repository;
     use crate::repository::fs::FileSystem;
     use crate::repository::memory::Memory;
-    use crate::repository::Repository;
 
     use super::{Error, Project};
 
@@ -590,11 +590,11 @@ mod tests {
     use semver::Version;
 
     use crate::changelog::Changelog;
+    use crate::package::Package;
     use crate::package::lockfile::CargoLockfile;
     use crate::package::manifest::CargoManifest;
-    use crate::package::Package;
-    use crate::repository::memory::Memory;
     use crate::repository::RepoSpec;
+    use crate::repository::memory::Memory;
 
     use super::Project;
 

--- a/packages/ploys/src/repository/git/mod.rs
+++ b/packages/ploys/src/repository/git/mod.rs
@@ -9,16 +9,16 @@ use std::collections::BTreeSet;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use gix::ThreadSafeRepository;
 use gix::config::File;
 use gix::create::{Kind, Options};
 use gix::traverse::tree::Recorder;
-use gix::ThreadSafeRepository;
 
 pub use self::error::Error;
 
+use super::Repository;
 use super::cache::Cache;
 use super::revision::Revision;
-use super::Repository;
 
 /// The local Git repository.
 #[derive(Clone)]

--- a/packages/ploys/src/repository/github/changelog.rs
+++ b/packages/ploys/src/repository/github/changelog.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use time::format_description::well_known::Iso8601;
 use time::OffsetDateTime;
+use time::format_description::well_known::Iso8601;
 
 use crate::changelog::{Change, Changeset, Release};
 

--- a/packages/ploys/src/repository/github/repo.rs
+++ b/packages/ploys/src/repository/github/repo.rs
@@ -1,6 +1,6 @@
+use reqwest::Method;
 use reqwest::blocking::{Client, RequestBuilder};
 use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
-use reqwest::Method;
 
 use super::{Error, GitHubRepoSpec};
 


### PR DESCRIPTION
This upgrades the packages to use the latest Rust 2024 edition.

Since the previous release, the 2024 edition of Rust has been released with some significant changes. Although the codebase doesn't need to explicitly use anything from this edition yet, it is always best to keep up-to-date in case new features are needed in the future.

This change refactors the various packages to use the new 2024 edition. The most notable and noisy change is that the order of imports has been updated. The other big change is how `impl Trait` captures lifetimes and now requires the use of the `use` keyword to specify that certain methods don't capture the lifetime of the receiver.