### PR TITLE
Add release assets for `ploys-api` package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     name: Build (${{ matrix.label }})
     runs-on: ${{ matrix.os }}
-    if: ${{ contains(github.event.release.tag_name, 'ploys-cli') }}
+    if: ${{ contains(github.event.release.tag_name, 'ploys-api') || contains(github.event.release.tag_name, 'ploys-cli') }}
     permissions:
       contents: write
 
@@ -72,8 +72,17 @@ jobs:
           targets: ${{ matrix.target }}
           toolchain: ${{ matrix.toolchain }}
 
-      - name: Upload
+      - name: Upload (ploys-api)
         uses: taiki-e/upload-rust-binary-action@v1
+        if: ${{ contains(github.event.release.tag_name, 'ploys-api') }}
+        with:
+          bin: ploys-api
+          target: ${{ matrix.target }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload (ploys-cli)
+        uses: taiki-e/upload-rust-binary-action@v1
+        if: ${{ contains(github.event.release.tag_name, 'ploys-cli') }}
         with:
           bin: ploys
           target: ${{ matrix.target }}


### PR DESCRIPTION
This simply adds release assets for the `ploys-api` package releases.

## Motivation

In order to support Docker releases in #300 efficiently, generated release assets for the package can be used to create cross-platform container images. Building the package inside of the container image as it is built would be slower, lose out on any caching benefits, and be redundant as it would already be built outside of the container. How that works is yet to be determined.

## Implementation

This change simply updates the release workflow to build and upload release assets for the `ploys-api` package now that it has been decoupled from Shuttle and supports running as a standalone binary.