### PR TITLE
Update `CargoManifest` default edition and resolver

### DIFF
--- a/packages/ploys/src/package/manifest/cargo/mod.rs
+++ b/packages/ploys/src/package/manifest/cargo/mod.rs
@@ -38,7 +38,7 @@ impl CargoManifest {
 
                     table.insert("name", value(name.into()));
                     table.insert("version", value("0.0.0"));
-                    table.insert("edition", value("2021"));
+                    table.insert("edition", value("2024"));
                     table
                 }),
             );
@@ -56,7 +56,7 @@ impl CargoManifest {
                 Item::Table({
                     let mut table = Table::new();
 
-                    table.insert("resolver", value("2"));
+                    table.insert("resolver", value("3"));
                     table.insert("members", value(Array::new()));
                     table
                 }),

--- a/packages/ploys/src/package/manifest/cargo/mod.rs
+++ b/packages/ploys/src/package/manifest/cargo/mod.rs
@@ -382,7 +382,7 @@ mod tests {
 
         let expected = indoc::indoc! {r#"
             [workspace]
-            resolver = "2"
+            resolver = "3"
             members = ["packages/*", "examples/example"]
         "#};
 


### PR DESCRIPTION
This updates the default `edition` and `resolver` fields in `CargoManifest` to `2024` and `3` respectively.

Both Rust and Cargo are continually being updated and the `2024` edition was released earlier in the year. This project should aim to keep up-to-date so that newly initialised projects and packages are always on the latest version. These can be manually downgraded if needed but that is less likely than wanting to use the latest.

This change simply updates the `CargoManifest ::new_package` and `CargoManifest ::new_workspace` constructors to use the latest values.