### PR TITLE
Rename `Memory` repository to `Staging`

### DIFF
--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -21,7 +21,7 @@ use url::Url;
 
 use crate::changelog::Changelog;
 use crate::project::Project;
-use crate::repository::memory::Memory;
+use crate::repository::staging::Staging;
 use crate::repository::{Remote, Repository};
 
 pub use self::bump::{Bump, BumpOrVersion, Error as BumpError};
@@ -33,7 +33,7 @@ use self::manifest::{Dependencies, DependenciesMut, DependencyMut, DependencyRef
 
 /// A project package.
 #[derive(Clone)]
-pub struct Package<T = Memory> {
+pub struct Package<T = Staging> {
     pub(crate) repository: T,
     manifest: Manifest,
     path: PathBuf,
@@ -44,7 +44,7 @@ impl Package {
     /// Constructs a new cargo package.
     pub fn new_cargo(name: impl Into<String>) -> Self {
         Self {
-            repository: Memory::new(),
+            repository: Staging::new(),
             manifest: Manifest::new_cargo(name),
             path: PathBuf::new(),
             primary: false,

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -48,7 +48,7 @@ use either::Either;
 use crate::package::lockfile::CargoLockfile;
 use crate::package::manifest::CargoManifest;
 use crate::package::{BumpOrVersion, Package, PackageKind};
-use crate::repository::memory::Memory;
+use crate::repository::staging::Staging;
 use crate::repository::{Remote, RepoSpec, Repository};
 
 pub use self::config::Config;
@@ -67,7 +67,7 @@ pub use self::release::{ReleaseBuilder, ReleaseRequest, ReleaseRequestBuilder};
 /// description = "{project-description}"
 /// repository = "https://github.com/{project-owner}/{project-name}"
 /// ```
-pub struct Project<T = Memory> {
+pub struct Project<T = Staging> {
     pub(crate) repository: T,
     config: Config,
 }
@@ -78,7 +78,7 @@ impl Project {
         let config = Config::new(name);
 
         Self {
-            repository: Memory::new().with_file("Ploys.toml", config.to_string().into_bytes()),
+            repository: Staging::new().with_file("Ploys.toml", config.to_string().into_bytes()),
             config,
         }
     }
@@ -333,7 +333,7 @@ mod fs {
 
     use crate::repository::Repository;
     use crate::repository::fs::FileSystem;
-    use crate::repository::memory::Memory;
+    use crate::repository::staging::Staging;
 
     use super::{Error, Project};
 
@@ -354,11 +354,11 @@ mod fs {
         }
     }
 
-    impl Project<Memory> {
+    impl Project<Staging> {
         /// Writes the project to the file system.
         ///
         /// This method upgrades the project to use a [`FileSystem`] repository
-        /// by writing the contents of the [`Memory`] repository to the file
+        /// by writing the contents of the [`Staging`] repository to the file
         /// system. This includes the current project configuration stored in
         /// the project and not the original configuration from the repository.
         pub fn write<P>(self, path: P, force: bool) -> Result<Project<FileSystem>, Error<IoError>>
@@ -583,7 +583,7 @@ mod tests {
     use crate::package::lockfile::CargoLockfile;
     use crate::package::manifest::CargoManifest;
     use crate::repository::RepoSpec;
-    use crate::repository::memory::Memory;
+    use crate::repository::staging::Staging;
 
     use super::Project;
 
@@ -654,8 +654,8 @@ mod tests {
     }
 
     #[test]
-    fn test_project_memory_repository() {
-        let repository = Memory::new().with_file("Ploys.toml", "[project]\nname = \"example\"");
+    fn test_project_staging_repository() {
+        let repository = Staging::new().with_file("Ploys.toml", "[project]\nname = \"example\"");
         let mut project = Project::open(repository).unwrap();
 
         assert_eq!(project.name(), "example");

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -17,8 +17,8 @@ pub mod git;
 #[cfg(feature = "github")]
 pub mod github;
 
-pub mod memory;
 pub mod revision;
+pub mod staging;
 
 use std::path::{Path, PathBuf};
 

--- a/packages/ploys/src/repository/staging/mod.rs
+++ b/packages/ploys/src/repository/staging/mod.rs
@@ -8,14 +8,14 @@ use parking_lot::Mutex;
 
 use super::{Repository, Stage};
 
-/// An in-memory repository.
+/// A staging repository.
 #[derive(Clone)]
-pub struct Memory {
+pub struct Staging {
     files: Arc<Mutex<BTreeMap<PathBuf, Bytes>>>,
 }
 
-impl Memory {
-    /// Creates a new in-memory repository.
+impl Staging {
+    /// Creates a new staging repository.
     pub fn new() -> Self {
         Self {
             files: Arc::new(Mutex::new(BTreeMap::new())),
@@ -35,7 +35,7 @@ impl Memory {
     }
 }
 
-impl Repository for Memory {
+impl Repository for Staging {
     type Error = Infallible;
 
     fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error> {
@@ -54,7 +54,7 @@ impl Repository for Memory {
     }
 }
 
-impl Stage for Memory {
+impl Stage for Staging {
     fn add_file(
         &mut self,
         path: impl Into<PathBuf>,
@@ -66,7 +66,7 @@ impl Stage for Memory {
     }
 }
 
-impl Default for Memory {
+impl Default for Staging {
     fn default() -> Self {
         Self::new()
     }

--- a/packages/ploys/tests/staging.rs
+++ b/packages/ploys/tests/staging.rs
@@ -1,10 +1,10 @@
 use ploys::project::Project;
-use ploys::repository::memory::Memory;
+use ploys::repository::staging::Staging;
 use tempfile::tempdir;
 
 #[test]
 fn test_project_write() -> Result<(), Box<dyn std::error::Error>> {
-    let memory = Memory::new()
+    let repository = Staging::new()
         .with_file("Ploys.toml", "[project]\nname = \"example\"")
         .with_file("Cargo.toml", "[workspace]\nmembers = [\"packages/*\"]")
         .with_file(
@@ -13,7 +13,7 @@ fn test_project_write() -> Result<(), Box<dyn std::error::Error>> {
         );
 
     let dir = tempdir()?;
-    let project = Project::open(memory)?;
+    let project = Project::open(repository)?;
     let project = project.write(dir.path(), false)?;
     let package = project.get_package("example").unwrap();
 


### PR DESCRIPTION
This renames the `Memory` repository to `Staging`.

The `Stage` trait was added in #261 to support staging files in a repository. This was only implemented on the `Memory` repository type but the next step is to implement it on the `FileSystem` repository type in order to support #255. This can be achieved by including the `Memory` repository within the `FileSystem` repository. This would effectively make the `Memory` repository the staging index so it would make sense to rename it accordingly.

This change simply renames the `Memory` repository to `Staging` and updates the modules, methods, variables, and documentation to reflect the change.