### PR TITLE
Implement `IntoIterator` for `Staging`

### DIFF
--- a/packages/ploys/src/repository/staging/mod.rs
+++ b/packages/ploys/src/repository/staging/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::collections::btree_map::IntoIter;
 use std::convert::Infallible;
 use std::path::{Path, PathBuf};
 
@@ -73,5 +74,14 @@ impl Stage for Staging {
 impl Default for Staging {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl IntoIterator for Staging {
+    type Item = (PathBuf, Bytes);
+    type IntoIter = IntoIter<PathBuf, Bytes>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.files.into_iter()
     }
 }


### PR DESCRIPTION
This simply implements `IntoIterator` for `Staging`.

The `Stage` trait was updated in #273 to add a new `add_files` method that accepts an `IntoIterator`. Implementing `IntoIterator` for `Staging` would allow it to be passed to this method, allowing the `Project::write` implementation to be simplified.

This change simply introduces the implementation of `IntoIterator` for `Staging` where the associated `Item` is a tuple of `PathBuf` and `Bytes`. This exposes the internal `BTreeMap` usage via the `IntoIter` type so a future update should mask this with a custom iterator newtype.