### PR TITLE
Implement `Commit` for `Git`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Setup
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Setup
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Configure Git
         run: |
+          git config --global init.defaultBranch main
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -17,7 +17,7 @@ github = ["dep:reqwest"]
 [dependencies]
 bytes = "1.10.1"
 either = "1.13.0"
-gix = { version = "0.73.0", optional = true }
+gix = { version = "0.73.0", features = ["tree-editor"], optional = true }
 globset = "0.4.13"
 itertools = "0.14.0"
 markdown = "1.0.0"

--- a/packages/ploys/src/repository/types/git/error.rs
+++ b/packages/ploys/src/repository/types/git/error.rs
@@ -78,6 +78,48 @@ impl From<gix::traverse::tree::breadthfirst::Error> for Error {
     }
 }
 
+impl From<gix::object::tree::editor::init::Error> for Error {
+    fn from(err: gix::object::tree::editor::init::Error) -> Self {
+        Self::Gix(err.into())
+    }
+}
+
+impl From<gix::object::tree::editor::write::Error> for Error {
+    fn from(err: gix::object::tree::editor::write::Error) -> Self {
+        Self::Gix(err.into())
+    }
+}
+
+impl From<gix::objs::tree::editor::Error> for Error {
+    fn from(err: gix::objs::tree::editor::Error) -> Self {
+        Self::Gix(err.into())
+    }
+}
+
+impl From<gix::object::write::Error> for Error {
+    fn from(err: gix::object::write::Error) -> Self {
+        Self::Gix(err.into())
+    }
+}
+
+impl From<gix::commit::Error> for Error {
+    fn from(err: gix::commit::Error) -> Self {
+        Self::Gix(err.into())
+    }
+}
+
+impl From<gix::reference::find::existing::Error> for Error {
+    fn from(err: gix::reference::find::existing::Error) -> Self {
+        Self::Gix(err.into())
+    }
+}
+
+impl From<gix::repository::edit_tree::Error> for Error {
+    fn from(err: gix::repository::edit_tree::Error) -> Self {
+        Self::Gix(err.into())
+    }
+}
+
 /// A Git error.
 #[derive(Debug)]
 pub enum GixError {
@@ -95,6 +137,20 @@ pub enum GixError {
     ObjectKind(Box<gix::object::peel::to_kind::Error>),
     /// A tree traversal error.
     Traverse(Box<gix::traverse::tree::breadthfirst::Error>),
+    /// A tree editor error.
+    TreeEditor(Box<gix::objs::tree::editor::Error>),
+    /// A tree editor initialization error.
+    TreeEditorInit(Box<gix::object::tree::editor::init::Error>),
+    /// A tree editor write error.
+    TreeEditorWrite(Box<gix::object::tree::editor::write::Error>),
+    /// An object write error.
+    ObjectWrite(Box<gix::object::write::Error>),
+    /// A commit error.
+    Commit(Box<gix::commit::Error>),
+    /// A find reference error.
+    FindReference(Box<gix::reference::find::existing::Error>),
+    /// An edit tree error.
+    EditTree(Box<gix::repository::edit_tree::Error>),
 }
 
 impl Display for GixError {
@@ -107,6 +163,13 @@ impl Display for GixError {
             Self::ObjectFind(err) => Display::fmt(err, f),
             Self::ObjectKind(err) => Display::fmt(err, f),
             Self::Traverse(err) => Display::fmt(err, f),
+            Self::TreeEditor(err) => Display::fmt(err, f),
+            Self::TreeEditorInit(err) => Display::fmt(err, f),
+            Self::TreeEditorWrite(err) => Display::fmt(err, f),
+            Self::ObjectWrite(err) => Display::fmt(err, f),
+            Self::Commit(err) => Display::fmt(err, f),
+            Self::FindReference(err) => Display::fmt(err, f),
+            Self::EditTree(err) => Display::fmt(err, f),
         }
     }
 }
@@ -152,5 +215,47 @@ impl From<gix::object::peel::to_kind::Error> for GixError {
 impl From<gix::traverse::tree::breadthfirst::Error> for GixError {
     fn from(err: gix::traverse::tree::breadthfirst::Error) -> Self {
         Self::Traverse(Box::new(err))
+    }
+}
+
+impl From<gix::object::tree::editor::init::Error> for GixError {
+    fn from(err: gix::object::tree::editor::init::Error) -> Self {
+        Self::TreeEditorInit(Box::new(err))
+    }
+}
+
+impl From<gix::object::tree::editor::write::Error> for GixError {
+    fn from(err: gix::object::tree::editor::write::Error) -> Self {
+        Self::TreeEditorWrite(Box::new(err))
+    }
+}
+
+impl From<gix::objs::tree::editor::Error> for GixError {
+    fn from(err: gix::objs::tree::editor::Error) -> Self {
+        Self::TreeEditor(Box::new(err))
+    }
+}
+
+impl From<gix::object::write::Error> for GixError {
+    fn from(err: gix::object::write::Error) -> Self {
+        Self::ObjectWrite(Box::new(err))
+    }
+}
+
+impl From<gix::commit::Error> for GixError {
+    fn from(err: gix::commit::Error) -> Self {
+        Self::Commit(Box::new(err))
+    }
+}
+
+impl From<gix::reference::find::existing::Error> for GixError {
+    fn from(err: gix::reference::find::existing::Error) -> Self {
+        Self::FindReference(Box::new(err))
+    }
+}
+
+impl From<gix::repository::edit_tree::Error> for GixError {
+    fn from(err: gix::repository::edit_tree::Error) -> Self {
+        Self::EditTree(Box::new(err))
     }
 }

--- a/packages/ploys/src/repository/types/git/params.rs
+++ b/packages/ploys/src/repository/types/git/params.rs
@@ -1,0 +1,30 @@
+/// The `Git` commit parameters.
+pub struct CommitParams {
+    message: String,
+}
+
+impl CommitParams {
+    /// Constructs new commit parameters with the given message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// Gets the commit message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl From<&str> for CommitParams {
+    fn from(message: &str) -> Self {
+        Self::new(message)
+    }
+}
+
+impl From<String> for CommitParams {
+    fn from(message: String) -> Self {
+        Self::new(message)
+    }
+}

--- a/packages/ploys/tests/git.rs
+++ b/packages/ploys/tests/git.rs
@@ -39,7 +39,13 @@ fn test_repository() -> Result<(), GitError> {
         Some("[project]\nname = \"example\"".into())
     );
 
-    let mut repo = Git::open(dir.path())?.with_revision(Revision::branch("main"));
+    let branch_name = gix::open(dir.path())?
+        .head()?
+        .referent_name()
+        .map(|name| name.shorten().to_string())
+        .unwrap_or_else(|| gix::init::DEFAULT_BRANCH_NAME.to_string());
+
+    let mut repo = Git::open(dir.path())?.with_revision(Revision::branch(branch_name));
 
     repo.add_file("Cargo.toml", "[package]\nname = \"example\"")?;
     repo.commit("Fourth commit")?;

--- a/packages/ploys/tests/git.rs
+++ b/packages/ploys/tests/git.rs
@@ -1,5 +1,89 @@
 use ploys::project::{Error, Project};
-use ploys::repository::types::git::Error as GitError;
+use ploys::repository::revision::Revision;
+use ploys::repository::types::git::{Error as GitError, Git};
+use ploys::repository::{Commit, Repository, Stage};
+use tempfile::tempdir;
+
+#[test]
+fn test_repository() -> Result<(), GitError> {
+    let dir = tempdir()?;
+    let mut repo = Git::init(dir.path())?;
+
+    repo.add_file("hello.txt", "Hello World!")?;
+    repo.add_file("foo/bar/baz", "Baz")?;
+    repo.commit("Initial commit")?;
+
+    assert_eq!(repo.get_file("hello.txt")?, Some("Hello World!".into()));
+    assert_eq!(repo.get_file("foo/bar/baz")?, Some("Baz".into()));
+
+    repo.add_file("README.md", "# Readme")?;
+    repo.remove_file("hello.txt")?;
+    repo.remove_file("foo/bar/baz")?;
+    repo.commit("Second commit")?;
+
+    assert_eq!(repo.get_file("README.md")?, Some("# Readme".into()));
+    assert_eq!(repo.get_file("hello.txt")?, None);
+    assert_eq!(repo.get_file("foo/bar/baz")?, None);
+
+    let mut repo = Git::open(dir.path())?;
+
+    assert_eq!(repo.get_file("README.md")?, Some("# Readme".into()));
+    assert_eq!(repo.get_file("hello.txt")?, None);
+    assert_eq!(repo.get_file("foo/bar/baz")?, None);
+
+    repo.add_file("Ploys.toml", "[project]\nname = \"example\"")?;
+    repo.commit("Third commit")?;
+
+    assert_eq!(
+        repo.get_file("Ploys.toml")?,
+        Some("[project]\nname = \"example\"".into())
+    );
+
+    let mut repo = Git::open(dir.path())?.with_revision(Revision::branch("main"));
+
+    repo.add_file("Cargo.toml", "[package]\nname = \"example\"")?;
+    repo.commit("Fourth commit")?;
+
+    assert_eq!(
+        repo.get_file("Cargo.toml")?,
+        Some("[package]\nname = \"example\"".into())
+    );
+
+    let sha = gix::open(dir.path())?
+        .head_commit()
+        .unwrap()
+        .id()
+        .to_string();
+
+    let mut repo = Git::open(dir.path())?.with_revision(Revision::sha(sha));
+
+    repo.remove_file("Cargo.toml")?;
+    repo.add_file("commit", "5")?;
+    repo.commit("Fifth commit")?;
+
+    assert_eq!(repo.get_file("Cargo.toml")?, None);
+    assert_eq!(
+        repo.get_file("Ploys.toml")?,
+        Some("[project]\nname = \"example\"".into())
+    );
+    assert_eq!(repo.get_file("commit")?, Some("5".into()));
+
+    let repo = Git::open(dir.path())?;
+
+    assert_eq!(
+        repo.get_file("Cargo.toml")?,
+        Some("[package]\nname = \"example\"".into())
+    );
+    assert_eq!(
+        repo.get_file("Ploys.toml")?,
+        Some("[project]\nname = \"example\"".into())
+    );
+    assert_eq!(repo.get_file("commit")?, None);
+
+    dir.close()?;
+
+    Ok(())
+}
 
 #[test]
 #[ignore]


### PR DESCRIPTION
This implements the `Commit` trait for the `Git` repository type.

## Motivation

The `Commit` trait was introduced in #272 with an implementation for the `FileSystem` repository type but not for any other repository types. The intention was to later expand it to the other types as the implementations were significantly more complex that they should be separate pull requests.

## Implementation

This change implements the `Commit` trait for the `Git` repository type by calling the relevant methods from the `gix` crate, which is not as simple as it may sound.

This relies on the `tree-editor` feature to be able to add and remove files from a tree. However, the tree to edit depends entirely on the state of the repository and what the current revision is set to. A new repository will not have a parent tree to edit and so an empty one must be constructed.

The revision also determines whether `commit` or `write_object` is called as `commit` requires a reference but the revision may be HEAD or a commit SHA. Using a tag reference is also problematic so `commit` only really works on a branch or when `HEAD` points to a branch.

This introduces a new `CommitParams` type to configure the commit message while allowing support for future updates to allow configuration of additional parameters such as commit signing. The `Error` type has also been updated with a number of new variants and so the complexity may require an alternative approach that does not expose the internal implementation details.

This change does not include commit signing as, although it is possible with `gix`, it is not something that an API is provided for and would likely need to call out to an external program based on the user's git configuration.