### PR TITLE
Remove `github` feature

### DIFF
--- a/packages/ploys-api/Cargo.toml
+++ b/packages/ploys-api/Cargo.toml
@@ -43,5 +43,4 @@ default-features = false
 [dependencies.ploys]
 version = "0.6.0"
 path = "../ploys"
-features = ["github"]
 default-features = false

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -9,10 +9,9 @@ license = "MIT OR Apache-2.0"
 edition = "2024"
 
 [features]
-default = ["fs", "git", "github"]
+default = ["fs", "git"]
 fs = ["dep:walkdir"]
 git = ["dep:gix"]
-github = ["dep:reqwest"]
 
 [dependencies]
 base64 = "0.22.1"
@@ -38,7 +37,6 @@ walkdir = { version = "2.5.0", optional = true }
 version = "0.12.9"
 features = ["blocking", "json", "rustls-tls", "charset", "http2", "system-proxy"]
 default-features = false
-optional = true
 
 [dev-dependencies]
 indoc = "2.0.5"

--- a/packages/ploys/src/package/error.rs
+++ b/packages/ploys/src/package/error.rs
@@ -88,7 +88,6 @@ impl From<crate::repository::types::git::Error> for Error<crate::repository::typ
     }
 }
 
-#[cfg(feature = "github")]
 impl From<crate::repository::types::github::Error>
     for Error<crate::repository::types::github::Error>
 {

--- a/packages/ploys/src/project/error.rs
+++ b/packages/ploys/src/project/error.rs
@@ -98,7 +98,6 @@ impl From<crate::repository::types::git::Error> for Error<crate::repository::typ
     }
 }
 
-#[cfg(feature = "github")]
 impl From<crate::repository::types::github::Error>
     for Error<crate::repository::types::github::Error>
 {

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -494,7 +494,6 @@ mod git {
     }
 }
 
-#[cfg(feature = "github")]
 mod github {
     use crate::repository::Open;
     use crate::repository::revision::Revision;

--- a/packages/ploys/src/repository/spec.rs
+++ b/packages/ploys/src/repository/spec.rs
@@ -41,7 +41,6 @@ impl RepoSpec {
     }
 
     /// Gets a GitHub repository specification.
-    #[cfg(feature = "github")]
     pub fn to_github(&self) -> Option<super::types::github::GitHubRepoSpec> {
         match self {
             Self::Url(url) => match url.host()? {
@@ -102,7 +101,6 @@ impl From<ShortRepoSpec> for RepoSpec {
     }
 }
 
-#[cfg(feature = "github")]
 impl From<super::types::github::GitHubRepoSpec> for RepoSpec {
     fn from(github: super::types::github::GitHubRepoSpec) -> Self {
         Self::Short(ShortRepoSpec::GitHub(github))
@@ -113,10 +111,8 @@ impl From<super::types::github::GitHubRepoSpec> for RepoSpec {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, EnumIs, EnumTryAs)]
 pub enum ShortRepoSpec {
     /// A default (GitHub) repository specification.
-    #[cfg(feature = "github")]
     Default(super::types::github::GitHubRepoSpec),
     /// A GitHub repository specification.
-    #[cfg(feature = "github")]
     GitHub(super::types::github::GitHubRepoSpec),
 }
 
@@ -124,24 +120,16 @@ impl ShortRepoSpec {
     /// Gets the repository URL.
     pub fn to_url(&self) -> Url {
         match self {
-            #[cfg(feature = "github")]
             Self::Default(spec) | Self::GitHub(spec) => spec.to_url(),
-            #[cfg(not(feature = "github"))]
-            _ => unreachable!(),
         }
     }
 }
 
 impl Display for ShortRepoSpec {
-    #[cfg_attr(not(feature = "github"), allow(unused_variables))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            #[cfg(feature = "github")]
             Self::Default(spec) => write!(f, "{spec}"),
-            #[cfg(feature = "github")]
             Self::GitHub(spec) => write!(f, "github:{spec}"),
-            #[cfg(not(feature = "github"))]
-            _ => unreachable!(),
         }
     }
 }
@@ -149,23 +137,17 @@ impl Display for ShortRepoSpec {
 impl FromStr for ShortRepoSpec {
     type Err = Error;
 
-    #[cfg_attr(not(feature = "github"), allow(unused_variables))]
     fn from_str(spec: &str) -> Result<Self, Self::Err> {
         match spec.split_once(':') {
             Some((kind, rest)) => match kind {
-                #[cfg(feature = "github")]
                 "github" => Ok(Self::GitHub(rest.parse()?)),
                 _ => Err(Error::unsupported(spec)),
             },
-            #[cfg(feature = "github")]
             None => Ok(Self::Default(spec.parse()?)),
-            #[cfg(not(feature = "github"))]
-            None => Err(Error::unsupported(spec)),
         }
     }
 }
 
-#[cfg(feature = "github")]
 impl From<super::types::github::GitHubRepoSpec> for ShortRepoSpec {
     fn from(github: super::types::github::GitHubRepoSpec) -> Self {
         Self::GitHub(github)
@@ -206,7 +188,7 @@ impl Display for Error {
 
 #[cfg(test)]
 mod tests {
-    #[cfg_attr(feature = "github", test)]
+    #[test]
     fn test_parse() {
         use super::RepoSpec;
 

--- a/packages/ploys/src/repository/types/mod.rs
+++ b/packages/ploys/src/repository/types/mod.rs
@@ -6,5 +6,4 @@ pub mod fs;
 #[cfg(feature = "git")]
 pub mod git;
 
-#[cfg(feature = "github")]
 pub mod github;


### PR DESCRIPTION
This removes the `github` feature from the `ploys` package.

## Motivation

This project is moving towards dropping potential support for other providers and focusing entirely on `GitHub` in the initial release. This involves a remote-first design where the source of truth is always a _GitHub_ repository. As such, the `github` feature is no longer necessary as the functionality will always be required.

## Implementation

This simply removes the `github` feature from the `ploys` package, updates the dependency in `ploys-api`, and removes the various `cfg` attributes.