### PR TITLE
Refactor collapsible `if let` chains

### DIFF
--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -33,16 +33,16 @@ pub async fn receive(
     match payload {
         Payload::PullRequest(payload) => match &*payload.action {
             "closed" if payload.pull_request.merged => {
-                if payload.pull_request.head.r#ref.starts_with("release/") {
-                    if let Some(sha) = &payload.pull_request.merge_commit_sha {
-                        create_release(
-                            payload.pull_request.head.r#ref[8..].to_owned(),
-                            sha.clone(),
-                            payload,
-                            &state,
-                        )
-                        .await?;
-                    }
+                if payload.pull_request.head.r#ref.starts_with("release/")
+                    && let Some(sha) = &payload.pull_request.merge_commit_sha
+                {
+                    create_release(
+                        payload.pull_request.head.r#ref[8..].to_owned(),
+                        sha.clone(),
+                        payload,
+                        &state,
+                    )
+                    .await?;
                 }
 
                 Ok(())

--- a/packages/ploys-cli/src/project/init.rs
+++ b/packages/ploys-cli/src/project/init.rs
@@ -125,10 +125,10 @@ impl Init {
             true => {
                 let mut author = format!("The {name} Project Developers");
 
-                if let Vcs::Git = vcs {
-                    if let Some(git_author) = Git::get_author() {
-                        author = git_author;
-                    }
+                if let Vcs::Git = vcs
+                    && let Some(git_author) = Git::get_author()
+                {
+                    author = git_author;
                 };
 
                 let author = Input::<String>::new()
@@ -203,10 +203,10 @@ impl Init {
             Template::None => {}
         }
 
-        if let Vcs::Git = vcs {
-            if let Template::CargoBin | Template::CargoLib = template {
-                project.add_file(".gitignore", b"/target\n");
-            }
+        if let Vcs::Git = vcs
+            && let Template::CargoBin | Template::CargoLib = template
+        {
+            project.add_file(".gitignore", b"/target\n");
         }
 
         if !self.path.exists() {

--- a/packages/ploys/src/changelog/change.rs
+++ b/packages/ploys/src/changelog/change.rs
@@ -55,32 +55,32 @@ impl Change {
             nodes.extend(root.children);
         }
 
-        if let Some(Node::Paragraph(paragraph)) = nodes.first_mut() {
-            if let Some((label, url)) = self.url {
-                if let Some(Node::Text(text)) = paragraph.children.last_mut() {
-                    text.value.push_str(" (");
-                } else {
-                    paragraph.children.push(Node::Text(markdown::mdast::Text {
-                        value: String::from(" ("),
-                        position: None,
-                    }));
-                }
-
-                paragraph.children.push(Node::Link(markdown::mdast::Link {
-                    children: vec![Node::Text(markdown::mdast::Text {
-                        value: label,
-                        position: None,
-                    })],
-                    position: None,
-                    url,
-                    title: None,
-                }));
-
+        if let Some(Node::Paragraph(paragraph)) = nodes.first_mut()
+            && let Some((label, url)) = self.url
+        {
+            if let Some(Node::Text(text)) = paragraph.children.last_mut() {
+                text.value.push_str(" (");
+            } else {
                 paragraph.children.push(Node::Text(markdown::mdast::Text {
-                    value: String::from(")"),
+                    value: String::from(" ("),
                     position: None,
                 }));
             }
+
+            paragraph.children.push(Node::Link(markdown::mdast::Link {
+                children: vec![Node::Text(markdown::mdast::Text {
+                    value: label,
+                    position: None,
+                })],
+                position: None,
+                url,
+                title: None,
+            }));
+
+            paragraph.children.push(Node::Text(markdown::mdast::Text {
+                value: String::from(")"),
+                position: None,
+            }));
         }
 
         nodes

--- a/packages/ploys/src/package/manifest/cargo/workspace.rs
+++ b/packages/ploys/src/package/manifest/cargo/workspace.rs
@@ -53,10 +53,10 @@ impl WorkspaceMut<'_> {
                         return;
                     }
 
-                    if let Ok(glob) = Glob::new(member.trim_start_matches("./")) {
-                        if glob.compile_matcher().is_match(path.as_ref()) {
-                            return;
-                        }
+                    if let Ok(glob) = Glob::new(member.trim_start_matches("./"))
+                        && glob.compile_matcher().is_match(path.as_ref())
+                    {
+                        return;
                     }
                 }
             }

--- a/packages/ploys/src/project/packages.rs
+++ b/packages/ploys/src/project/packages.rs
@@ -44,19 +44,18 @@ where
                         .flatten()
                         .and_then(|bytes| Manifest::from_bytes(kind, &bytes).ok());
 
-                    if let Some(manifest) = manifest {
-                        if let Ok(members) = manifest.members() {
-                            if let Ok(files) = project.repository.get_index() {
-                                self.state = State::Manifest {
-                                    packages: ManifestPackages {
-                                        project,
-                                        manifest,
-                                        members,
-                                        files: Box::new(files),
-                                    },
-                                };
-                            }
-                        }
+                    if let Some(manifest) = manifest
+                        && let Ok(members) = manifest.members()
+                        && let Ok(files) = project.repository.get_index()
+                    {
+                        self.state = State::Manifest {
+                            packages: ManifestPackages {
+                                project,
+                                manifest,
+                                members,
+                                files: Box::new(files),
+                            },
+                        };
                     }
                 }
                 State::Manifest { packages } => match packages.next() {
@@ -71,14 +70,13 @@ where
                             .flatten()
                             .and_then(|bytes| Manifest::from_bytes(kind, &bytes).ok());
 
-                        if let Some(manifest) = manifest {
-                            if let Ok(members) = manifest.members() {
-                                if let Ok(files) = packages.project.repository.get_index() {
-                                    packages.manifest = manifest;
-                                    packages.members = members;
-                                    packages.files = Box::new(files);
-                                }
-                            }
+                        if let Some(manifest) = manifest
+                            && let Ok(members) = manifest.members()
+                            && let Ok(files) = packages.project.repository.get_index()
+                        {
+                            packages.manifest = manifest;
+                            packages.members = members;
+                            packages.files = Box::new(files);
                         }
                     }
                 },

--- a/packages/ploys/src/project/release/request.rs
+++ b/packages/ploys/src/project/release/request.rs
@@ -154,20 +154,20 @@ where
             }
         }
 
-        if self.options.update_lockfile {
-            if let Some(path) = self.package.kind().lockfile_name() {
-                let lockfile = self
-                    .project
-                    .repository
-                    .get_file(path)
-                    .ok()
-                    .flatten()
-                    .and_then(|bytes| Lockfile::from_bytes(self.package.kind(), &bytes).ok());
+        if self.options.update_lockfile
+            && let Some(path) = self.package.kind().lockfile_name()
+        {
+            let lockfile = self
+                .project
+                .repository
+                .get_file(path)
+                .ok()
+                .flatten()
+                .and_then(|bytes| Lockfile::from_bytes(self.package.kind(), &bytes).ok());
 
-                if let Some(mut lockfile) = lockfile {
-                    lockfile.set_package_version(self.package.name(), version.clone());
-                    files.push((path.to_owned(), lockfile.to_string()));
-                }
+            if let Some(mut lockfile) = lockfile {
+                lockfile.set_package_version(self.package.name(), version.clone());
+                files.push((path.to_owned(), lockfile.to_string()));
             }
         }
 


### PR DESCRIPTION
This resolves the `clippy::collapsible_if` lint in Rust `1.89.0`.

The 2024 edition of Rust [introduced](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/let-chains.html#let-chains-in-if-and-while) the [ability](https://rust-for-c-programmers.com/ch21/21_15_if_let_chains_rust_2024.html#2115-if-let-chains-rust-2024) to chain `let` expressions in an `if` condition. This allows nested `if` expressions to be collapsed into a single expression. However, the `collapsible_if` clippy lint was not updated to suggest collapsing `if let` until the current release.

This change simply refactors the code to avoid triggering the lint by collapsing nested `if let` expressions. Some of the changes may be better off as a `match` but the additional variants to do so have not been implemented yet so that can wait.
