### PR TITLE
Add GitHub container registry package releases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.github
+target/*
+!**/ploys-api

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -1,0 +1,78 @@
+name: "Docker Build"
+description: "Builds multi-arch Docker images"
+inputs:
+  package:
+    description: "The package name"
+    required: true
+  prefix:
+    description: "The published package name prefix"
+    default: ""
+  registry:
+    description: "The container registry address"
+    default: "ghcr.io"
+  username:
+    description: "The container registry username"
+    default: ""
+  password:
+    description: "The container registry password"
+    required: true
+  platform:
+    description: "The target build platform"
+    required: true
+  location:
+    description: "The directory containing the binary"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username != '' && inputs.username || github.repository_owner }}
+        password: ${{ inputs.password }}
+
+    - name: Get Metadata
+      id: metadata
+      uses: ./.github/actions/docker-metadata
+      with:
+        package: ${{ inputs.package }}
+        prefix: ${{ inputs.prefix }}
+        username: ${{ inputs.username != '' && inputs.username || github.repository_owner }}
+
+    - name: Build and push by digest
+      id: build
+      uses: docker/build-push-action@v6
+      with:
+        platforms: ${{ inputs.platform }}
+        labels: ${{ steps.metadata.outputs.labels }}
+        tags: ${{ inputs.registry }}/${{ inputs.username != '' && inputs.username || github.repository_owner }}/${{ inputs.prefix }}${{ inputs.package }}
+        outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+        context: .
+        file: packages/${{ inputs.package }}/Dockerfile
+        build-args: |
+          BIN_DIR=${{ inputs.location }}
+
+    - name: Export digest
+      shell: bash
+      run: |
+        mkdir -p ${{ runner.temp }}/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+    - name: Get Platform
+      shell: bash
+      run: |
+        platform=${{ inputs.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+    - name: Upload digest
+      uses: actions/upload-artifact@v4
+      with:
+        name: digests-${{ env.PLATFORM_PAIR }}
+        path: ${{ runner.temp }}/digests/*
+        if-no-files-found: error
+        retention-days: 1

--- a/.github/actions/docker-metadata/action.yml
+++ b/.github/actions/docker-metadata/action.yml
@@ -1,0 +1,79 @@
+name: "Docker Metadata"
+description: "Gets Docker metadata for a Cargo package"
+inputs:
+  package:
+    description: "The package name"
+    required: true
+  prefix:
+    description: "The published package name prefix"
+    default: ""
+  registry:
+    description: "The container registry address"
+    default: "ghcr.io"
+  username:
+    description: "The container registry username"
+    default: ""
+outputs:
+  version:
+    description: "The package version"
+    value: ${{ steps.image_meta.outputs.version || steps.image_meta_release.outputs.version }}
+  annotations:
+    description: "The metadata annotations"
+    value: ${{ steps.image_meta.outputs.annotations || steps.image_meta_release.outputs.annotations }}
+  labels:
+    description: "The metadata labels"
+    value: ${{ steps.image_meta.outputs.labels || steps.image_meta_release.outputs.labels }}
+  tags:
+    description: "The metadata tags"
+    value: ${{ steps.image_meta.outputs.tags || steps.image_meta_release.outputs.tags }}
+runs:
+  using: composite
+  steps:
+    - name: Get Package Metadata
+      id: package_meta
+      shell: bash
+      run: |
+        package_name="${{ inputs.package }}"
+        package_meta=$(cargo metadata --no-deps --format-version 1 | jq -r ".packages[] | select(.name==\"$package_name\")")
+        package_desc=$(echo "$package_meta" | jq -r '.description')
+        package_lice=$(echo "$package_meta" | jq -r '.license')
+        package_vers=$(echo "$package_meta" | jq -r '.version')
+
+        {
+          echo "labels<<EOF"
+          echo "org.opencontainers.image.title=$package_name"
+          echo "org.opencontainers.image.description=$package_desc"
+          echo "org.opencontainers.image.licenses=$package_lice"
+          echo "org.opencontainers.image.version=$package_vers"
+          echo "EOF"
+          echo "version=$package_vers"
+        } >> $GITHUB_OUTPUT
+
+    - name: Get Image Metadata
+      id: image_meta
+      if: ${{ github.event_name != 'release' && github.event.action != 'created' }}
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.registry }}/${{ inputs.username != '' && inputs.username || github.repository_owner }}/${{ inputs.prefix }}${{ inputs.package }}
+        labels: ${{ steps.package_meta.outputs.labels }}
+        annotations: ${{ steps.package_meta.outputs.labels }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=sha
+        flavor: latest=false
+
+    - name: Get Image Metadata (release)
+      id: image_meta_release
+      if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.registry }}/${{ inputs.username != '' && inputs.username || github.repository_owner }}/${{ inputs.prefix }}${{ inputs.package }}
+        labels: ${{ steps.package_meta.outputs.labels }}
+        annotations: ${{ steps.package_meta.outputs.labels }}
+        tags: |
+          type=semver,pattern={{version}},value=${{ steps.package_meta.outputs.version }}
+          type=semver,pattern={{major}}.{{minor}},value=${{ steps.package_meta.outputs.version }}
+          type=semver,pattern={{major}},value=${{ steps.package_meta.outputs.version }}
+          type=sha
+        flavor: latest=true

--- a/.github/actions/docker-package/action.yml
+++ b/.github/actions/docker-package/action.yml
@@ -1,0 +1,74 @@
+name: "Docker Build"
+description: "Builds multi-arch Docker images"
+inputs:
+  package:
+    description: "The package name"
+    required: true
+  prefix:
+    description: "The published package name prefix"
+    default: ""
+  registry:
+    description: "The container registry address"
+    default: "ghcr.io"
+  username:
+    description: "The container registry username"
+    default: ""
+  password:
+    description: "The container registry password"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Download digests
+      uses: actions/download-artifact@v4
+      with:
+        path: ${{ runner.temp }}/digests
+        pattern: digests-*
+        merge-multiple: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username != '' && inputs.username || github.repository_owner }}
+        password: ${{ inputs.password }}
+
+    - name: Get Metadata
+      id: metadata
+      uses: ./.github/actions/docker-metadata
+      with:
+        package: ${{ inputs.package }}
+        prefix: ${{ inputs.prefix }}
+        username: ${{ inputs.username != '' && inputs.username || github.repository_owner }}
+
+    - name: Create manifest list and push
+      working-directory: ${{ runner.temp }}/digests
+      shell: bash
+      run: |
+        ANNOTATIONS=()
+        while IFS= read -r annotation; do
+          [[ -z "$annotation" ]] && continue
+          ANNOTATIONS+=(--annotation "${annotation/manifest:/index:}")
+        done <<< "${{ steps.metadata.outputs.annotations }}"
+
+        TAGS=()
+        while IFS= read -r tag; do
+          [[ -z "$tag" ]] && continue
+          TAGS+=(--tag "$tag")
+        done <<< "${{ steps.metadata.outputs.tags }}"
+
+        DIGESTS=()
+        for digest in *; do
+          [[ -f "$digest" ]] || continue
+          DIGESTS+=("${{ inputs.registry }}/${{ inputs.username != '' && inputs.username || github.repository_owner }}/${{ inputs.prefix }}${{ inputs.package }}@sha256:${digest}")
+        done
+
+        docker buildx imagetools create "${ANNOTATIONS[@]}" "${TAGS[@]}" "${DIGESTS[@]}"
+
+    - name: Inspect image
+      shell: bash
+      run: |
+        docker buildx imagetools inspect ${{ inputs.registry }}/${{ inputs.username != '' && inputs.username || github.repository_owner }}/${{ inputs.prefix }}${{ inputs.package }}:${{ steps.metadata.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ !contains(github.event.release.tag_name, 'ploys') || contains(github.event.release.tag_name, 'ploys-cli') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup
         uses: dtolnay/rust-toolchain@master
@@ -33,7 +33,7 @@ jobs:
     if: ${{ contains(github.event.release.tag_name, 'ploys-api') || contains(github.event.release.tag_name, 'ploys-cli') }}
     permissions:
       contents: write
-
+      packages: write
     strategy:
       matrix:
         include:
@@ -41,11 +41,13 @@ jobs:
             target: aarch64-unknown-linux-gnu
             toolchain: stable
             os: ubuntu-24.04-arm
+            platform: linux/arm64
 
           - label: linux, x86_64
             target: x86_64-unknown-linux-gnu
             toolchain: stable
             os: ubuntu-latest
+            platform: linux/amd64
 
           - label: macos, aarch64
             target: aarch64-apple-darwin
@@ -64,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup
         uses: dtolnay/rust-toolchain@master
@@ -87,3 +89,30 @@ jobs:
           bin: ploys
           target: ${{ matrix.target }}
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker Image (ploys-api)
+        if: ${{ contains(github.event.release.tag_name, 'ploys-api') && contains(matrix.platform, 'linux/') }}
+        uses: ./.github/actions/docker-build
+        with:
+          package: ploys-api
+          password: ${{ secrets.GITHUB_TOKEN }}
+          platform: ${{ matrix.platform }}
+          location: ./target/${{ matrix.target }}/release
+
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.release.tag_name, 'ploys-api') }}
+    permissions:
+      contents: read
+      packages: write
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Package Docker Image
+        uses: ./.github/actions/docker-package
+        with:
+          package: ploys-api
+          password: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/ploys-api/Dockerfile
+++ b/packages/ploys-api/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:bookworm-slim
+
+ARG BIN_DIR
+
+COPY $BIN_DIR/ploys-api /usr/local/bin/ploys-api
+
+EXPOSE 8080/tcp
+
+ENTRYPOINT ["ploys-api", "serve", "--addr", "0.0.0.0:8080"]


### PR DESCRIPTION
Closes #300.

This updates the `release` workflow to build GitHub container registry packages for `ploys-api`.

## Motivation

The `ploys-api` crate can now be run as a standalone executable without `shuttle`, but there needs to be a simple way to deploy it to various systems. The release asset should now be added to releases but Docker integration would be useful.

## Implementation

This change adds a new `Dockerfile` for the `ploys-api` package with the entry point set to run the server. This requires a BIN_DIR build argument to select where to get the binary from as it will not compile the project inside the container. Running the container with an entry point like this allows users to pass additional args to the server, such as `-v` to increase verbosity.

This also updates the release workflow with multi-arch Docker image builds. This takes the binary produced by the existing _build and upload release asset_ action and creates a new image in the GitHub container registry for that platform. The digest is then uploaded as an artifact before being downloaded in the `package` job where a manifest is composed to create tagged images that work across different platforms.

The workflow required several in-repo composite actions to be created to condense the logic and avoid duplication or multiple `if` conditions. These have been tested in a separate repository but the implementation isn't the cleanest. In the future this functionality should be integrated into the project itself as part of its ability to manage releases.