### PR TITLE
Add `Commit` trait with `FileSystem` implementation

### DIFF
--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -67,3 +67,12 @@ pub trait Stage: Repository {
     /// Removes a file from the index.
     fn remove_file(&mut self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error>;
 }
+
+/// Defines the ability to commit files in a repository.
+pub trait Commit: Stage {
+    /// The associated commit context.
+    type Context;
+
+    /// Commits the staged file changes to the repository.
+    fn commit(&mut self, context: impl Into<Self::Context>) -> Result<(), Self::Error>;
+}


### PR DESCRIPTION
This adds a new `Commit` trait as an extension of `Stage` with an initial implementation for `FileSystem`.

The `Stage` trait was added in #261 as an extension to the `Repository` trait that enabled adding files, and updated in #265 to support removing files. However, there was no API to persist these changes to the repository and so the `Project::write` implementation had to manually write each file and construct a new `FileSystem` repository without any staged changes.

This change introduces a new `Commit` trait with an associated `Context` to allow repositories such as `Git` to include a commit message. This includes an implementation for `FileSystem` that does not use a context. The implementation supports adding and removing files but this required some additional changes:

* The path in `FileSystem` is now canonicalized. This should always succeed because the path has already been validated but should avoid any comparison checks or issues with changing the current directory.
* The `Staged` type has a new `drain` method and a private `Drain` iterator. This ensures that changes are removed from the staging area as they are processed. The implementation is not strictly correct as a partial commit will lose the change that errored.

This also includes updated tests to ensure that the `FileSystem` repository works as expected.