### PR TITLE
Add custom error type for `Staged` repository

### DIFF
--- a/packages/ploys/src/repository/fs/error.rs
+++ b/packages/ploys/src/repository/fs/error.rs
@@ -33,3 +33,11 @@ impl From<walkdir::Error> for Error {
         Self::Io(err.into())
     }
 }
+
+impl From<crate::repository::staged::Error<Error>> for Error {
+    fn from(err: crate::repository::staged::Error<Error>) -> Self {
+        match err {
+            crate::repository::staged::Error::Inner(err) => err,
+        }
+    }
+}

--- a/packages/ploys/src/repository/fs/mod.rs
+++ b/packages/ploys/src/repository/fs/mod.rs
@@ -51,11 +51,11 @@ impl Repository for FileSystem {
     type Error = Error;
 
     fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error> {
-        self.inner.get_file(path)
+        self.inner.get_file(path).map_err(Into::into)
     }
 
     fn get_index(&self) -> Result<impl Iterator<Item = PathBuf>, Self::Error> {
-        self.inner.get_index()
+        self.inner.get_index().map_err(Into::into)
     }
 }
 
@@ -80,7 +80,7 @@ impl Stage for FileSystem {
     }
 
     fn remove_file(&mut self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error> {
-        self.inner.remove_file(path)
+        self.inner.remove_file(path).map_err(Into::into)
     }
 }
 

--- a/packages/ploys/src/repository/staged/error.rs
+++ b/packages/ploys/src/repository/staged/error.rs
@@ -1,0 +1,27 @@
+use std::fmt::{self, Display};
+
+/// The `Staged` repository error.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error<T> {
+    /// An inner repository error.
+    Inner(T),
+}
+
+impl<T> Display for Error<T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Inner(err) => Display::fmt(err, f),
+        }
+    }
+}
+
+impl<T> std::error::Error for Error<T> where T: std::error::Error {}
+
+impl<T> From<T> for Error<T> {
+    fn from(err: T) -> Self {
+        Self::Inner(err)
+    }
+}

--- a/packages/ploys/src/repository/staged/mod.rs
+++ b/packages/ploys/src/repository/staged/mod.rs
@@ -1,4 +1,5 @@
 mod drain;
+mod error;
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -7,6 +8,8 @@ use bytes::Bytes;
 use itertools::Itertools;
 
 use self::drain::Drain;
+
+pub use self::error::Error;
 
 use super::{Repository, Stage};
 
@@ -44,13 +47,13 @@ impl<T> Repository for Staged<T>
 where
     T: Repository,
 {
-    type Error = T::Error;
+    type Error = Error<T::Error>;
 
     fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error> {
         match self.files.get(path.as_ref()) {
             Some(Some(file)) => Ok(Some(file.clone())),
             Some(None) => Ok(None),
-            None => self.inner.get_file(path),
+            None => Ok(self.inner.get_file(path)?),
         }
     }
 


### PR DESCRIPTION
This adds a custom error type for the `Staged` repository type.

In order to support #277 there needs to be a way to validate paths within each repository. As an invalid path should return an error, the repository should have its own error type. It would technically be possible to require a `From` implementation for a custom _invalid path_ error but the bounds would affect the various impl blocks.

This change introduces a new `Error` type for the `Staged` repository and updates the various methods to map to the new error. This includes a `From` implementation to convert from a `staged::Error<fs::Error>` to an `fs::Error`. This implementation should be okay as when paths are validated it can map the new error variants to each other.