### PR TITLE
Replace repository file `Cow<Path>` with `PathBuf`

### DIFF
--- a/packages/ploys/src/project/packages.rs
+++ b/packages/ploys/src/project/packages.rs
@@ -1,6 +1,5 @@
-use std::borrow::Cow;
 use std::iter::FusedIterator;
-use std::path::Path;
+use std::path::PathBuf;
 
 use strum::IntoEnumIterator;
 
@@ -98,7 +97,7 @@ struct ManifestPackages<'a, T> {
     project: &'a Project<T>,
     manifest: Manifest,
     members: Members,
-    files: Box<dyn Iterator<Item = Cow<'a, Path>> + 'a>,
+    files: Box<dyn Iterator<Item = PathBuf> + 'a>,
 }
 
 impl<'a, T> Iterator for ManifestPackages<'a, T>

--- a/packages/ploys/src/repository/cache.rs
+++ b/packages/ploys/src/repository/cache.rs
@@ -60,7 +60,7 @@ impl Cache {
     }
 
     /// Gets or inserts the index.
-    pub fn get_or_try_index<E, F>(&self, with: F) -> Result<impl Iterator<Item = &Path>, E>
+    pub fn get_or_try_index<E, F>(&self, with: F) -> Result<impl Iterator<Item = PathBuf>, E>
     where
         F: FnOnce() -> Result<BTreeSet<PathBuf>, E>,
     {
@@ -73,7 +73,7 @@ impl Cache {
                         .collect()
                 })
             })
-            .map(|index| index.keys().map(PathBuf::as_path))
+            .map(|index| index.keys().map(Clone::clone))
     }
 
     /// Gets or inserts the index and file with the given path.

--- a/packages/ploys/src/repository/fs/mod.rs
+++ b/packages/ploys/src/repository/fs/mod.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
 
@@ -43,7 +42,7 @@ impl Repository for FileSystem {
         }
     }
 
-    fn get_index(&self) -> Result<impl Iterator<Item = Cow<'_, Path>>, Self::Error> {
+    fn get_index(&self) -> Result<impl Iterator<Item = PathBuf>, Self::Error> {
         let index = WalkDir::new(&self.path)
             .into_iter()
             .filter_entry(|entry| {
@@ -53,13 +52,11 @@ impl Repository for FileSystem {
             .flat_map(|res| match res {
                 Ok(entry) => match entry.file_type().is_dir() {
                     true => None,
-                    false => Some(Ok(Cow::Owned(
-                        entry
-                            .path()
-                            .strip_prefix(&self.path)
-                            .expect("prefixed")
-                            .to_owned(),
-                    ))),
+                    false => Some(Ok(entry
+                        .path()
+                        .strip_prefix(&self.path)
+                        .expect("prefixed")
+                        .to_owned())),
                 },
                 Err(err) => Some(Err(err)),
             })

--- a/packages/ploys/src/repository/git/mod.rs
+++ b/packages/ploys/src/repository/git/mod.rs
@@ -4,7 +4,6 @@
 
 mod error;
 
-use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -106,18 +105,14 @@ impl Repository for Git {
         )
     }
 
-    fn get_index(&self) -> Result<impl Iterator<Item = Cow<'_, Path>>, Self::Error> {
+    fn get_index(&self) -> Result<impl Iterator<Item = PathBuf>, Self::Error> {
         if !matches!(&self.revision, Revision::Sha(_)) {
-            return Ok(
-                Box::new(self.get_index_uncached()?.into_iter().map(Cow::Owned))
-                    as Box<dyn Iterator<Item = Cow<'_, Path>>>,
-            );
+            return Ok(Box::new(self.get_index_uncached()?.into_iter())
+                as Box<dyn Iterator<Item = PathBuf>>);
         }
 
         Ok(Box::new(
-            self.cache
-                .get_or_try_index(|| self.get_index_uncached())?
-                .map(Cow::Borrowed),
+            self.cache.get_or_try_index(|| self.get_index_uncached())?,
         ))
     }
 }

--- a/packages/ploys/src/repository/github/mod.rs
+++ b/packages/ploys/src/repository/github/mod.rs
@@ -8,7 +8,6 @@ mod error;
 mod repo;
 mod spec;
 
-use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
@@ -144,18 +143,14 @@ impl Repository for GitHub {
         )
     }
 
-    fn get_index(&self) -> Result<impl Iterator<Item = Cow<'_, Path>>, Self::Error> {
+    fn get_index(&self) -> Result<impl Iterator<Item = PathBuf>, Self::Error> {
         if !matches!(&self.revision, Revision::Sha(_)) {
-            return Ok(
-                Box::new(self.get_index_uncached()?.into_iter().map(Cow::Owned))
-                    as Box<dyn Iterator<Item = Cow<'_, Path>>>,
-            );
+            return Ok(Box::new(self.get_index_uncached()?.into_iter())
+                as Box<dyn Iterator<Item = PathBuf>>);
         }
 
         Ok(Box::new(
-            self.cache
-                .get_or_try_index(|| self.get_index_uncached())?
-                .map(Cow::Borrowed),
+            self.cache.get_or_try_index(|| self.get_index_uncached())?,
         ))
     }
 }

--- a/packages/ploys/src/repository/memory/mod.rs
+++ b/packages/ploys/src/repository/memory/mod.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::path::{Path, PathBuf};
@@ -41,8 +40,8 @@ impl Repository for Memory {
         Ok(self.files.get(path.as_ref()).cloned())
     }
 
-    fn get_index(&self) -> Result<impl Iterator<Item = Cow<'_, Path>>, Self::Error> {
-        Ok(self.files.keys().map(|path| Cow::Borrowed(path.as_path())))
+    fn get_index(&self) -> Result<impl Iterator<Item = PathBuf>, Self::Error> {
+        Ok(self.files.keys().map(Clone::clone))
     }
 }
 

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -20,8 +20,7 @@ pub mod github;
 pub mod memory;
 pub mod revision;
 
-use std::borrow::Cow;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
 
@@ -37,7 +36,7 @@ pub trait Repository {
     fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error>;
 
     /// Gets the index.
-    fn get_index(&self) -> Result<impl Iterator<Item = Cow<'_, Path>>, Self::Error>;
+    fn get_index(&self) -> Result<impl Iterator<Item = PathBuf>, Self::Error>;
 }
 
 impl<T> Repository for &T
@@ -50,7 +49,7 @@ where
         (*self).get_file(path)
     }
 
-    fn get_index(&self) -> Result<impl Iterator<Item = Cow<'_, Path>>, Self::Error> {
+    fn get_index(&self) -> Result<impl Iterator<Item = PathBuf>, Self::Error> {
         (*self).get_index()
     }
 }


### PR DESCRIPTION
This is a follow-up to #256 that replaces the usage of `Cow<Path>` for repository file paths with `PathBuf`.

The `Repository` trait includes the ability to iterate over the file path index. This used `Cow<Path>` to allow the iterator to borrow from the internal storage to avoid allocating new paths. However, for the commonly used `FileSystem` and `Git` repositories this would always return an owned path so this was only beneficial for the `Memory` repository.

In order to support #255, there needs to be a way to update existing projects with a FileSystem or Git repository. The problem is that the design of the repositories needs to be reworked to use multiple repositories together. Updating the repositories to be cheaply cloned while allowing the `Memory` repository to share data across instances is the first step towards those changes. This means that the repositories can no longer return references to interior data.

This change simply replaces the usage of `Cow<Path>` with `PathBuf` as in a future update there will be no need for the `Cow::Borrowed` variant.