### PR TITLE
Add consistent `GitHub` repository revision methods

### DIFF
--- a/packages/ploys/src/repository/types/github/mod.rs
+++ b/packages/ploys/src/repository/types/github/mod.rs
@@ -60,8 +60,13 @@ impl GitHub {
 }
 
 impl GitHub {
-    /// Builds the repository with the given revision.
-    pub fn with_revision(mut self, revision: impl Into<Revision>) -> Self {
+    /// Gets the revision.
+    pub fn revision(&self) -> &Revision {
+        &self.inner.inner.inner().revision
+    }
+
+    /// Sets the revision.
+    pub fn set_revision(&mut self, revision: impl Into<Revision>) {
         let revision = revision.into();
 
         if let Revision::Sha(_) = &revision {
@@ -79,6 +84,11 @@ impl GitHub {
         }
 
         self.inner.inner.inner_mut().revision = revision;
+    }
+
+    /// Builds the repository with the given revision.
+    pub fn with_revision(mut self, revision: impl Into<Revision>) -> Self {
+        self.set_revision(revision);
         self
     }
 


### PR DESCRIPTION
This adds revision methods to the `GitHub` repository that are consistent with the `Git` repository.

## Motivation

The `GitHub` repository type exposes a `with_revision` method that allows it to be built with a specific revision. However, the `Git` repository type also has `revision` and `set_revision` methods so the two repository types are inconsistent.

These methods are useful and used internally so it makes more sense to add them to `GitHub` rather than remove them from `Git`. There may be value in exposing these via the `GitLike` trait or an alternative mechanism to ensure that the methods don't drift over time.

## Implementation

This simply adds the `revision` getter method and `set_revision` setter method to the `GitHub` repository type. These are lifted from the `Git` repository type. Fortunately the implementation of `with_revision` was already lifted from `set_revision` so the change is minimal.