### PR TITLE
Remove `Staging` repository infallible file methods

### DIFF
--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -78,7 +78,9 @@ impl Project {
         let config = Config::new(name);
 
         Self {
-            repository: Staging::new().with_file("Ploys.toml", config.to_string().into_bytes()),
+            repository: Staging::new()
+                .with_file("Ploys.toml", config.to_string().into_bytes())
+                .expect("infallible"),
             config,
         }
     }
@@ -591,8 +593,8 @@ mod tests {
     use crate::package::Package;
     use crate::package::lockfile::CargoLockfile;
     use crate::package::manifest::CargoManifest;
-    use crate::repository::RepoSpec;
     use crate::repository::types::staging::Staging;
+    use crate::repository::{RepoSpec, Stage};
 
     use super::Project;
 
@@ -665,7 +667,9 @@ mod tests {
 
     #[test]
     fn test_project_staging_repository() {
-        let repository = Staging::new().with_file("Ploys.toml", "[project]\nname = \"example\"");
+        let repository = Staging::new()
+            .with_file("Ploys.toml", "[project]\nname = \"example\"")
+            .unwrap();
         let mut project = Project::open(repository).unwrap();
 
         assert_eq!(project.name(), "example");

--- a/packages/ploys/src/repository/types/staged/mod.rs
+++ b/packages/ploys/src/repository/types/staged/mod.rs
@@ -105,7 +105,11 @@ mod tests {
 
     #[test]
     fn test_staged_repository() {
-        let inner = Staging::new().with_file("a", "A").with_file("b", "B");
+        let inner = Staging::new()
+            .with_file("a", "A")
+            .unwrap()
+            .with_file("b", "B")
+            .unwrap();
         let mut outer = Staged::new(inner);
 
         assert_eq!(outer.get_file("a"), Ok(Some("A".into())));

--- a/packages/ploys/src/repository/types/staging/mod.rs
+++ b/packages/ploys/src/repository/types/staging/mod.rs
@@ -20,18 +20,6 @@ impl Staging {
             files: BTreeMap::new(),
         }
     }
-
-    /// Adds the given file to the index.
-    pub fn add_file(&mut self, path: impl Into<PathBuf>, file: impl Into<Bytes>) -> &mut Self {
-        self.files.insert(path.into(), file.into());
-        self
-    }
-
-    /// Builds the repository with the given file in the index.
-    pub fn with_file(mut self, path: impl Into<PathBuf>, file: impl Into<Bytes>) -> Self {
-        self.add_file(path, file);
-        self
-    }
 }
 
 impl Repository for Staging {
@@ -52,7 +40,7 @@ impl Stage for Staging {
         path: impl Into<PathBuf>,
         file: impl Into<Bytes>,
     ) -> Result<&mut Self, Self::Error> {
-        self.add_file(path, file);
+        self.files.insert(path.into(), file.into());
 
         Ok(self)
     }

--- a/packages/ploys/tests/staging.rs
+++ b/packages/ploys/tests/staging.rs
@@ -1,16 +1,17 @@
 use ploys::project::Project;
+use ploys::repository::Stage;
 use ploys::repository::types::staging::Staging;
 use tempfile::tempdir;
 
 #[test]
 fn test_project_write() -> Result<(), Box<dyn std::error::Error>> {
     let repository = Staging::new()
-        .with_file("Ploys.toml", "[project]\nname = \"example\"")
-        .with_file("Cargo.toml", "[workspace]\nmembers = [\"packages/*\"]")
+        .with_file("Ploys.toml", "[project]\nname = \"example\"")?
+        .with_file("Cargo.toml", "[workspace]\nmembers = [\"packages/*\"]")?
         .with_file(
             "packages/example/Cargo.toml",
             "[package]\nname = \"example\"",
-        );
+        )?;
 
     let dir = tempdir()?;
     let project = Project::open(repository)?;


### PR DESCRIPTION
This simply removes the infallible file method overrides for the `Staging` repository type.

In order to prepare for the upcoming path validation in #277, the `Staging` repository type should not override the `Stage` trait methods with infallible methods that don't return a `Result`.

This change removes the custom `add_file` and `with_file` methods from the `Staging` repository type in favour of using the fallible ones from the `Stage` trait. This requires bringing the trait into scope and handling the error case. This uses `unwrap` in tests and an `expect` in the `Project` constructor as the error has not yet been changed from `Infallible`.