### PR TITLE
Add project authors configuration

### DIFF
--- a/Ploys.toml
+++ b/Ploys.toml
@@ -1,4 +1,5 @@
 [project]
 name = "ploys"
 description = "Manage projects, packages, releases and deployments"
+authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
 repository = "https://github.com/ploys/ploys"

--- a/packages/ploys/src/project/config/mod.rs
+++ b/packages/ploys/src/project/config/mod.rs
@@ -77,6 +77,23 @@ impl Config {
         self
     }
 
+    /// Gets the project authors.
+    pub fn project_authors(&self) -> impl Iterator<Item = &str> {
+        self.project().authors()
+    }
+
+    /// Sets the project authors.
+    pub fn set_project_authors(&mut self, authors: impl IntoIterator<Item = String>) -> &mut Self {
+        self.project_mut().set_authors(authors);
+        self
+    }
+
+    /// Builds the config with the given project authors.
+    pub fn with_project_authors(mut self, authors: impl IntoIterator<Item = String>) -> Self {
+        self.set_project_authors(authors);
+        self
+    }
+
     /// The project section.
     pub fn project(&self) -> Project<'_> {
         Project::from_table(

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -143,6 +143,27 @@ impl<T> Project<T> {
         self.set_repository(repository);
         self
     }
+
+    /// Gets the project authors.
+    pub fn authors(&self) -> impl Iterator<Item = &str> {
+        self.config.project_authors()
+    }
+
+    /// Sets the project authors.
+    pub fn set_authors(
+        &mut self,
+        authors: impl IntoIterator<Item = impl Into<String>>,
+    ) -> &mut Self {
+        self.config
+            .set_project_authors(authors.into_iter().map(Into::into));
+        self
+    }
+
+    /// Builds the project with the given authors.
+    pub fn with_authors(mut self, authors: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.set_authors(authors);
+        self
+    }
 }
 
 impl<T> Project<T>
@@ -609,7 +630,8 @@ mod tests {
     fn test_builder() {
         let project = Project::new("example")
             .with_description("An example project.")
-            .with_repository("ploys/example".parse::<RepoSpec>().unwrap());
+            .with_repository("ploys/example".parse::<RepoSpec>().unwrap())
+            .with_authors(["Joe Bloggs <joe.bloggs@example.com>"]);
 
         assert_eq!(project.name(), "example");
         assert_eq!(project.description().unwrap(), "An example project.");
@@ -617,12 +639,17 @@ mod tests {
             project.repository().unwrap(),
             "ploys/example".parse::<RepoSpec>().unwrap()
         );
+        assert_eq!(
+            project.authors().collect::<Vec<_>>(),
+            ["Joe Bloggs <joe.bloggs@example.com>"]
+        );
 
         let mut project = project.reloaded().unwrap();
 
         assert_eq!(project.name(), "example");
         assert_eq!(project.description(), None);
         assert_eq!(project.repository(), None);
+        assert_eq!(project.authors().count(), 0);
 
         let package_a = Package::new_cargo("example-one");
         let package_b = Package::new_cargo("example-two")


### PR DESCRIPTION
This adds support for defining project authors in the project configuration.

## Motivation

Various package formats such as `Cargo.toml` and `package.json` support an authors or contributors field for defining the authors of a package. Although this is deprecated in Cargo and optional in NPM, it may still be required in other formats so it is still a useful property to control.

The concept of project authors is slightly different to individual package authors but being able to specify the authors of a project allows packages to effectively inherit this configuration by default. This means that an eventual `package init` command can use this information without searching for the authors from another package, or from the Git configuration.

## Implementation

This simply adds a new `authors` field to the project configuration format and provides the various methods to get and set the authors. There may be future work to format this if the list of authors is long, and there may be a benefit of adding individual authors rather than overriding the entire field but that is not included at this time.

The project's own configuration has also been updated to demonstrate.