### PR TITLE
Remove `Arc` and `Mutex` from `Staging` repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,7 +2577,6 @@ dependencies = [
  "indoc",
  "markdown",
  "once_cell",
- "parking_lot",
  "pretty_assertions",
  "reqwest",
  "semver",

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -21,7 +21,6 @@ gix = { version = "0.70.0", optional = true }
 globset = "0.4.13"
 markdown = "1.0.0"
 once_cell = "1.20.2"
-parking_lot = "0.12.4"
 semver = "1.0.19"
 serde = { version = "1.0.185", features = ["derive"] }
 strum = { version = "0.26.3", features = ["derive"] }

--- a/packages/ploys/src/repository/staging/mod.rs
+++ b/packages/ploys/src/repository/staging/mod.rs
@@ -1,30 +1,28 @@
 use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use bytes::Bytes;
-use parking_lot::Mutex;
 
 use super::{Repository, Stage};
 
 /// A staging repository.
 #[derive(Clone)]
 pub struct Staging {
-    files: Arc<Mutex<BTreeMap<PathBuf, Bytes>>>,
+    files: BTreeMap<PathBuf, Bytes>,
 }
 
 impl Staging {
     /// Creates a new staging repository.
     pub fn new() -> Self {
         Self {
-            files: Arc::new(Mutex::new(BTreeMap::new())),
+            files: BTreeMap::new(),
         }
     }
 
     /// Adds the given file to the index.
     pub fn add_file(&mut self, path: impl Into<PathBuf>, file: impl Into<Bytes>) -> &mut Self {
-        self.files.lock().insert(path.into(), file.into());
+        self.files.insert(path.into(), file.into());
         self
     }
 
@@ -39,18 +37,11 @@ impl Repository for Staging {
     type Error = Infallible;
 
     fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error> {
-        Ok(self.files.lock().get(path.as_ref()).cloned())
+        Ok(self.files.get(path.as_ref()).cloned())
     }
 
     fn get_index(&self) -> Result<impl Iterator<Item = PathBuf>, Self::Error> {
-        Ok(self
-            .files
-            .lock()
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>()
-            .into_boxed_slice()
-            .into_iter())
+        Ok(self.files.keys().cloned())
     }
 }
 


### PR DESCRIPTION
This reverses #258 to remove the `Arc` and `Mutex` from the newly renamed `Staging` repository.

As part of #263 it was decided that sharing the contents of the `Staging` repository across clones was a mistake as it allowed changes to the `Project` to be made from a `Package`. This caused the `Project::add_package` method to add files from a repository to itself. The original intent was to avoid cloning individual files and replace repository references as a way to read changes to a project from a package.

This change simply reverses the previous change that added `Arc` and `Mutex` while handling the subsequent rename from `Memory` to `Repository`. It also tweaks the implementation of `get_index` to call `cloned` instead of the original `map(Clone::clone)`. The result is that all staged files in a project will be cloned but that will be handled in a follow-up PR.