### PR TITLE
Add path validation to `FileSystem::open`

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -365,7 +365,7 @@ mod fs {
         where
             P: Into<PathBuf>,
         {
-            Self::open(FileSystem::open(path))
+            Self::open(FileSystem::open(path)?)
         }
 
         /// Opens a project from a [`FileSystem`] repository in the current
@@ -387,16 +387,7 @@ mod fs {
             P: Into<PathBuf>,
         {
             let path = path.into();
-            let meta = path.metadata().map_err(FsError::Io)?;
-
-            if !meta.is_dir() {
-                return Err(Error::Repository(FsError::Io(IoError::new(
-                    ErrorKind::NotADirectory,
-                    "Expected a directory",
-                ))));
-            }
-
-            let repository = FileSystem::open(&path);
+            let repository = FileSystem::open(&path)?;
 
             if !force && repository.get_index()?.count() > 0 {
                 return Err(Error::Repository(FsError::Io(IoError::new(

--- a/packages/ploys/src/repository/fs/error.rs
+++ b/packages/ploys/src/repository/fs/error.rs
@@ -1,9 +1,12 @@
 use std::fmt::{self, Display};
 use std::io;
+use std::path::PathBuf;
 
 /// The `FileSystem` repository error.
 #[derive(Debug)]
 pub enum Error {
+    /// An invalid directory error.
+    Directory(PathBuf),
     /// An I/O error.
     Io(io::Error),
 }
@@ -11,6 +14,7 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Directory(path) => write!(f, "Invalid directory: `{}`", path.display()),
             Self::Io(err) => Display::fmt(err, f),
         }
     }

--- a/packages/ploys/src/repository/fs/mod.rs
+++ b/packages/ploys/src/repository/fs/mod.rs
@@ -18,15 +18,25 @@ pub struct FileSystem {
 
 impl FileSystem {
     /// Opens a file system repository.
-    pub fn open(path: impl Into<PathBuf>) -> Self {
-        Self {
-            inner: Staged::new(Inner { path: path.into() }),
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self, Error> {
+        let path = path.into();
+
+        let Ok(meta) = path.metadata() else {
+            return Err(Error::Directory(path));
+        };
+
+        if !meta.is_dir() {
+            return Err(Error::Directory(path));
         }
+
+        Ok(Self {
+            inner: Staged::new(Inner { path }),
+        })
     }
 
     /// Opens a file system repository in the current directory.
     pub fn current_dir() -> Result<Self, Error> {
-        Ok(Self::open(std::env::current_dir()?))
+        Self::open(std::env::current_dir()?)
     }
 
     /// Gets the file system path.


### PR DESCRIPTION
This adds path validation to the `open` method of the `FileSystem` repository.

The `open` method for repositories was previously provided by a trait but now uses separate implementations on each repository type. These differ across the types as the `Git` repository returns an error whereas `FileSystem` does not. This inconsistency should be resolved such that they behave in similar ways.

This change simply updates the `FileSystem::open` method to return a result and validates that the given path is accessible and is a directory. This includes a new `Directory` error variant for the error type added in #270. The logic has been moved from the `Project::write` implementation using the new error variant instead of an I/O error.