### PR TITLE
Implement `Repository` traits for references

### DIFF
--- a/packages/ploys/src/repository/remote.rs
+++ b/packages/ploys/src/repository/remote.rs
@@ -45,3 +45,91 @@ pub trait Remote: GitLike {
         latest: bool,
     ) -> Result<u64, Self::Error>;
 }
+
+impl<T> Remote for &T
+where
+    T: Remote,
+{
+    fn request_package_release(
+        &self,
+        package: &str,
+        version: BumpOrVersion,
+    ) -> Result<(), Self::Error> {
+        (**self).request_package_release(package, version)
+    }
+
+    fn get_changelog_release(
+        &self,
+        package: &str,
+        version: &Version,
+        is_primary: bool,
+    ) -> Result<Release, Self::Error> {
+        (**self).get_changelog_release(package, version, is_primary)
+    }
+
+    fn create_pull_request(
+        &self,
+        head: &str,
+        base: &str,
+        title: &str,
+        body: &str,
+    ) -> Result<u64, Self::Error> {
+        (**self).create_pull_request(head, base, title, body)
+    }
+
+    fn create_release(
+        &self,
+        tag: &str,
+        sha: &str,
+        name: &str,
+        body: &str,
+        prerelease: bool,
+        latest: bool,
+    ) -> Result<u64, Self::Error> {
+        (**self).create_release(tag, sha, name, body, prerelease, latest)
+    }
+}
+
+impl<T> Remote for &mut T
+where
+    T: Remote,
+{
+    fn request_package_release(
+        &self,
+        package: &str,
+        version: BumpOrVersion,
+    ) -> Result<(), Self::Error> {
+        (**self).request_package_release(package, version)
+    }
+
+    fn get_changelog_release(
+        &self,
+        package: &str,
+        version: &Version,
+        is_primary: bool,
+    ) -> Result<Release, Self::Error> {
+        (**self).get_changelog_release(package, version, is_primary)
+    }
+
+    fn create_pull_request(
+        &self,
+        head: &str,
+        base: &str,
+        title: &str,
+        body: &str,
+    ) -> Result<u64, Self::Error> {
+        (**self).create_pull_request(head, base, title, body)
+    }
+
+    fn create_release(
+        &self,
+        tag: &str,
+        sha: &str,
+        name: &str,
+        body: &str,
+        prerelease: bool,
+        latest: bool,
+    ) -> Result<u64, Self::Error> {
+        (**self).create_release(tag, sha, name, body, prerelease, latest)
+    }
+}

--- a/packages/ploys/src/repository/vcs.rs
+++ b/packages/ploys/src/repository/vcs.rs
@@ -23,3 +23,61 @@ pub trait GitLike: Repository {
     /// Updates the branch to point to the given SHA.
     fn update_branch(&self, name: &str, sha: &str) -> Result<(), Self::Error>;
 }
+
+impl<T> GitLike for &T
+where
+    T: GitLike,
+{
+    fn sha(&self) -> Result<String, Self::Error> {
+        (**self).sha()
+    }
+
+    fn commit(
+        &self,
+        message: &str,
+        files: Vec<(RelativePathBuf, String)>,
+    ) -> Result<String, Self::Error> {
+        (**self).commit(message, files)
+    }
+
+    fn get_default_branch(&self) -> Result<String, Self::Error> {
+        (**self).get_default_branch()
+    }
+
+    fn create_branch(&self, name: &str) -> Result<(), Self::Error> {
+        (**self).create_branch(name)
+    }
+
+    fn update_branch(&self, name: &str, sha: &str) -> Result<(), Self::Error> {
+        (**self).update_branch(name, sha)
+    }
+}
+
+impl<T> GitLike for &mut T
+where
+    T: GitLike,
+{
+    fn sha(&self) -> Result<String, Self::Error> {
+        (**self).sha()
+    }
+
+    fn commit(
+        &self,
+        message: &str,
+        files: Vec<(RelativePathBuf, String)>,
+    ) -> Result<String, Self::Error> {
+        (**self).commit(message, files)
+    }
+
+    fn get_default_branch(&self) -> Result<String, Self::Error> {
+        (**self).get_default_branch()
+    }
+
+    fn create_branch(&self, name: &str) -> Result<(), Self::Error> {
+        (**self).create_branch(name)
+    }
+
+    fn update_branch(&self, name: &str, sha: &str) -> Result<(), Self::Error> {
+        (**self).update_branch(name, sha)
+    }
+}


### PR DESCRIPTION
This implements the various `Repository` traits for references and mutable references.

## Motivation

The various `Repository` traits were previously implemented on references to repositories, but the implementations were removed in #260 due to the changes in #259 and #258.

This project has gone through several iterations working out the best API and there was a point where repositories shared their contents across instances. The original purpose was to avoid calling the GitHub API too many times and thereby avoid hitting any rate limits when no token was supplied. This proved to be problematic for numerous reasons and so the current logic is less concerned about rate limits.

Now the concern is needless allocations when cloning the repository that no longer shares storage across instances. This is a lesser problem due to the `Bytes` type from the `bytes` crate as the actual file contents will still be shared but it is still unnecessary cloning in many cases.

## Implementation

This change essentially reverts the changes from #260 and expands on it by implementing the `Repository`, `Stage`, `Commit`, `GitLike` and `Remote` for both immutable and mutable references. This would potentially support a future `get_package_mut` method that uses a mutable reference to the repository and will support the upcoming change of using references in the `get_package` and `get_packages` methods.

The `Stage` and `Commit` traits are only implemented on mutable references as it is not possible to implement on immutable references due to the `&mut self` receiver.