### PR TITLE
Implement `Commit` for `GitHub`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2670,6 +2670,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 name = "ploys"
 version = "0.4.0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "either",
  "gix",

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -15,6 +15,7 @@ git = ["dep:gix"]
 github = ["dep:reqwest"]
 
 [dependencies]
+base64 = "0.22.1"
 bytes = "1.10.1"
 either = "1.13.0"
 gix = { version = "0.73.0", features = ["tree-editor"], optional = true }

--- a/packages/ploys/src/repository/types/github/params.rs
+++ b/packages/ploys/src/repository/types/github/params.rs
@@ -1,0 +1,30 @@
+/// The `GitHub` commit parameters.
+pub struct CommitParams {
+    message: String,
+}
+
+impl CommitParams {
+    /// Constructs new commit parameters with the given message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// Gets the commit message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl From<&str> for CommitParams {
+    fn from(message: &str) -> Self {
+        Self::new(message)
+    }
+}
+
+impl From<String> for CommitParams {
+    fn from(message: String) -> Self {
+        Self::new(message)
+    }
+}


### PR DESCRIPTION
This implements the `Commit` trait for the `GitHub` repository type.

## Motivation

The `Commit` trait was introduced to provide a standardised way of committing changes to a repository. This was added to the `Git` repository type in #291 but not to the `GitHub` repository type.

## Implementation

This takes much of the implementation of `GitLike::commit` for `GitHub` and adapts it to commit the staged changes within the repository rather than external files using the `Commit` trait. This includes the ability to remove files and updates the branch or revision as necessary. The `GitLike::commit` method has not yet been removed as it is used by the release request process.

The change also introduces a dependency on the `base64` crate in order to support non-utf-8 files by encoding the contents for use in the GitHub API.

Unfortunately this does not include any automated tests as it is not feasible to test this without mocking the API.