### PR TITLE
Add graceful server shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3488,6 +3488,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "socket2",
  "tokio-macros",

--- a/packages/ploys-api/Cargo.toml
+++ b/packages/ploys-api/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0.117"
 serde_with = "3.11.0"
 sha2 = "0.10.8"
 time = { version = "0.3.36", features = ["serde", "formatting", "parsing"] }
-tokio = { version = "1.33.0", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.33.0", features = ["rt-multi-thread", "macros", "signal"] }
 tower-service = "0.3.3"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"


### PR DESCRIPTION
This adds graceful shutdown to the `ploys-api` server.

## Motivation

In order to support Docker containers in #300, the server should support graceful shutdowns via signal handling. This will allow it to respond to signal events such as Ctrl+C or SIGTERM to properly shut down the process once the tasks have finished. Otherwise, without providing the `--init` flag to `docker run` or manually embedding `tini`, the process will not stop and the container will need to be killed.

## Implementation

This change simply follows the official `axum` examples by using the `signal` feature from `tokio` along with the `with_graceful_shutdown` method to respond to the shutdown signal.