### PR TITLE
Update returned `Package` to use repository reference

### DIFF
--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -92,7 +92,7 @@ impl Info {
 
     pub fn print<T>(&self, project: Project<T>) -> Result<(), Error>
     where
-        T: Repository + Clone,
+        T: Repository,
     {
         println!("{}:\n", style("Project").underlined().bold());
         println!("Name:        {}", project.name());

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -304,10 +304,10 @@ where
 
 impl<T> Project<T>
 where
-    T: Repository + Clone,
+    T: Repository,
 {
     /// Gets a package with the given name.
-    pub fn get_package(&self, name: impl AsRef<str>) -> Option<Package<T>> {
+    pub fn get_package(&self, name: impl AsRef<str>) -> Option<Package<&T>> {
         self.packages()
             .find(|package| package.name() == name.as_ref())
     }
@@ -353,11 +353,14 @@ where
         package: impl AsRef<str>,
         version: impl Into<BumpOrVersion>,
     ) -> Result<ReleaseRequestBuilder<'_, T>, Error<T::Error>> {
-        let package = self.get_package(package.as_ref()).ok_or_else(|| {
-            Error::Package(crate::package::Error::NotFound(
-                package.as_ref().to_string(),
-            ))
-        })?;
+        let package = self
+            .get_package(package.as_ref())
+            .ok_or_else(|| {
+                Error::Package(crate::package::Error::NotFound(
+                    package.as_ref().to_string(),
+                ))
+            })?
+            .detached();
 
         Ok(ReleaseRequestBuilder::new(self, package, version.into()))
     }
@@ -367,11 +370,14 @@ where
         &self,
         package: impl AsRef<str>,
     ) -> Result<ReleaseBuilder<'_, T>, Error<T::Error>> {
-        let package = self.get_package(package.as_ref()).ok_or_else(|| {
-            Error::Package(crate::package::Error::NotFound(
-                package.as_ref().to_string(),
-            ))
-        })?;
+        let package = self
+            .get_package(package.as_ref())
+            .ok_or_else(|| {
+                Error::Package(crate::package::Error::NotFound(
+                    package.as_ref().to_string(),
+                ))
+            })?
+            .detached();
 
         Ok(ReleaseBuilder::new(self, package))
     }

--- a/packages/ploys/src/project/packages.rs
+++ b/packages/ploys/src/project/packages.rs
@@ -28,9 +28,9 @@ impl<'a, T> Packages<'a, T> {
 
 impl<'a, T> Iterator for Packages<'a, T>
 where
-    T: Repository + Clone,
+    T: Repository,
 {
-    type Item = Package<T>;
+    type Item = Package<&'a T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -85,7 +85,7 @@ where
     }
 }
 
-impl<T> FusedIterator for Packages<'_, T> where T: Repository + Clone {}
+impl<T> FusedIterator for Packages<'_, T> where T: Repository {}
 
 #[allow(clippy::large_enum_variant)]
 enum State<'a, T> {
@@ -103,9 +103,9 @@ struct ManifestPackages<'a, T> {
 
 impl<'a, T> Iterator for ManifestPackages<'a, T>
 where
-    T: Repository + Clone,
+    T: Repository,
 {
-    type Item = Package<T>;
+    type Item = Package<&'a T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -145,4 +145,4 @@ where
     }
 }
 
-impl<T> FusedIterator for ManifestPackages<'_, T> where T: Repository + Clone {}
+impl<T> FusedIterator for ManifestPackages<'_, T> where T: Repository {}

--- a/packages/ploys/src/project/release/request.rs
+++ b/packages/ploys/src/project/release/request.rs
@@ -93,7 +93,7 @@ impl<T> ReleaseRequestBuilder<'_, T> {
 
 impl<T> ReleaseRequestBuilder<'_, T>
 where
-    T: Remote + Clone,
+    T: Remote,
 {
     /// Finishes the release request.
     pub fn finish(mut self) -> Result<ReleaseRequest, crate::project::Error<T::Error>> {

--- a/packages/ploys/src/repository/adapters/subdirectory.rs
+++ b/packages/ploys/src/repository/adapters/subdirectory.rs
@@ -73,6 +73,32 @@ impl<T> Subdirectory<T> {
     }
 }
 
+impl<T> Subdirectory<&T>
+where
+    T: Clone,
+{
+    /// Detaches the inner repository from the reference by cloning it.
+    pub(crate) fn detached(self) -> Subdirectory<T> {
+        Subdirectory {
+            repo: self.repo.clone(),
+            path: self.path,
+        }
+    }
+}
+
+impl<T> Subdirectory<&mut T>
+where
+    T: Clone,
+{
+    /// Detaches the inner repository from the reference by cloning it.
+    pub(crate) fn detached(self) -> Subdirectory<T> {
+        Subdirectory {
+            repo: self.repo.clone(),
+            path: self.path,
+        }
+    }
+}
+
 impl<T> Repository for Subdirectory<T>
 where
     T: Repository,


### PR DESCRIPTION
This is a follow-up to #318 that effectively reverses the changes in #259.

## Motivation

The `Project::get_package` and `Project::packages` methods return packages that clone the repository. Although this will not clone the staged file contents, it will still clone the mapping of paths to files and other repository metadata.

Now that #318 has restored the ability to use references, those methods can be updated to return packages that use a reference to the repository instead of cloning it. This should avoid needless cloning when filtering the packages iterator.

## Implementation

This change updates the `Packages` iterator to return `Package<&T>` instead of `Package<T>`, avoiding the need for cloning the repository. This allowed the `get_package` and `packages` methods to also use a reference, and that allowed various `Clone` bounds to be removed.

This also introduces a new `Package::detached` method that detaches it from the repository by cloning it. This used an internal `detached` method on the `Subdirectory` repository adapter to simplify the logic.