### PR TITLE
Bump `markdown` to `1.0.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,9 +2294,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markdown"
-version = "1.0.0-alpha.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6491e6c702bf7e3b24e769d800746d5f2c06a6c6a2db7992612e0f429029e81"
+checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
 dependencies = [
  "unicode-id",
 ]

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -18,7 +18,7 @@ github = ["dep:reqwest"]
 either = "1.13.0"
 gix = { version = "0.70.0", optional = true }
 globset = "0.4.13"
-markdown = "=1.0.0-alpha.21"
+markdown = "1.0.0"
 once_cell = "1.20.2"
 semver = "1.0.19"
 serde = { version = "1.0.185", features = ["derive"] }


### PR DESCRIPTION
This bumps the `markdown` crate to `1.0.0`.

The project previously used an alpha version of the `markdown` crate as it was still in development, but it has since been released.

This change simply updates the dependency version as there are no code changes required.