### PR TITLE
Add `Project::write` method for `FileSystem` repository

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -373,6 +373,18 @@ mod fs {
         pub fn current_dir() -> Result<Self, Error<FsError>> {
             Self::open(FileSystem::current_dir()?)
         }
+
+        /// Writes the project to the file system.
+        ///
+        /// This method writes any staged file changes in this project to the
+        /// file system, including the addition and removal of files. This
+        /// includes the current project configuration, overriding any changes
+        /// on disk.
+        pub fn write(&mut self) -> Result<&mut Self, Error<FsError>> {
+            self.repository.commit(())?;
+
+            Ok(self)
+        }
     }
 
     impl Project<Staging> {

--- a/packages/ploys/tests/fs.rs
+++ b/packages/ploys/tests/fs.rs
@@ -93,3 +93,35 @@ fn test_project() -> Result<(), Error<FsError>> {
 
     Ok(())
 }
+
+#[test]
+fn test_project_write() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempdir()?;
+
+    std::fs::write(
+        dir.path().join("Ploys.toml"),
+        "[project]\nname = \"example\"",
+    )?;
+
+    let mut project = Project::fs(dir.path())?;
+
+    project.add_file("file.txt", "New File")?;
+
+    assert!(!dir.path().join("file.txt").exists());
+
+    project.write()?;
+
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("file.txt"))?,
+        "New File"
+    );
+
+    assert_eq!(
+        project.get_file(dir.path().join("file.txt"))?,
+        Some("New File".into())
+    );
+
+    dir.close()?;
+
+    Ok(())
+}


### PR DESCRIPTION
This adds a new `Project::write` method for the `FileSystem` repository type.

The original `Project::write` method implementation in #209 was implemented on the now `Project<Staging>` type. This meant that it was only possible to write changes to the file system for a newly created project. However, in order to support #255, there needs to be a way to write changes for an existing project.

This change adds a new `write` method to `Project<FileSystem>` and a new test to ensure that it works correctly. This is allowed to use the same name as `Project<FileSystem>` is considered a different type. This may cause some minor confusion as this takes an `&mut self` receiver instead of `self` and does not include the `force` option. For this reason it may be best to rename the old method to `written` to follow the same conventions as `committed`.