### PR TITLE
Add methods to alter the changelog release version

### DIFF
--- a/packages/ploys/src/changelog/release.rs
+++ b/packages/ploys/src/changelog/release.rs
@@ -34,6 +34,18 @@ impl Release {
         &self.version
     }
 
+    /// Sets the release version.
+    pub fn set_version(&mut self, version: impl Into<String>) -> &mut Self {
+        self.version = version.into();
+        self
+    }
+
+    /// Builds the release with the given version.
+    pub fn with_version(mut self, version: impl Into<String>) -> Self {
+        self.set_version(version);
+        self
+    }
+
     /// Gets the release date.
     pub fn date(&self) -> Option<&str> {
         self.date.as_deref()


### PR DESCRIPTION
This adds the `set_version` and `with_version` methods to the changelog `Release` struct.

## Motivation

The `Changelog` type is composed of multiple `Release` sections that can be constructed with the version title but cannot be updated with a new version. This seemed redundant when the title was required on construction and the thought of altering a release title seemed problematic. However, the `set_version` and `with_version` methods would be useful for a new `package changelog` command in the `ploys-cli` package.

## Implementation

This change simply adds 2 new methods, `set_version` and `with_version`, to the `Release` type in the `changelog` module matching the other `set_` and `with_` methods.