### PR TITLE
Add `Repository` extension `Stage` trait

### DIFF
--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -223,7 +223,7 @@ where
 impl Package {
     /// Adds a file to the package.
     pub fn add_file(&mut self, path: impl AsRef<Path>, file: impl Into<Bytes>) -> &mut Self {
-        self.repository.insert_file(self.path.join(path), file);
+        self.repository.add_file(self.path.join(path), file);
         self
     }
 

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -146,7 +146,7 @@ impl<T> Project<T> {
 impl Project {
     /// Adds a file to the project.
     pub fn add_file(&mut self, path: impl Into<PathBuf>, file: impl Into<Bytes>) -> &mut Self {
-        self.repository.insert_file(path, file);
+        self.repository.add_file(path, file);
         self
     }
 

--- a/packages/ploys/src/repository/memory/mod.rs
+++ b/packages/ploys/src/repository/memory/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use parking_lot::Mutex;
 
-use super::Repository;
+use super::{Repository, Stage};
 
 /// An in-memory repository.
 #[derive(Clone)]
@@ -22,15 +22,15 @@ impl Memory {
         }
     }
 
-    /// Inserts a file into the repository.
-    pub fn insert_file(&mut self, path: impl Into<PathBuf>, file: impl Into<Bytes>) -> &mut Self {
+    /// Adds the given file to the index.
+    pub fn add_file(&mut self, path: impl Into<PathBuf>, file: impl Into<Bytes>) -> &mut Self {
         self.files.lock().insert(path.into(), file.into());
         self
     }
 
-    /// Builds the repository with the given file.
+    /// Builds the repository with the given file in the index.
     pub fn with_file(mut self, path: impl Into<PathBuf>, file: impl Into<Bytes>) -> Self {
-        self.insert_file(path, file);
+        self.add_file(path, file);
         self
     }
 }
@@ -51,6 +51,18 @@ impl Repository for Memory {
             .collect::<Vec<_>>()
             .into_boxed_slice()
             .into_iter())
+    }
+}
+
+impl Stage for Memory {
+    fn add_file(
+        &mut self,
+        path: impl Into<PathBuf>,
+        file: impl Into<Bytes>,
+    ) -> Result<&mut Self, Self::Error> {
+        self.add_file(path, file);
+
+        Ok(self)
     }
 }
 

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -38,3 +38,27 @@ pub trait Repository: Clone {
     /// Gets the index.
     fn get_index(&self) -> Result<impl Iterator<Item = PathBuf>, Self::Error>;
 }
+
+/// Defines the ability to stage files in a repository.
+pub trait Stage: Repository {
+    /// Adds the given file to the index.
+    fn add_file(
+        &mut self,
+        path: impl Into<PathBuf>,
+        file: impl Into<Bytes>,
+    ) -> Result<&mut Self, Self::Error>;
+
+    /// Builds the repository with the given file in the index.
+    fn with_file(
+        mut self,
+        path: impl Into<PathBuf>,
+        file: impl Into<Bytes>,
+    ) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        self.add_file(path, file)?;
+
+        Ok(self)
+    }
+}


### PR DESCRIPTION
This adds a new `Stage` trait for staging repository changes.

The current `Memory` repository type provides the ability to add new files to the repository. The other repository types, such as `FileSystem` and `Git`, do not provide this functionality which prevents the implementation of #255. By providing a trait, the `Project::add_file` and `Package::add_file` methods would be able to abstract over the different repository implementations.

However, due to the nature of the `Git` repository, it would only be possible to write to the working directory or staging index and this would only work when targeting the head commit. Changes could then be made outside of the program and invalidate the state before crafting the final commit. The `FileSystem` repository poses similar issues and it does not solve persisting changes to the project or package manifests. Therefore the various repositories need to contain a staging index that can then be committed.

This change introduces a new `Stage` trait as an extension of the `Repository` trait that provides the ability to add files to the staging index. This is currently only implemented on the `Memory` repository type but further updates will expand this to the other types. For consistency, this renames the existing `insert_file` method to `add_file` and leaves the associated methods to override the trait methods to avoid dealing with the infallible error.

This change necessitates further changes to rename the `get_index` method and update terminology.