### PR TITLE
Remove `Staged` adapter from `Project` and `Package`

### DIFF
--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -22,7 +22,7 @@ use url::Url;
 use crate::changelog::Changelog;
 use crate::project::Project;
 use crate::repository::staging::Staging;
-use crate::repository::{Remote, Repository, Stage, Staged};
+use crate::repository::{Remote, Repository, Stage};
 
 pub use self::bump::{Bump, BumpOrVersion, Error as BumpError};
 pub use self::error::Error;
@@ -34,7 +34,7 @@ use self::manifest::{Dependencies, DependenciesMut, DependencyMut, DependencyRef
 /// A project package.
 #[derive(Clone)]
 pub struct Package<T = Staging> {
-    pub(crate) repository: Staged<T>,
+    pub(crate) repository: T,
     manifest: Manifest,
     path: PathBuf,
     primary: bool,
@@ -44,7 +44,7 @@ impl Package {
     /// Constructs a new cargo package.
     pub fn new_cargo(name: impl Into<String>) -> Self {
         Self {
-            repository: Staged::new(Staging::new()),
+            repository: Staging::new(),
             manifest: Manifest::new_cargo(name),
             path: PathBuf::new(),
             primary: false,
@@ -368,7 +368,6 @@ where
         );
 
         self.repository
-            .inner
             .request_package_release(self.name(), version)?;
 
         Ok(())
@@ -386,11 +385,8 @@ where
         &self,
         version: impl Borrow<Version>,
     ) -> Result<crate::changelog::Release, T::Error> {
-        self.repository.inner.get_changelog_release(
-            self.name(),
-            version.borrow(),
-            self.is_primary(),
-        )
+        self.repository
+            .get_changelog_release(self.name(), version.borrow(), self.is_primary())
     }
 }
 

--- a/packages/ploys/src/project/release/mod.rs
+++ b/packages/ploys/src/project/release/mod.rs
@@ -51,7 +51,7 @@ where
 {
     /// Finishes the release.
     pub fn finish(self) -> Result<Release, T::Error> {
-        let sha = self.project.repository.inner.sha()?;
+        let sha = self.project.repository.sha()?;
 
         let version = self.package.version();
 
@@ -92,7 +92,6 @@ where
         let id = self
             .project
             .repository
-            .inner
             .create_release(&tag, &sha, &name, &body, prerelease, latest)?;
 
         info!(id, "Created release");

--- a/packages/ploys/src/project/release/request.rs
+++ b/packages/ploys/src/project/release/request.rs
@@ -4,7 +4,6 @@ use tracing::{info, info_span};
 use crate::changelog::Release;
 use crate::package::{BumpOrVersion, Lockfile, Package};
 use crate::project::Project;
-use crate::repository::Repository;
 
 use super::Remote;
 
@@ -208,33 +207,28 @@ where
         let default_branch = self
             .project
             .repository
-            .inner
             .get_default_branch()
             .map_err(crate::project::Error::Repository)?;
 
         self.project
             .repository
-            .inner
             .create_branch(&branch)
             .map_err(crate::project::Error::Repository)?;
 
         let sha = self
             .project
             .repository
-            .inner
             .commit(&title, files)
             .map_err(crate::project::Error::Repository)?;
 
         self.project
             .repository
-            .inner
             .update_branch(&branch, &sha)
             .map_err(crate::project::Error::Repository)?;
 
         let id = self
             .project
             .repository
-            .inner
             .create_pull_request(&branch, &default_branch, &title, &body)
             .map_err(crate::project::Error::Repository)?;
 


### PR DESCRIPTION
Closes #263.

This reverses #266 by removing the `Staged` repository adapter from the `Project` and `Package` types.

The `Staged` repository adapter was added to the `Project` and `Package` types to allow files to be added regardless of the embedded repository type. This would allow the default `T` to be the unit type `()` and represent a state where there is no backing repository. However, this would have required the bounds and errors to be updated to refer to the `Staged` type which was not ideal.

This change simply removes the `Staged` repository adapter from the `Project` and `Package` types and updates the various methods to no longer refer to the inner repository.