### PR TITLE
Replace repository file `Cow<[u8]>` with `Bytes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,6 +2570,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 name = "ploys"
 version = "0.4.0"
 dependencies = [
+ "bytes",
  "either",
  "gix",
  "globset",

--- a/packages/ploys-cli/src/project/init.rs
+++ b/packages/ploys-cli/src/project/init.rs
@@ -174,7 +174,7 @@ impl Init {
 
                 package.add_file(
                     "src/main.rs",
-                    b"fn main() {\n    println!(\"Hello, world!\");\n}\n",
+                    "fn main() {\n    println!(\"Hello, world!\");\n}\n",
                 );
                 package.add_file("CHANGELOG.md", Changelog::new().to_string().into_bytes());
                 project.add_package(package)?;
@@ -196,7 +196,7 @@ impl Init {
                     }
                 }
 
-                package.add_file("src/lib.rs", b"\n");
+                package.add_file("src/lib.rs", "\n");
                 package.add_file("CHANGELOG.md", Changelog::new().to_string().into_bytes());
                 project.add_package(package)?;
             }
@@ -206,7 +206,7 @@ impl Init {
         if let Vcs::Git = vcs
             && let Template::CargoBin | Template::CargoLib = template
         {
-            project.add_file(".gitignore", b"/target\n");
+            project.add_file(".gitignore", "/target\n");
         }
 
         if !self.path.exists() {

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -15,6 +15,7 @@ git = ["dep:gix"]
 github = ["dep:reqwest"]
 
 [dependencies]
+bytes = "1.10.1"
 either = "1.13.0"
 gix = { version = "0.70.0", optional = true }
 globset = "0.4.13"

--- a/packages/ploys/src/repository/fs/mod.rs
+++ b/packages/ploys/src/repository/fs/mod.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
 
+use bytes::Bytes;
 use walkdir::WalkDir;
 
 use super::Repository;
@@ -34,9 +35,9 @@ impl FileSystem {
 impl Repository for FileSystem {
     type Error = Error;
 
-    fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Cow<'_, [u8]>>, Self::Error> {
+    fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error> {
         match std::fs::read(self.path.join(path.as_ref())) {
-            Ok(bytes) => Ok(Some(Cow::Owned(bytes))),
+            Ok(bytes) => Ok(Some(bytes.into())),
             Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
             Err(err) => Err(err),
         }

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -23,6 +23,8 @@ pub mod revision;
 use std::borrow::Cow;
 use std::path::Path;
 
+use bytes::Bytes;
+
 pub use self::remote::Remote;
 pub use self::spec::{Error as RepoSpecError, RepoSpec, ShortRepoSpec};
 pub use self::vcs::GitLike;
@@ -32,7 +34,7 @@ pub trait Repository {
     type Error;
 
     /// Gets a file at the given path.
-    fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Cow<'_, [u8]>>, Self::Error>;
+    fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error>;
 
     /// Gets the index.
     fn get_index(&self) -> Result<impl Iterator<Item = Cow<'_, Path>>, Self::Error>;
@@ -44,7 +46,7 @@ where
 {
     type Error = T::Error;
 
-    fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Cow<'_, [u8]>>, Self::Error> {
+    fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error> {
         (*self).get_file(path)
     }
 

--- a/packages/ploys/tests/memory.rs
+++ b/packages/ploys/tests/memory.rs
@@ -5,11 +5,11 @@ use tempfile::tempdir;
 #[test]
 fn test_project_write() -> Result<(), Box<dyn std::error::Error>> {
     let memory = Memory::new()
-        .with_file("Ploys.toml", b"[project]\nname = \"example\"")
-        .with_file("Cargo.toml", b"[workspace]\nmembers = [\"packages/*\"]")
+        .with_file("Ploys.toml", "[project]\nname = \"example\"")
+        .with_file("Cargo.toml", "[workspace]\nmembers = [\"packages/*\"]")
         .with_file(
             "packages/example/Cargo.toml",
-            b"[package]\nname = \"example\"",
+            "[package]\nname = \"example\"",
         );
 
     let dir = tempdir()?;


### PR DESCRIPTION
This replaces the usage of `Cow<[u8]>` for repository file contents with `Bytes` from the `bytes` crate.

The repository file contents was stored as a `Box<[u8]>` as this was deemed the best representation for a fixed-length heap-allocated collection of bytes. Until #194 the repository methods would return a reference to the internal bytes, but once caching was removed in some scenarios it was updated to return a `Cow`. This enabled the addition of the `FileSystem` repository type in #207 which would always return owned bytes as a `Vec`. However, this representation still allowed for references to be returned which constrains the repository implementations.

In order to support #255, there needs to be a way to update existing projects with a `FileSystem` or `Git` repository. The problem is that the design of the repositories needs to be reworked to use multiple repositories together. Updating the repositories to be cheaply cloned while allowing the `Memory` repository to share data across instances is the first step towards those changes. This means that the repositories can no longer return references to interior data.

This change replaces the usage of `Cow<[u8]>` with `Bytes` from the `bytes` crate to allow cached or stored file contents to be cheaply cloned without allocating new memory each time. This includes changing the storage and all methods that read and write file contents. At the same time, this improves the ergonomics for adding files as both `String` and `&str` can be passed in rather than raw bytes.