### PR TITLE
Update returned `Package` to use cloned repository

### DIFF
--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -375,10 +375,13 @@ where
     }
 }
 
-impl<'a, T> Package<&'a T> {
+impl<T> Package<T>
+where
+    T: Repository,
+{
     /// Constructs a package from a manifest.
     pub(super) fn from_manifest(
-        project: &'a Project<T>,
+        project: &Project<T>,
         path: impl Into<PathBuf>,
         manifest: Manifest,
     ) -> Option<Self> {
@@ -392,7 +395,7 @@ impl<'a, T> Package<&'a T> {
         };
 
         Some(Self {
-            repository: &project.repository,
+            repository: project.repository.clone(),
             manifest: manifest.clone(),
             path: path.into(),
             primary,

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -256,7 +256,7 @@ where
     T: Repository,
 {
     /// Gets a package with the given name.
-    pub fn get_package(&self, name: impl AsRef<str>) -> Option<Package<&'_ T>> {
+    pub fn get_package(&self, name: impl AsRef<str>) -> Option<Package<T>> {
         self.packages()
             .find(|package| package.name() == name.as_ref())
     }

--- a/packages/ploys/src/project/packages.rs
+++ b/packages/ploys/src/project/packages.rs
@@ -29,7 +29,7 @@ impl<'a, T> Iterator for Packages<'a, T>
 where
     T: Repository,
 {
-    type Item = Package<&'a T>;
+    type Item = Package<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -104,7 +104,7 @@ impl<'a, T> Iterator for ManifestPackages<'a, T>
 where
     T: Repository,
 {
-    type Item = Package<&'a T>;
+    type Item = Package<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {

--- a/packages/ploys/src/project/release/mod.rs
+++ b/packages/ploys/src/project/release/mod.rs
@@ -35,12 +35,12 @@ impl Release {
 /// The package release builder.
 pub struct ReleaseBuilder<'a, T> {
     project: &'a Project<T>,
-    package: Package<&'a T>,
+    package: Package<T>,
 }
 
 impl<'a, T> ReleaseBuilder<'a, T> {
     /// Constructs a new release builder.
-    pub(crate) fn new(project: &'a Project<T>, package: Package<&'a T>) -> Self {
+    pub(crate) fn new(project: &'a Project<T>, package: Package<T>) -> Self {
         Self { project, package }
     }
 }

--- a/packages/ploys/src/project/release/request.rs
+++ b/packages/ploys/src/project/release/request.rs
@@ -43,7 +43,7 @@ impl ReleaseRequest {
 /// repository.
 pub struct ReleaseRequestBuilder<'a, T> {
     project: &'a Project<T>,
-    package: Package<&'a T>,
+    package: Package<T>,
     version: BumpOrVersion,
     options: Options,
 }
@@ -52,7 +52,7 @@ impl<'a, T> ReleaseRequestBuilder<'a, T> {
     /// Constructs a new release request builder.
     pub(crate) fn new(
         project: &'a Project<T>,
-        package: Package<&'a T>,
+        package: Package<T>,
         version: BumpOrVersion,
     ) -> Self {
         Self {

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -29,7 +29,7 @@ pub use self::spec::{Error as RepoSpecError, RepoSpec, ShortRepoSpec};
 pub use self::vcs::GitLike;
 
 /// Defines a file repository.
-pub trait Repository {
+pub trait Repository: Clone {
     type Error;
 
     /// Gets a file at the given path.


### PR DESCRIPTION
This updates the `Packages` iterator and `Project` methods to use a cloned repository instead of a reference.

The `Project::get_package` and `Project::packages` methods return packages that contain a repository that is a reference to the repository in the parent project. However, with the change in #258, it is now possible to replace this with an owned repository as the file contents for all repositories should now be shared across each cloned instance. This allows the package and project to be updated independently without the shared reference preventing mutable access to the project.

This change simply updates the `Packages` iterator and related methods to clone the project's repository and remove the reference. This required the `Repository` trait to include the `Clone` bound which may be relaxed later.