### PR TITLE
Remove unused `RefType` enum

### DIFF
--- a/packages/ploys-api/src/github/webhook/payload.rs
+++ b/packages/ploys-api/src/github/webhook/payload.rs
@@ -102,13 +102,6 @@ pub struct RepositoryDispatchPayload {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum RefType {
-    Tag,
-    Branch,
-}
-
-#[derive(Debug, Deserialize)]
 pub struct Repository {
     pub id: u64,
     pub full_name: String,


### PR DESCRIPTION
This removes the unused `RefType` enum from `ploys-api`.

## Motivation

Rust version `1.90.0` just released and appears to do a better job at identifying dead code. As such, it has identified the `RefType` enum. This was previously masked by the `Deserialize` derive.

## Implementation

This change simply removes the `RefType` enum from `ploys-api`. As this is a binary crate (and the module is not exported), this is simply a refactor.