### PR TITLE
Add package license symlinks

### DIFF
--- a/packages/ploys-api/LICENSE-APACHE
+++ b/packages/ploys-api/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/packages/ploys-api/LICENSE-MIT
+++ b/packages/ploys-api/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/packages/ploys-cli/LICENSE-APACHE
+++ b/packages/ploys-cli/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/packages/ploys-cli/LICENSE-MIT
+++ b/packages/ploys-cli/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/packages/ploys/LICENSE-APACHE
+++ b/packages/ploys/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/packages/ploys/LICENSE-MIT
+++ b/packages/ploys/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
This adds symlinks to the license files from the package directories.

## Motivation

The license files should be included with any distributed source code for licensing reasons. This is despite the `Cargo.toml` file specifying the applicable license SPDX. This is not a problem in the repository but publishing individual packages to _crates.io_ will make the source available via _docs.rs_ which may be problematic.

The project will also need to handle symlinks at some point so adding these now would allow the functionality to be tested in a real codebase.

## Implementation

This simply adds _LICENSE-APACHE_ and _LICENSE-MIT_ symlinks in each of the packages to the corresponding files in the root of the repository.