### PR TITLE
Add custom error type for `FileSystem` repository

### DIFF
--- a/packages/ploys/src/project/error.rs
+++ b/packages/ploys/src/project/error.rs
@@ -77,8 +77,8 @@ impl<T> From<crate::package::BumpError> for Error<T> {
 }
 
 #[cfg(feature = "fs")]
-impl From<std::io::Error> for Error<std::io::Error> {
-    fn from(err: std::io::Error) -> Self {
+impl From<crate::repository::fs::Error> for Error<crate::repository::fs::Error> {
+    fn from(err: crate::repository::fs::Error) -> Self {
         Self::Repository(err)
     }
 }

--- a/packages/ploys/src/repository/fs/error.rs
+++ b/packages/ploys/src/repository/fs/error.rs
@@ -1,0 +1,31 @@
+use std::fmt::{self, Display};
+use std::io;
+
+/// The `FileSystem` repository error.
+#[derive(Debug)]
+pub enum Error {
+    /// An I/O error.
+    Io(io::Error),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(err) => Display::fmt(err, f),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        Self::Io(err)
+    }
+}
+
+impl From<walkdir::Error> for Error {
+    fn from(err: walkdir::Error) -> Self {
+        Self::Io(err.into())
+    }
+}

--- a/packages/ploys/src/repository/fs/mod.rs
+++ b/packages/ploys/src/repository/fs/mod.rs
@@ -1,8 +1,12 @@
-use std::io::{Error, ErrorKind};
+mod error;
+
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
 use walkdir::WalkDir;
+
+pub use self::error::Error;
 
 use super::{Repository, Stage, Staged};
 
@@ -71,7 +75,7 @@ impl Repository for Inner {
         match std::fs::read(self.path.join(path.as_ref())) {
             Ok(bytes) => Ok(Some(bytes.into())),
             Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
-            Err(err) => Err(err),
+            Err(err) => Err(err.into()),
         }
     }
 

--- a/packages/ploys/tests/fs.rs
+++ b/packages/ploys/tests/fs.rs
@@ -1,11 +1,11 @@
-use std::io::Error as IoError;
 use std::path::Path;
 
 use ploys::project::{Error, Project};
+use ploys::repository::fs::Error as FsError;
 
 #[test]
 #[ignore]
-fn test_project() -> Result<(), Error<IoError>> {
+fn test_project() -> Result<(), Error<FsError>> {
     let project = Project::fs("../..")?;
 
     assert_eq!(project.name(), "ploys");


### PR DESCRIPTION
This adds a new custom `Error` struct for the `FileSystem` repository type.

The `FileSystem` repository type used `std::io::Error` as the associated `Error` in the `Repository` trait. However, there are other reasons for an error that may need to be added in a future update. The `Git` and `GitHub` repository types already provide their own error type with an `Io` variant and so the `FileSystem` should be updated to reflect this. This will simplify any refactoring of the `Project::write` method in order to enable #255.

This change simply adds a new `Error` struct and updates the various places that the old error was used. This does not make any changes to the `Project::write` method other than map the errors to the `Io` variant.