### PR TITLE
Redesign `Memory` repository with `Arc` and `Mutex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,7 +684,7 @@ checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "windows-sys 0.48.0",
 ]
 
@@ -2272,9 +2272,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2511,9 +2511,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2521,15 +2521,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.17",
  "smallvec",
- "windows-targets 0.48.1",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2577,6 +2577,7 @@ dependencies = [
  "indoc",
  "markdown",
  "once_cell",
+ "parking_lot",
  "pretty_assertions",
  "reqwest",
  "semver",
@@ -2853,6 +2854,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags 2.5.0",
 ]
 
 [[package]]

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -21,6 +21,7 @@ gix = { version = "0.70.0", optional = true }
 globset = "0.4.13"
 markdown = "1.0.0"
 once_cell = "1.20.2"
+parking_lot = "0.12.4"
 semver = "1.0.19"
 serde = { version = "1.0.185", features = ["derive"] }
 strum = { version = "0.26.3", features = ["derive"] }

--- a/packages/ploys/src/repository/memory/mod.rs
+++ b/packages/ploys/src/repository/memory/mod.rs
@@ -1,28 +1,30 @@
 use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use bytes::Bytes;
+use parking_lot::Mutex;
 
 use super::Repository;
 
 /// An in-memory repository.
 #[derive(Clone)]
 pub struct Memory {
-    files: BTreeMap<PathBuf, Bytes>,
+    files: Arc<Mutex<BTreeMap<PathBuf, Bytes>>>,
 }
 
 impl Memory {
     /// Creates a new in-memory repository.
     pub fn new() -> Self {
         Self {
-            files: BTreeMap::new(),
+            files: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
 
     /// Inserts a file into the repository.
     pub fn insert_file(&mut self, path: impl Into<PathBuf>, file: impl Into<Bytes>) -> &mut Self {
-        self.files.insert(path.into(), file.into());
+        self.files.lock().insert(path.into(), file.into());
         self
     }
 
@@ -37,11 +39,18 @@ impl Repository for Memory {
     type Error = Infallible;
 
     fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error> {
-        Ok(self.files.get(path.as_ref()).cloned())
+        Ok(self.files.lock().get(path.as_ref()).cloned())
     }
 
     fn get_index(&self) -> Result<impl Iterator<Item = PathBuf>, Self::Error> {
-        Ok(self.files.keys().map(Clone::clone))
+        Ok(self
+            .files
+            .lock()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>()
+            .into_boxed_slice()
+            .into_iter())
     }
 }
 


### PR DESCRIPTION
This redesigns the `Memory` repository to use `Arc` and `Mutex` to share contents across multiple instances.

Prior to #256 and #257, the implementation of the `Memory` repository returned references to the inner contents. This avoided the need to allocate new file paths and contents when accessing the inner data. However, that restricted the implementation so that a clone of the repository would diverge. This required the implementation of the `Repository` trait on references and the `Packages` iterator returning a `Package<&T>`.

In order to support #255, the way in which repositories are handled needs to be redesigned such that both `Project` and `Package` types contain multiple types of repository. Removing the reference described above would therefore involve a clone being able to access the same internal data.

This change simply alters the implementation of the `Memory` repository to use `Arc<Mutex<BTreeMap<PathBuf, Bytes>>>` so that the contents are shared across clones. This includes the `Mutex` type from the `parking_lot` crate as it avoids lock poisoning.

The downside to this change is that iterating over the file index now clones and collects the keys when the iterator is constructed. In the future the implementation may be swapped out to a different data structure that supports iterating over the live keys.