### PR TITLE
Add package README files

### DIFF
--- a/packages/ploys-api/README.md
+++ b/packages/ploys-api/README.md
@@ -1,0 +1,27 @@
+# ploys-api
+
+[![Build][build-badge]][build-badge-url]
+[![License][license-badge]][license-badge-url]
+
+A remote API to manage projects, packages, releases and deployments.
+
+> [!IMPORTANT]
+> This crate is still in development and is not yet suitable for public use.
+
+## License
+
+This project is dual licensed under the following licenses at your discretion:
+
+- [MIT License](LICENSE-MIT)
+- [Apache License, Version 2.0](LICENSE-APACHE)
+
+### Contribution
+
+Unless explicitly stated otherwise any contribution intentionally submitted for
+inclusion in the work shall be dual licensed as above without additional terms
+or conditions.
+
+[build-badge]: https://img.shields.io/github/actions/workflow/status/ploys/ploys/ci.yml
+[build-badge-url]: https://github.com/ploys/ploys/actions/workflows/ci.yml
+[license-badge]: https://img.shields.io/badge/license-MIT%20OR%20Apache%202.0-blue.svg
+[license-badge-url]: https://github.com/ploys/ploys#license

--- a/packages/ploys-cli/README.md
+++ b/packages/ploys-cli/README.md
@@ -1,0 +1,28 @@
+# ploys-cli
+
+[![Build][build-badge]][build-badge-url]
+[![License][license-badge]][license-badge-url]
+
+A command line application to manage projects, packages, releases and
+deployments.
+
+> [!IMPORTANT]
+> This crate is still in development and is not yet suitable for public use.
+
+## License
+
+This project is dual licensed under the following licenses at your discretion:
+
+- [MIT License](LICENSE-MIT)
+- [Apache License, Version 2.0](LICENSE-APACHE)
+
+### Contribution
+
+Unless explicitly stated otherwise any contribution intentionally submitted for
+inclusion in the work shall be dual licensed as above without additional terms
+or conditions.
+
+[build-badge]: https://img.shields.io/github/actions/workflow/status/ploys/ploys/ci.yml
+[build-badge-url]: https://github.com/ploys/ploys/actions/workflows/ci.yml
+[license-badge]: https://img.shields.io/badge/license-MIT%20OR%20Apache%202.0-blue.svg
+[license-badge-url]: https://github.com/ploys/ploys#license

--- a/packages/ploys/README.md
+++ b/packages/ploys/README.md
@@ -1,0 +1,27 @@
+# ploys
+
+[![Build][build-badge]][build-badge-url]
+[![License][license-badge]][license-badge-url]
+
+A utility to manage projects, packages, releases and deployments.
+
+> [!IMPORTANT]
+> This crate is still in development and is not yet suitable for public use.
+
+## License
+
+This project is dual licensed under the following licenses at your discretion:
+
+- [MIT License](LICENSE-MIT)
+- [Apache License, Version 2.0](LICENSE-APACHE)
+
+### Contribution
+
+Unless explicitly stated otherwise any contribution intentionally submitted for
+inclusion in the work shall be dual licensed as above without additional terms
+or conditions.
+
+[build-badge]: https://img.shields.io/github/actions/workflow/status/ploys/ploys/ci.yml
+[build-badge-url]: https://github.com/ploys/ploys/actions/workflows/ci.yml
+[license-badge]: https://img.shields.io/badge/license-MIT%20OR%20Apache%202.0-blue.svg
+[license-badge-url]: https://github.com/ploys/ploys#license


### PR DESCRIPTION
This adds _README.md_ files for each of the packages.

## Motivation

The _ploys_ and _ploys-cli_ packages published on _crates.io_ would benefit from having a _README.md_ file to document what the package does. Although the project is not in a state that is ready for public use, it would be better to include that information upfront rather than let anyone stumble upon the package and try to decipher what it does by the documentation.

The _ploys-api_ package is not published but would also benefit from having a similar notice for anyone that discovers the repository.

The initial documents can then lay the foundation for further documentation to be added.

## Implementation

This simply adds 3 _README.md_ files, one for each package, based on the root _README.md_. This makes use of #325 to link to the licenses, although _GitHub_ should probably redirect to the root license instead of the symlink.