### PR TITLE
Add `Stage::remove_file` method

### DIFF
--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -61,4 +61,7 @@ pub trait Stage: Repository {
 
         Ok(self)
     }
+
+    /// Removes a file from the index.
+    fn remove_file(&mut self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error>;
 }

--- a/packages/ploys/src/repository/staging/mod.rs
+++ b/packages/ploys/src/repository/staging/mod.rs
@@ -55,6 +55,10 @@ impl Stage for Staging {
 
         Ok(self)
     }
+
+    fn remove_file(&mut self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error> {
+        Ok(self.files.remove(path.as_ref()))
+    }
 }
 
 impl Default for Staging {


### PR DESCRIPTION
This adds a new `remove_file` method to the `Stage` trait.

The `Stage` trait was added as an extension of the `Repository` trait in #261 to support staging file changes in a generalised way. The initial implementation only supported adding files to the `Staging` repository type. However, in order to address #263, it should also support removing files sooner rather than later because it will affect the design of the API.

This change simply adds a new `Stage::remove_file` method with an implementation for the `Staging` repository.