### PR TITLE
Add `aarch64-unknown-linux-gnu` build to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
     strategy:
       matrix:
         include:
+          - label: linux, aarch64
+            target: aarch64-unknown-linux-gnu
+            toolchain: stable
+            os: ubuntu-24.04-arm
+            cache: linux-aarch64
+
           - label: linux, x86_64
             target: x86_64-unknown-linux-gnu
             toolchain: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - label: linux, aarch64
+            target: aarch64-unknown-linux-gnu
+            toolchain: stable
+            os: ubuntu-24.04-arm
+
           - label: linux, x86_64
             target: x86_64-unknown-linux-gnu
             toolchain: stable


### PR DESCRIPTION
This adds the `aarch64-unknown-linux-gnu` target to the continuous integration and release GitHub Actions workflows.

## Motivation

The upcoming support for Docker releases in #300 should support ARM devices such as the Raspberry Pi so this needs to be tested and artifacts should be built.

## Implementation

This simply changes the job matrix to include the new target using the `ubuntu-24.04-arm` runner OS.