### PR TITLE
Add `Staged` repository adapter for `Project` and `Package`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2182,6 +2182,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,6 +2584,7 @@ dependencies = [
  "gix",
  "globset",
  "indoc",
+ "itertools 0.14.0",
  "markdown",
  "once_cell",
  "pretty_assertions",
@@ -2672,7 +2682,7 @@ dependencies = [
  "anstyle",
  "difflib",
  "float-cmp",
- "itertools",
+ "itertools 0.10.5",
  "normalize-line-endings",
  "predicates-core",
  "regex",

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -19,6 +19,7 @@ bytes = "1.10.1"
 either = "1.13.0"
 gix = { version = "0.70.0", optional = true }
 globset = "0.4.13"
+itertools = "0.14.0"
 markdown = "1.0.0"
 once_cell = "1.20.2"
 semver = "1.0.19"

--- a/packages/ploys/src/project/release/mod.rs
+++ b/packages/ploys/src/project/release/mod.rs
@@ -51,7 +51,7 @@ where
 {
     /// Finishes the release.
     pub fn finish(self) -> Result<Release, T::Error> {
-        let sha = self.project.repository.sha()?;
+        let sha = self.project.repository.inner.sha()?;
 
         let version = self.package.version();
 
@@ -92,6 +92,7 @@ where
         let id = self
             .project
             .repository
+            .inner
             .create_release(&tag, &sha, &name, &body, prerelease, latest)?;
 
         info!(id, "Created release");

--- a/packages/ploys/src/project/release/request.rs
+++ b/packages/ploys/src/project/release/request.rs
@@ -4,6 +4,7 @@ use tracing::{info, info_span};
 use crate::changelog::Release;
 use crate::package::{BumpOrVersion, Lockfile, Package};
 use crate::project::Project;
+use crate::repository::Repository;
 
 use super::Remote;
 
@@ -207,28 +208,33 @@ where
         let default_branch = self
             .project
             .repository
+            .inner
             .get_default_branch()
             .map_err(crate::project::Error::Repository)?;
 
         self.project
             .repository
+            .inner
             .create_branch(&branch)
             .map_err(crate::project::Error::Repository)?;
 
         let sha = self
             .project
             .repository
+            .inner
             .commit(&title, files)
             .map_err(crate::project::Error::Repository)?;
 
         self.project
             .repository
+            .inner
             .update_branch(&branch, &sha)
             .map_err(crate::project::Error::Repository)?;
 
         let id = self
             .project
             .repository
+            .inner
             .create_pull_request(&branch, &default_branch, &title, &body)
             .map_err(crate::project::Error::Repository)?;
 

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -6,6 +6,7 @@
 mod cache;
 mod remote;
 mod spec;
+mod staged;
 mod vcs;
 
 #[cfg(feature = "fs")]
@@ -26,6 +27,7 @@ use bytes::Bytes;
 
 pub use self::remote::Remote;
 pub use self::spec::{Error as RepoSpecError, RepoSpec, ShortRepoSpec};
+pub use self::staged::Staged;
 pub use self::vcs::GitLike;
 
 /// Defines a file repository.

--- a/packages/ploys/src/repository/staged.rs
+++ b/packages/ploys/src/repository/staged.rs
@@ -1,0 +1,96 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use bytes::Bytes;
+use itertools::Itertools;
+
+use super::{Repository, Stage};
+
+/// A repository adapter for staging changes.
+#[derive(Clone)]
+pub struct Staged<T> {
+    inner: T,
+    files: BTreeMap<PathBuf, Option<Bytes>>,
+}
+
+impl<T> Staged<T> {
+    /// Constructs a new staged repository adapter.
+    pub fn new(repo: T) -> Self {
+        Self {
+            inner: repo,
+            files: BTreeMap::new(),
+        }
+    }
+}
+
+impl<T> Repository for Staged<T>
+where
+    T: Repository,
+{
+    type Error = T::Error;
+
+    fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error> {
+        match self.files.get(path.as_ref()) {
+            Some(Some(file)) => Ok(Some(file.clone())),
+            Some(None) => Ok(None),
+            None => self.inner.get_file(path),
+        }
+    }
+
+    fn get_index(&self) -> Result<impl Iterator<Item = PathBuf>, Self::Error> {
+        Ok(self
+            .files
+            .iter()
+            .filter_map(|(key, val)| val.as_ref().map(|_| key.clone()))
+            .merge(self.inner.get_index()?)
+            .unique())
+    }
+}
+
+impl<T> Stage for Staged<T>
+where
+    T: Repository,
+{
+    fn add_file(
+        &mut self,
+        path: impl Into<PathBuf>,
+        file: impl Into<Bytes>,
+    ) -> Result<&mut Self, Self::Error> {
+        self.files.insert(path.into(), Some(file.into()));
+
+        Ok(self)
+    }
+
+    fn remove_file(&mut self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error> {
+        Ok(self.files.insert(path.as_ref().to_owned(), None).flatten())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::repository::staging::Staging;
+    use crate::repository::{Repository, Stage};
+
+    use super::Staged;
+
+    #[test]
+    fn test_staged_repository() {
+        let inner = Staging::new().with_file("a", "A").with_file("b", "B");
+        let mut outer = Staged::new(inner);
+
+        assert_eq!(outer.get_file("a"), Ok(Some("A".into())));
+        assert_eq!(outer.get_file("b"), Ok(Some("B".into())));
+        assert_eq!(outer.get_file("c"), Ok(None));
+
+        outer.add_file("c", "C").unwrap();
+        outer.remove_file("a").unwrap();
+
+        assert_eq!(outer.get_file("a"), Ok(None));
+        assert_eq!(outer.get_file("b"), Ok(Some("B".into())));
+        assert_eq!(outer.get_file("c"), Ok(Some("C".into())));
+
+        assert_eq!(outer.inner.get_file("a"), Ok(Some("A".into())));
+        assert_eq!(outer.inner.get_file("b"), Ok(Some("B".into())));
+        assert_eq!(outer.inner.get_file("c"), Ok(None));
+    }
+}

--- a/packages/ploys/src/repository/staged.rs
+++ b/packages/ploys/src/repository/staged.rs
@@ -9,7 +9,7 @@ use super::{Repository, Stage};
 /// A repository adapter for staging changes.
 #[derive(Clone)]
 pub struct Staged<T> {
-    inner: T,
+    pub(crate) inner: T,
     files: BTreeMap<PathBuf, Option<Bytes>>,
 }
 
@@ -19,6 +19,14 @@ impl<T> Staged<T> {
         Self {
             inner: repo,
             files: BTreeMap::new(),
+        }
+    }
+
+    /// Builds the adapter with the given repository.
+    pub fn with_repository<U>(self, repo: U) -> Staged<U> {
+        Staged {
+            inner: repo,
+            files: self.files,
         }
     }
 }


### PR DESCRIPTION
This adds a new `Staged` repository adapter used in `Project` and `Package`.

The implementation of the `Project` and `Package` types used a generic `T` to store an interior `Repository`.  The goal was to use the Typestate pattern to support different operations depending on the type of repository. However, the ability to update the contents of a repository was limited to the `Staging` repository type. At first the plan was to embed the `Staging` repository within the other repositories such as `FileSystem` and `Git` to allow file changes to be staged across all repositories, but after further thought in #263 it became clear that this approach was problematic.

This change introduces a new `Staged` repository adapter that wraps an existing repository with the ability to add and remove files without changing the underlying repository. The adapter has been added to the `Project` and `Package` types but otherwise does not alter the functionality or exposed API in any way. Most methods simply call through to the inner repository but this lays the foundations for further changes.