### PR TITLE
Update `Repository` and `Package` to use relative paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2588,6 +2588,7 @@ dependencies = [
  "markdown",
  "once_cell",
  "pretty_assertions",
+ "relative-path",
  "reqwest",
  "semver",
  "serde",
@@ -2917,6 +2918,15 @@ name = "regex-syntax"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+
+[[package]]
+name = "relative-path"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca40a312222d8ba74837cb474edef44b37f561da5f773981007a10bbaa992b0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "reqwest"

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -22,6 +22,7 @@ globset = "0.4.13"
 itertools = "0.14.0"
 markdown = "1.0.0"
 once_cell = "1.20.2"
+relative-path = { version = "2.0.1", features = ["serde"] }
 semver = "1.0.19"
 serde = { version = "1.0.185", features = ["derive"] }
 strum = { version = "0.26.3", features = ["derive"] }

--- a/packages/ploys/src/package/kind.rs
+++ b/packages/ploys/src/package/kind.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use strum::EnumIter;
 
 /// The package kind.
@@ -11,16 +9,16 @@ pub enum PackageKind {
 
 impl PackageKind {
     /// Gets the package file name.
-    pub fn file_name(&self) -> &'static Path {
+    pub fn file_name(&self) -> &'static str {
         match self {
-            Self::Cargo => Path::new("Cargo.toml"),
+            Self::Cargo => "Cargo.toml",
         }
     }
 
     /// Gets the lockfile name.
-    pub(crate) fn lockfile_name(&self) -> Option<&'static Path> {
+    pub(crate) fn lockfile_name(&self) -> Option<&'static str> {
         match self {
-            Self::Cargo => Some(Path::new("Cargo.lock")),
+            Self::Cargo => Some("Cargo.lock"),
         }
     }
 }

--- a/packages/ploys/src/project/packages.rs
+++ b/packages/ploys/src/project/packages.rs
@@ -1,6 +1,7 @@
 use std::iter::FusedIterator;
-use std::path::PathBuf;
+use std::path::Path;
 
+use relative_path::RelativePathBuf;
 use strum::IntoEnumIterator;
 
 use crate::package::manifest::Members;
@@ -97,7 +98,7 @@ struct ManifestPackages<'a, T> {
     project: &'a Project<T>,
     manifest: Manifest,
     members: Members,
-    files: Box<dyn Iterator<Item = PathBuf> + 'a>,
+    files: Box<dyn Iterator<Item = RelativePathBuf> + 'a>,
 }
 
 impl<'a, T> Iterator for ManifestPackages<'a, T>
@@ -111,7 +112,7 @@ where
             let path = self.files.next()?;
             let manifest_path = self.manifest.package_kind().file_name();
 
-            if path.file_name() != Some(manifest_path.as_os_str()) {
+            if path.file_name() != Some(manifest_path) {
                 continue;
             }
 
@@ -119,7 +120,7 @@ where
                 continue;
             };
 
-            if path != manifest_path && !self.members.includes(parent) {
+            if path != manifest_path && !self.members.includes(Path::new(parent.as_str())) {
                 continue;
             }
 

--- a/packages/ploys/src/project/release/request.rs
+++ b/packages/ploys/src/project/release/request.rs
@@ -1,3 +1,4 @@
+use relative_path::RelativePathBuf;
 use semver::Version;
 use tracing::{info, info_span};
 
@@ -167,7 +168,7 @@ where
 
             if let Some(mut lockfile) = lockfile {
                 lockfile.set_package_version(self.package.name(), version.clone());
-                files.push((path.to_owned(), lockfile.to_string()));
+                files.push((RelativePathBuf::from(path), lockfile.to_string()));
             }
         }
 

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -11,23 +11,28 @@ mod vcs;
 pub mod revision;
 pub mod types;
 
-use std::path::{Path, PathBuf};
-
 use bytes::Bytes;
+use relative_path::{RelativePath, RelativePathBuf};
 
 pub use self::remote::Remote;
 pub use self::spec::{Error as RepoSpecError, RepoSpec, ShortRepoSpec};
 pub use self::vcs::GitLike;
 
 /// Defines a file repository.
+///
+/// # Paths
+///
+/// Repositories use [`RelativePath`] to address files to avoid portability
+/// issues across operating systems. This uses a fixed `/` separator and is
+/// guaranteed to be valid UTF-8.
 pub trait Repository: Clone {
     type Error;
 
     /// Gets a file at the given path.
-    fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error>;
+    fn get_file(&self, path: impl AsRef<RelativePath>) -> Result<Option<Bytes>, Self::Error>;
 
     /// Gets the index.
-    fn get_index(&self) -> Result<impl Iterator<Item = PathBuf>, Self::Error>;
+    fn get_index(&self) -> Result<impl Iterator<Item = RelativePathBuf>, Self::Error>;
 }
 
 /// Defines the ability to stage files in a repository.
@@ -35,14 +40,14 @@ pub trait Stage: Repository {
     /// Adds the given file to the index.
     fn add_file(
         &mut self,
-        path: impl Into<PathBuf>,
+        path: impl Into<RelativePathBuf>,
         file: impl Into<Bytes>,
     ) -> Result<&mut Self, Self::Error>;
 
     /// Adds multiple staged files to the repository.
     fn add_files(
         &mut self,
-        files: impl IntoIterator<Item = (PathBuf, Bytes)>,
+        files: impl IntoIterator<Item = (RelativePathBuf, Bytes)>,
     ) -> Result<&mut Self, Self::Error> {
         for (path, file) in files {
             self.add_file(path, file)?;
@@ -54,7 +59,7 @@ pub trait Stage: Repository {
     /// Builds the repository with the given file in the index.
     fn with_file(
         mut self,
-        path: impl Into<PathBuf>,
+        path: impl Into<RelativePathBuf>,
         file: impl Into<Bytes>,
     ) -> Result<Self, Self::Error>
     where
@@ -68,7 +73,7 @@ pub trait Stage: Repository {
     /// Builds the repository with the given staged files.
     fn with_files(
         mut self,
-        files: impl IntoIterator<Item = (PathBuf, Bytes)>,
+        files: impl IntoIterator<Item = (RelativePathBuf, Bytes)>,
     ) -> Result<Self, Self::Error>
     where
         Self: Sized,
@@ -79,7 +84,8 @@ pub trait Stage: Repository {
     }
 
     /// Removes a file from the index.
-    fn remove_file(&mut self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error>;
+    fn remove_file(&mut self, path: impl AsRef<RelativePath>)
+    -> Result<Option<Bytes>, Self::Error>;
 }
 
 /// Defines the ability to commit files in a repository.

--- a/packages/ploys/src/repository/types/staged/drain.rs
+++ b/packages/ploys/src/repository/types/staged/drain.rs
@@ -1,13 +1,13 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
 
 use bytes::Bytes;
+use relative_path::RelativePathBuf;
 
 /// An iterator that drains a file map.
-pub struct Drain<'a>(pub &'a mut BTreeMap<PathBuf, Option<Bytes>>);
+pub struct Drain<'a>(pub &'a mut BTreeMap<RelativePathBuf, Option<Bytes>>);
 
 impl<'a> Iterator for Drain<'a> {
-    type Item = (PathBuf, Option<Bytes>);
+    type Item = (RelativePathBuf, Option<Bytes>);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.pop_first()

--- a/packages/ploys/src/repository/types/staging/mod.rs
+++ b/packages/ploys/src/repository/types/staging/mod.rs
@@ -1,16 +1,16 @@
 use std::collections::BTreeMap;
 use std::collections::btree_map::IntoIter;
 use std::convert::Infallible;
-use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
+use relative_path::{RelativePath, RelativePathBuf};
 
 use crate::repository::{Repository, Stage};
 
 /// A staging repository.
 #[derive(Clone)]
 pub struct Staging {
-    files: BTreeMap<PathBuf, Bytes>,
+    files: BTreeMap<RelativePathBuf, Bytes>,
 }
 
 impl Staging {
@@ -25,11 +25,11 @@ impl Staging {
 impl Repository for Staging {
     type Error = Infallible;
 
-    fn get_file(&self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error> {
+    fn get_file(&self, path: impl AsRef<RelativePath>) -> Result<Option<Bytes>, Self::Error> {
         Ok(self.files.get(path.as_ref()).cloned())
     }
 
-    fn get_index(&self) -> Result<impl Iterator<Item = PathBuf>, Self::Error> {
+    fn get_index(&self) -> Result<impl Iterator<Item = RelativePathBuf>, Self::Error> {
         Ok(self.files.keys().cloned())
     }
 }
@@ -37,7 +37,7 @@ impl Repository for Staging {
 impl Stage for Staging {
     fn add_file(
         &mut self,
-        path: impl Into<PathBuf>,
+        path: impl Into<RelativePathBuf>,
         file: impl Into<Bytes>,
     ) -> Result<&mut Self, Self::Error> {
         self.files.insert(path.into(), file.into());
@@ -47,14 +47,17 @@ impl Stage for Staging {
 
     fn add_files(
         &mut self,
-        files: impl IntoIterator<Item = (PathBuf, Bytes)>,
+        files: impl IntoIterator<Item = (RelativePathBuf, Bytes)>,
     ) -> Result<&mut Self, Self::Error> {
         self.files.extend(files);
 
         Ok(self)
     }
 
-    fn remove_file(&mut self, path: impl AsRef<Path>) -> Result<Option<Bytes>, Self::Error> {
+    fn remove_file(
+        &mut self,
+        path: impl AsRef<RelativePath>,
+    ) -> Result<Option<Bytes>, Self::Error> {
         Ok(self.files.remove(path.as_ref()))
     }
 }
@@ -66,8 +69,8 @@ impl Default for Staging {
 }
 
 impl IntoIterator for Staging {
-    type Item = (PathBuf, Bytes);
-    type IntoIter = IntoIter<PathBuf, Bytes>;
+    type Item = (RelativePathBuf, Bytes);
+    type IntoIter = IntoIter<RelativePathBuf, Bytes>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.files.into_iter()

--- a/packages/ploys/src/repository/vcs.rs
+++ b/packages/ploys/src/repository/vcs.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use relative_path::RelativePathBuf;
 
 use super::Repository;
 
@@ -8,7 +8,11 @@ pub trait GitLike: Repository {
     fn sha(&self) -> Result<String, Self::Error>;
 
     /// Commits the changes to the repository.
-    fn commit(&self, message: &str, files: Vec<(PathBuf, String)>) -> Result<String, Self::Error>;
+    fn commit(
+        &self,
+        message: &str,
+        files: Vec<(RelativePathBuf, String)>,
+    ) -> Result<String, Self::Error>;
 
     /// Gets the default branch.
     fn get_default_branch(&self) -> Result<String, Self::Error>;

--- a/packages/ploys/tests/fs.rs
+++ b/packages/ploys/tests/fs.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use ploys::project::{Error, Project};
 use ploys::repository::types::fs::{Error as FsError, FileSystem};
 use ploys::repository::{Commit, Stage};
@@ -61,11 +59,8 @@ fn test_project() -> Result<(), Error<FsError>> {
     let ploys = packages.iter().find(|pkg| pkg.name() == "ploys").unwrap();
 
     assert_eq!(ploys.name(), "ploys");
-    assert_eq!(ploys.path(), Path::new("packages/ploys"));
-    assert_eq!(
-        ploys.manifest_path(),
-        Path::new("packages/ploys/Cargo.toml")
-    );
+    assert_eq!(ploys.path(), "packages/ploys");
+    assert_eq!(ploys.manifest_path(), "packages/ploys/Cargo.toml");
 
     let ploys_api = packages
         .iter()
@@ -73,11 +68,8 @@ fn test_project() -> Result<(), Error<FsError>> {
         .unwrap();
 
     assert_eq!(ploys_api.name(), "ploys-api");
-    assert_eq!(ploys_api.path(), Path::new("packages/ploys-api"));
-    assert_eq!(
-        ploys_api.manifest_path(),
-        Path::new("packages/ploys-api/Cargo.toml")
-    );
+    assert_eq!(ploys_api.path(), "packages/ploys-api");
+    assert_eq!(ploys_api.manifest_path(), "packages/ploys-api/Cargo.toml");
 
     let ploys_cli = packages
         .iter()
@@ -85,11 +77,8 @@ fn test_project() -> Result<(), Error<FsError>> {
         .unwrap();
 
     assert_eq!(ploys_cli.name(), "ploys-cli");
-    assert_eq!(ploys_cli.path(), Path::new("packages/ploys-cli"));
-    assert_eq!(
-        ploys_cli.manifest_path(),
-        Path::new("packages/ploys-cli/Cargo.toml")
-    );
+    assert_eq!(ploys_cli.path(), "packages/ploys-cli");
+    assert_eq!(ploys_cli.manifest_path(), "packages/ploys-cli/Cargo.toml");
 
     Ok(())
 }
@@ -116,10 +105,7 @@ fn test_project_write() -> Result<(), Box<dyn std::error::Error>> {
         "New File"
     );
 
-    assert_eq!(
-        project.get_file(dir.path().join("file.txt"))?,
-        Some("New File".into())
-    );
+    assert_eq!(project.get_file("file.txt")?, Some("New File".into()));
 
     dir.close()?;
 

--- a/packages/ploys/tests/git.rs
+++ b/packages/ploys/tests/git.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use ploys::project::{Error, Project};
 use ploys::repository::types::git::Error as GitError;
 
@@ -19,11 +17,8 @@ fn test_project() -> Result<(), Error<GitError>> {
     let ploys = packages.iter().find(|pkg| pkg.name() == "ploys").unwrap();
 
     assert_eq!(ploys.name(), "ploys");
-    assert_eq!(ploys.path(), Path::new("packages/ploys"));
-    assert_eq!(
-        ploys.manifest_path(),
-        Path::new("packages/ploys/Cargo.toml")
-    );
+    assert_eq!(ploys.path(), "packages/ploys");
+    assert_eq!(ploys.manifest_path(), "packages/ploys/Cargo.toml");
 
     let ploys_api = packages
         .iter()
@@ -31,11 +26,8 @@ fn test_project() -> Result<(), Error<GitError>> {
         .unwrap();
 
     assert_eq!(ploys_api.name(), "ploys-api");
-    assert_eq!(ploys_api.path(), Path::new("packages/ploys-api"));
-    assert_eq!(
-        ploys_api.manifest_path(),
-        Path::new("packages/ploys-api/Cargo.toml")
-    );
+    assert_eq!(ploys_api.path(), "packages/ploys-api");
+    assert_eq!(ploys_api.manifest_path(), "packages/ploys-api/Cargo.toml");
 
     let ploys_cli = packages
         .iter()
@@ -43,11 +35,8 @@ fn test_project() -> Result<(), Error<GitError>> {
         .unwrap();
 
     assert_eq!(ploys_cli.name(), "ploys-cli");
-    assert_eq!(ploys_cli.path(), Path::new("packages/ploys-cli"));
-    assert_eq!(
-        ploys_cli.manifest_path(),
-        Path::new("packages/ploys-cli/Cargo.toml")
-    );
+    assert_eq!(ploys_cli.path(), "packages/ploys-cli");
+    assert_eq!(ploys_cli.manifest_path(), "packages/ploys-cli/Cargo.toml");
 
     Ok(())
 }

--- a/packages/ploys/tests/github.rs
+++ b/packages/ploys/tests/github.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use ploys::project::{Error, Project};
 use ploys::repository::revision::Revision;
 use ploys::repository::types::github::Error as GitHubError;
@@ -29,11 +27,8 @@ fn test_project() -> Result<(), Error<GitHubError>> {
     let ploys = packages.iter().find(|pkg| pkg.name() == "ploys").unwrap();
 
     assert_eq!(ploys.name(), "ploys");
-    assert_eq!(ploys.path(), Path::new("packages/ploys"));
-    assert_eq!(
-        ploys.manifest_path(),
-        Path::new("packages/ploys/Cargo.toml")
-    );
+    assert_eq!(ploys.path(), "packages/ploys");
+    assert_eq!(ploys.manifest_path(), "packages/ploys/Cargo.toml");
 
     let ploys_api = packages
         .iter()
@@ -41,11 +36,8 @@ fn test_project() -> Result<(), Error<GitHubError>> {
         .unwrap();
 
     assert_eq!(ploys_api.name(), "ploys-api");
-    assert_eq!(ploys_api.path(), Path::new("packages/ploys-api"));
-    assert_eq!(
-        ploys_api.manifest_path(),
-        Path::new("packages/ploys-api/Cargo.toml")
-    );
+    assert_eq!(ploys_api.path(), "packages/ploys-api");
+    assert_eq!(ploys_api.manifest_path(), "packages/ploys-api/Cargo.toml");
 
     let ploys_cli = packages
         .iter()
@@ -53,11 +45,8 @@ fn test_project() -> Result<(), Error<GitHubError>> {
         .unwrap();
 
     assert_eq!(ploys_cli.name(), "ploys-cli");
-    assert_eq!(ploys_cli.path(), Path::new("packages/ploys-cli"));
-    assert_eq!(
-        ploys_cli.manifest_path(),
-        Path::new("packages/ploys-cli/Cargo.toml")
-    );
+    assert_eq!(ploys_cli.path(), "packages/ploys-cli");
+    assert_eq!(ploys_cli.manifest_path(), "packages/ploys-cli/Cargo.toml");
 
     Ok(())
 }


### PR DESCRIPTION
This updates the `Repository` trait and `Package` struct to use relative paths.

## Motivation

The `Repository` trait provides a standardised way to interact with file repositories and uses the standard `Path` and `PathBuf` types to reference files by their path. However, the current implementation is problematic for two core reasons:

* There are portability issues due to differing behaviour across platforms.
* Paths are not relative to the repository and therefore may escape the repository root.

The portability issues relate to how different operating systems use paths. The documentation for the [relative-path](https://crates.io/crates/relative-path) crate goes into the specifics but differing character encodings and path separators mean that there is no consistent specification of a path.

The escaping issue relates to how absolute paths or the parent directory (`..`) can be used to specify a path that exists outside of the repository. This issue has been observed in the codebase.

### Issue 1

On line [`416` of `packages/ploys/src/project/mod.rs`](https://github.com/ploys/ploys/blob/f618caca97318cf9d0bd40d8212645419b94e7a8/packages/ploys/src/project/mod.rs#L416), the following code was used:

```rust
.with_file(path.join("Ploys.toml"), self.config.to_string())?
```

This joins `Ploys.toml` to the given path. However, the repository has already been constructed with a base path. Therefore if a relative path such as `foo/bar` had been given to the repository, this would have unintentionally created a file at `foo/bar/foo/bar/Ploys.toml` instead of `foo/bar/Ploys.toml`. The method containing this code is only used in two places and neither situation caught the issue.

The first of these is a test using the `tempfile` crate to create a temporary directory. As the temporary directory uses an absolute path, the path stored in the repository is technically the correct location as long as the base path does not change but will be seen as a separate entry to `Ploys.toml`.

The second is in the `project init` command. As this defaults to the current directory `.`, prepending the file path with it again does not actually alter the logical path and so the file is created at the correct location. Had this been overridden then the issue would have been apparent.

### Issue 2

On line [`120` of `packages/ploys/tests/fs.rs`](https://github.com/ploys/ploys/blob/f618caca97318cf9d0bd40d8212645419b94e7a8/packages/ploys/tests/fs.rs#L120), the following code was used:

```rust
project.get_file(dir.path().join("file.txt"))?,
```

This is similar to the previous issue except when getting a file from the repository instead of adding one. The directory is again an absolute path and so it is possible to get a file from any absolute path, even if not contained within the repository.

## Implementation

This change is rather large and noisy but the core alteration is the swap from `Path` and `PathBuf` to `RelativePath` and `RelativePathBuf` from the [relative-path](https://crates.io/crates/relative-path) crate. This ensures that absolute paths cannot be represented and so only `..` can be used to escape the repository until a further update can introduce additional logic.

This focuses on the `Repository` trait as that is ultimately where the path restrictions will be implemented, and the `Package` type which includes an internal path relative to the given repository. The `Project` type has also been updated but only to alter the file methods which pass through to the inner repository. This also includes some minor changes, such as altering the output of the `PackageKind::file_name` and `PackageKind::lockfile_name` methods to return a static string slice instead of a `Path`.

This change does not alter the package manifest's usage of `Path` because it is not necessarily against the specification and this project may want to refer to unsupported manifests in the future. It also does not alter the `FileSystem` repository type's use of `Path` as the base path as it needs to be absolute.

The change to relative paths has simplified some of the code and tests as it is now possible to directly compare a relative path with a string slice. This is due to relative paths only supporting UTF-8 and the standard library not providing the `PartialEq` implementation even though the underlying `OsStr` does.

## Next Steps

The next steps are to add logic to prevent `..` from escaping the repository and normalising the path such that `.` and `..` cannot create multiple entries for the same file, all while ensuring the ability to work with symlinks.