### PR TITLE
Add `/github` app information route

### DIFF
--- a/packages/ploys-api/src/github/mod.rs
+++ b/packages/ploys-api/src/github/mod.rs
@@ -1,1 +1,19 @@
+use axum::Json;
+use axum::extract::State;
+use serde::Serialize;
+
+use crate::state::AppState;
+
 pub mod webhook;
+
+/// Gets the application information.
+pub async fn get(state: State<AppState>) -> Json<AppInfo> {
+    Json(AppInfo {
+        client_id: state.github_app_client_id.to_string(),
+    })
+}
+
+#[derive(Serialize)]
+pub struct AppInfo {
+    client_id: String,
+}

--- a/packages/ploys-api/src/serve/mod.rs
+++ b/packages/ploys-api/src/serve/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Error;
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::{Extension, Router};
 use clap::Args;
 use tokio::net::TcpListener;
@@ -36,6 +36,7 @@ impl Serve {
         };
 
         let router = Router::new()
+            .route("/github", get(crate::github::get))
             .route(
                 "/github/webhook",
                 post(crate::github::webhook::receive)


### PR DESCRIPTION
This adds a new `/github` route to the API server to get application information.

## Motivation

The current aim is to support authentication via the device code flow (#245), but this requires the CLI to know about the GitHub App's client identifier. As this project supports multiple app instances (currently only _ploys_ and _ploys-dev_), this cannot be hardcoded into the executable.

Rather than have users pass client identifiers to the CLI, it would instead be better to have users pass the server URL which can be used to query the identifier.

## Implementation

This simply adds a new `GET /github` route to `ploys-api` that returns a JSON object with the client identifier.