### PR TITLE
Move GitHub body and response structs to methods

### DIFF
--- a/packages/ploys/src/repository/types/github/mod.rs
+++ b/packages/ploys/src/repository/types/github/mod.rs
@@ -402,6 +402,17 @@ impl Repository for Inner {
     }
 
     fn get_index(&self) -> Result<impl Iterator<Item = RelativePathBuf>, Self::Error> {
+        #[derive(Deserialize)]
+        struct TreeResponse {
+            tree: Vec<TreeResponseEntry>,
+        }
+
+        #[derive(Deserialize)]
+        struct TreeResponseEntry {
+            path: RelativePathBuf,
+            r#type: String,
+        }
+
         let entries = self
             .repository
             .get(
@@ -651,6 +662,12 @@ impl Remote for GitHub {
             version: String,
         }
 
+        #[derive(Serialize)]
+        struct RepositoryDispatchEvent<T> {
+            event_type: String,
+            client_payload: T,
+        }
+
         self.inner
             .inner
             .inner()
@@ -808,21 +825,4 @@ impl From<GitHubRepoSpec> for GitHub {
     fn from(repo: GitHubRepoSpec) -> Self {
         Self::open(repo).expect("valid repo specification")
     }
-}
-
-#[derive(Deserialize)]
-struct TreeResponse {
-    tree: Vec<TreeResponseEntry>,
-}
-
-#[derive(Deserialize)]
-struct TreeResponseEntry {
-    path: RelativePathBuf,
-    r#type: String,
-}
-
-#[derive(Serialize)]
-struct RepositoryDispatchEvent<T> {
-    event_type: String,
-    client_payload: T,
 }


### PR DESCRIPTION
This simply moves the various GitHub API body and response structs to methods.

## Motivation

This project uses the GitHub API via manual requests rather than a specific client utility. This is because the aim of the project is to bootstrap the creation and management of new packages, such as a new GitHub API client. Crates such as `octocrab` are async-only so it seemed easier to manually call the API than adapt it for blocking requests. This meant creating various serializable and deserializable structs rather than introducing the `serde_json` crate.

Some of these structs are defined within the methods that use them whereas others are defined at the top level of the module. The project should be consistent in how these are defined and the best option would be to move them inside the methods that use them.

## Implementation

This change simply moves the structs inside the methods as they are only used once so do not need to be duplicated.