### PR TITLE
Fix repository `get_file` error on missing file

### DIFF
--- a/packages/ploys/src/repository/types/git/mod.rs
+++ b/packages/ploys/src/repository/types/git/mod.rs
@@ -140,15 +140,21 @@ impl Repository for Inner {
     type Error = Error;
 
     fn get_file(&self, path: impl AsRef<RelativePath>) -> Result<Option<Bytes>, Self::Error> {
-        if !matches!(self.revision, Revision::Sha(_)) {
-            return Ok(Some(self.get_file_uncached(path.as_ref())?));
-        }
+        let res = if !matches!(self.revision, Revision::Sha(_)) {
+            self.get_file_uncached(path.as_ref()).map(Some)
+        } else {
+            self.cache.get_or_try_init(
+                path,
+                |path| self.get_file_uncached(path),
+                || self.get_index_uncached(),
+            )
+        };
 
-        self.cache.get_or_try_init(
-            path,
-            |path| self.get_file_uncached(path),
-            || self.get_index_uncached(),
-        )
+        match res {
+            Ok(file) => Ok(file),
+            Err(Error::Io(err)) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err),
+        }
     }
 
     fn get_index(&self) -> Result<impl Iterator<Item = RelativePathBuf>, Self::Error> {


### PR DESCRIPTION
This fixes an issue with the `Git` and `GitHub` implementations of `Repository::get_file` returning an error when a file is missing instead of `Ok(None)`.

The various repository implementations and internal caching have gone through a lot of churn since initial inception but are now finally settling on a coherent API. Unfortunately, this has resulted in unintended changes that have caused the implementation of `get_file` in `Repository` for `Git` and `GitHub` to incorrectly return an error when a file is not found.

A previous fix (#164) attempted to resolve the issue in caching but since then the cache implementation has changed significantly.

This change simply updates the implementations of `get_file` for `Git` and `GitHub` to check for a `NotFound` error and return `Ok(None)` instead.