### PR TITLE
Remove `Clone` bound from `Repository` trait

### DIFF
--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -92,7 +92,7 @@ impl Info {
 
     pub fn print<T>(&self, project: Project<T>) -> Result<(), Error>
     where
-        T: Repository,
+        T: Repository + Clone,
     {
         println!("{}:\n", style("Project").underlined().bold());
         println!("Name:        {}", project.name());

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -396,7 +396,7 @@ where
 
 impl<T> Package<T>
 where
-    T: Repository,
+    T: Repository + Clone,
 {
     /// Constructs a package from a manifest.
     pub(super) fn from_manifest(

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -304,7 +304,7 @@ where
 
 impl<T> Project<T>
 where
-    T: Repository,
+    T: Repository + Clone,
 {
     /// Gets a package with the given name.
     pub fn get_package(&self, name: impl AsRef<str>) -> Option<Package<T>> {
@@ -345,7 +345,7 @@ where
 
 impl<T> Project<T>
 where
-    T: Remote,
+    T: Remote + Clone,
 {
     /// Constructs a new package release request builder.
     pub fn create_package_release_request(

--- a/packages/ploys/src/project/packages.rs
+++ b/packages/ploys/src/project/packages.rs
@@ -28,7 +28,7 @@ impl<'a, T> Packages<'a, T> {
 
 impl<'a, T> Iterator for Packages<'a, T>
 where
-    T: Repository,
+    T: Repository + Clone,
 {
     type Item = Package<T>;
 
@@ -85,7 +85,7 @@ where
     }
 }
 
-impl<T> FusedIterator for Packages<'_, T> where T: Repository {}
+impl<T> FusedIterator for Packages<'_, T> where T: Repository + Clone {}
 
 #[allow(clippy::large_enum_variant)]
 enum State<'a, T> {
@@ -103,7 +103,7 @@ struct ManifestPackages<'a, T> {
 
 impl<'a, T> Iterator for ManifestPackages<'a, T>
 where
-    T: Repository,
+    T: Repository + Clone,
 {
     type Item = Package<T>;
 
@@ -145,4 +145,4 @@ where
     }
 }
 
-impl<T> FusedIterator for ManifestPackages<'_, T> where T: Repository {}
+impl<T> FusedIterator for ManifestPackages<'_, T> where T: Repository + Clone {}

--- a/packages/ploys/src/project/release/request.rs
+++ b/packages/ploys/src/project/release/request.rs
@@ -93,7 +93,7 @@ impl<T> ReleaseRequestBuilder<'_, T> {
 
 impl<T> ReleaseRequestBuilder<'_, T>
 where
-    T: Remote,
+    T: Remote + Clone,
 {
     /// Finishes the release request.
     pub fn finish(mut self) -> Result<ReleaseRequest, crate::project::Error<T::Error>> {

--- a/packages/ploys/src/repository/mod.rs
+++ b/packages/ploys/src/repository/mod.rs
@@ -26,7 +26,7 @@ pub use self::vcs::GitLike;
 /// Repositories use [`RelativePath`] to address files to avoid portability
 /// issues across operating systems. This uses a fixed `/` separator and is
 /// guaranteed to be valid UTF-8.
-pub trait Repository: Clone {
+pub trait Repository {
     type Error;
 
     /// Gets a file at the given path.
@@ -98,7 +98,10 @@ pub trait Commit: Stage {
     fn commit(&mut self, context: impl Into<Self::Context>) -> Result<(), Self::Error>;
 
     /// Builds the repository with the staged file changes committed.
-    fn committed(mut self, context: impl Into<Self::Context>) -> Result<Self, Self::Error> {
+    fn committed(mut self, context: impl Into<Self::Context>) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
         self.commit(context)?;
 
         Ok(self)


### PR DESCRIPTION
This removes the `Clone` supertrait bound from the `Repository` trait.

## Motivation

The `Repository` trait currently requires that it also implements the `Clone` trait and, while this is likely to be the case, it is perhaps too restrictive. Removing the trait bound at this point would simply shift the burden on to implementations using the trait, but doing so now allows the change to be separate from the next set of changes. Doing so would also remove the `Sized` bound from the trait and make it dyn compatible.

## Implementation

This change removes the `Clone` supertrait bound from `Repository` and updates the various implementations to add the `Clone` bound separately. This also adjusts the `Commit::committed` method signature to require `Self: Sized` which was previously implied by the `Clone: Sized` bound.