### PR TITLE
Add `Stage` bound to `Project` and `Package` file methods

### DIFF
--- a/packages/ploys-cli/src/project/init.rs
+++ b/packages/ploys-cli/src/project/init.rs
@@ -175,8 +175,8 @@ impl Init {
                 package.add_file(
                     "src/main.rs",
                     "fn main() {\n    println!(\"Hello, world!\");\n}\n",
-                );
-                package.add_file("CHANGELOG.md", Changelog::new().to_string().into_bytes());
+                )?;
+                package.add_file("CHANGELOG.md", Changelog::new().to_string().into_bytes())?;
                 project.add_package(package)?;
             }
             Template::CargoLib => {
@@ -196,8 +196,8 @@ impl Init {
                     }
                 }
 
-                package.add_file("src/lib.rs", "\n");
-                package.add_file("CHANGELOG.md", Changelog::new().to_string().into_bytes());
+                package.add_file("src/lib.rs", "\n")?;
+                package.add_file("CHANGELOG.md", Changelog::new().to_string().into_bytes())?;
                 project.add_package(package)?;
             }
             Template::None => {}
@@ -206,7 +206,7 @@ impl Init {
         if let Vcs::Git = vcs
             && let Template::CargoBin | Template::CargoLib = template
         {
-            project.add_file(".gitignore", "/target\n");
+            project.add_file(".gitignore", "/target\n")?;
         }
 
         if !self.path.exists() {

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -220,17 +220,32 @@ where
     }
 }
 
-impl Package {
+impl<T> Package<T>
+where
+    T: Stage,
+{
     /// Adds a file to the package.
-    pub fn add_file(&mut self, path: impl AsRef<Path>, file: impl Into<Bytes>) -> &mut Self {
-        self.repository.add_file(self.path.join(path), file).ok();
-        self
+    pub fn add_file(
+        &mut self,
+        path: impl AsRef<Path>,
+        file: impl Into<Bytes>,
+    ) -> Result<&mut Self, Error<T::Error>> {
+        self.repository
+            .add_file(self.path.join(path), file)
+            .map_err(Error::Repository)?;
+
+        Ok(self)
     }
 
     /// Builds the package with the given file.
-    pub fn with_file(mut self, path: impl AsRef<Path>, file: impl Into<Bytes>) -> Self {
-        self.add_file(path, file);
-        self
+    pub fn with_file(
+        mut self,
+        path: impl AsRef<Path>,
+        file: impl Into<Bytes>,
+    ) -> Result<Self, Error<T::Error>> {
+        self.add_file(path, file)?;
+
+        Ok(self)
     }
 }
 
@@ -433,7 +448,7 @@ mod tests {
         assert_eq!(package.version().to_string(), "0.1.0");
         assert_eq!(package.changelog(), None);
 
-        package.add_file("hello-world.txt", "Hello World!");
+        package.add_file("hello-world.txt", "Hello World!").unwrap();
 
         let txt = package.get_file("hello-world.txt").unwrap();
 


### PR DESCRIPTION
This generalises the `add_file`, `with_file`, `add_package` and `with_package` methods for `Project` and `Package` to support additional repository types via the `Stage` bound.

The original implementation of the above methods only supported the default `Staging` repository type in order to add files and packages. However, with the introduction of the `Stage` trait in #261, it is now possible to generalise those methods.

This change simply updates the methods to include the `T: Stage` bound and updates the method signatures to always return a `Result` with the appropriate error type. Previously `add_file` would not return an error, and although the `Staging` error is `Infallible` it may soon be updated to validate the path and disallow `.git`.
