### PR TITLE
Add project management client

### DIFF
--- a/packages/ploys/src/client/credentials/mod.rs
+++ b/packages/ploys/src/client/credentials/mod.rs
@@ -1,0 +1,34 @@
+mod token;
+
+pub use self::token::Token;
+
+/// The client authentication credentials.
+#[derive(Clone, Debug, Default)]
+pub struct Credentials {
+    access_token: Option<Token>,
+}
+
+impl Credentials {
+    /// Constructs new client authentication credentials.
+    pub fn new() -> Self {
+        Self { access_token: None }
+    }
+
+    /// Builds the credentials with the given access token.
+    pub fn with_access_token(mut self, token: impl Into<Token>) -> Self {
+        self.set_access_token(token);
+        self
+    }
+}
+
+impl Credentials {
+    /// Gets the access token.
+    pub fn get_access_token(&self) -> Option<Token> {
+        self.access_token.clone()
+    }
+
+    /// Sets the access token.
+    pub fn set_access_token(&mut self, token: impl Into<Token>) {
+        self.access_token = Some(token.into());
+    }
+}

--- a/packages/ploys/src/client/credentials/token.rs
+++ b/packages/ploys/src/client/credentials/token.rs
@@ -1,0 +1,95 @@
+use std::fmt::{self, Debug, Display};
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+/// An authentication token.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Token {
+    value: String,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "time::serde::iso8601::option"
+    )]
+    expiry: Option<OffsetDateTime>,
+}
+
+impl Token {
+    /// Constructs a new authentication token.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            expiry: None,
+        }
+    }
+
+    /// Builds the token with the given expiry.
+    pub fn with_expiry(mut self, expiry: impl Into<OffsetDateTime>) -> Self {
+        self.set_expiry(expiry);
+        self
+    }
+}
+
+impl Token {
+    /// Gets the token value.
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    /// Sets the token value.
+    pub fn set_value(&mut self, value: impl Into<String>) {
+        self.value = value.into();
+    }
+
+    /// Gets the token expiry.
+    pub fn expiry(&self) -> Option<&OffsetDateTime> {
+        self.expiry.as_ref()
+    }
+
+    /// Sets the token expiry.
+    pub fn set_expiry(&mut self, expiry: impl Into<OffsetDateTime>) {
+        self.expiry = Some(expiry.into());
+    }
+
+    /// Checks if the token is expired.
+    pub fn is_expired(&self) -> bool {
+        match self.expiry {
+            Some(exp) => exp <= OffsetDateTime::now_utc(),
+            None => false,
+        }
+    }
+}
+
+impl Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.value, f)
+    }
+}
+
+impl Debug for Token {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Token")
+            .field("value", &"***")
+            .field("expiry", &self.expiry)
+            .finish()
+    }
+}
+
+impl From<&str> for Token {
+    fn from(value: &str) -> Self {
+        Self {
+            value: value.to_string(),
+            expiry: None,
+        }
+    }
+}
+
+impl From<String> for Token {
+    fn from(value: String) -> Self {
+        Self {
+            value,
+            expiry: None,
+        }
+    }
+}

--- a/packages/ploys/src/client/error.rs
+++ b/packages/ploys/src/client/error.rs
@@ -1,0 +1,33 @@
+use std::fmt::{self, Display};
+
+/// The client error.
+#[derive(Debug)]
+pub enum Error {
+    /// A request error.
+    Request(reqwest::Error),
+    /// A project error.
+    Project(crate::project::Error<crate::repository::types::github::Error>),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Request(err) => Display::fmt(err, f),
+            Self::Project(err) => Display::fmt(err, f),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
+        Self::Request(err)
+    }
+}
+
+impl From<crate::project::Error<crate::repository::types::github::Error>> for Error {
+    fn from(err: crate::project::Error<crate::repository::types::github::Error>) -> Self {
+        Self::Project(err)
+    }
+}

--- a/packages/ploys/src/client/mod.rs
+++ b/packages/ploys/src/client/mod.rs
@@ -1,0 +1,72 @@
+mod credentials;
+mod error;
+
+use reqwest::blocking::Client as HttpClient;
+
+use crate::project::Project;
+use crate::repository::RepoAddr;
+use crate::repository::types::github::{Error as RepoError, GitHub};
+
+pub use self::credentials::{Credentials, Token};
+pub use self::error::Error;
+
+/// The project management client.
+#[derive(Clone, Debug)]
+pub struct Client {
+    credentials: Option<Credentials>,
+    http_client: HttpClient,
+}
+
+impl Client {
+    /// Constructs a new project management client.
+    pub fn new() -> Result<Self, Error> {
+        Ok(Self {
+            credentials: None,
+            http_client: HttpClient::builder()
+                .user_agent(concat!("ploys/", env!("CARGO_PKG_VERSION")))
+                .build()?,
+        })
+    }
+
+    /// Builds the client with the given authentication credentials.
+    pub fn with_credentials(mut self, credentials: impl Into<Credentials>) -> Self {
+        self.set_credentials(credentials);
+        self
+    }
+}
+
+impl Client {
+    /// Gets a project with the given repository address.
+    pub fn get_project<R>(&self, repo: R) -> Result<Project<GitHub>, Error>
+    where
+        R: TryInto<RepoAddr, Error: Into<RepoError>>,
+    {
+        match self.get_access_token() {
+            Some(token) => Ok(Project::github_with_authentication_token(
+                repo,
+                token.value(),
+            )?),
+            None => Ok(Project::github(repo)?),
+        }
+    }
+
+    /// Sets the client authentication credentials.
+    pub fn set_credentials(&mut self, credentials: impl Into<Credentials>) {
+        self.credentials = Some(credentials.into());
+    }
+}
+
+impl Client {
+    /// Gets the HTTP client.
+    pub(crate) fn http_client(&self) -> &HttpClient {
+        &self.http_client
+    }
+
+    /// Gets the authentication credentials access token.
+    pub(crate) fn get_access_token(&self) -> Option<Token> {
+        match &self.credentials {
+            Some(credentials) => credentials.get_access_token(),
+            None => None,
+        }
+    }
+}

--- a/packages/ploys/src/lib.rs
+++ b/packages/ploys/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod changelog;
+pub mod client;
 pub mod package;
 pub mod project;
 pub mod repository;

--- a/packages/ploys/src/repository/types/github/changelog.rs
+++ b/packages/ploys/src/repository/types/github/changelog.rs
@@ -15,9 +15,8 @@ pub(super) fn get_release(
     package: &str,
     version: &Version,
     is_primary: bool,
-    token: Option<&str>,
 ) -> Result<Release, Error> {
-    let tags = get_all_tags(repository, token)?;
+    let tags = get_all_tags(repository)?;
     let tagname = match is_primary {
         true => version.to_string(),
         false => format!("{package}-{version}"),
@@ -37,11 +36,11 @@ pub(super) fn get_release(
         .unwrap_or_else(OffsetDateTime::now_utc);
 
     let pull_requests = match (prev_tag, tag) {
-        (None, None) => self::all(repository, token)?,
-        (None, Some(tag)) => self::until(repository, &tag.name, &tag.target.oid, token)?,
+        (None, None) => self::all(repository)?,
+        (None, Some(tag)) => self::until(repository, &tag.name, &tag.target.oid)?,
         (Some(_), _) if prev_version.expect("prev") > *version => Vec::new(),
-        (Some(from), None) => self::between(repository, &from, "HEAD", token)?,
-        (Some(from), Some(to)) => self::between(repository, &from, &to.name, token)?,
+        (Some(from), None) => self::between(repository, &from, "HEAD")?,
+        (Some(from), Some(to)) => self::between(repository, &from, &to.name)?,
     };
 
     let package_label = format!("package: {package}");
@@ -109,13 +108,13 @@ query($owner: String!, $name: String!, $cursor: String) {
 "#;
 
 /// Gets all tags.
-fn get_all_tags(repository: &Repo, token: Option<&str>) -> Result<Vec<GitTag>, Error> {
+fn get_all_tags(repository: &Repo) -> Result<Vec<GitTag>, Error> {
     let mut tags = Vec::new();
     let mut cursor = None;
 
     loop {
         let response = repository
-            .graphql(token)
+            .graphql()
             .json(&Query {
                 query: ALL_TAGS_QUERY,
                 variables: Variables {
@@ -218,13 +217,13 @@ query($owner: String!, $name: String!, $cursor: String) {
 "#;
 
 /// Gets all pull requests.
-fn all(repository: &Repo, token: Option<&str>) -> Result<Vec<PullRequest>, Error> {
+fn all(repository: &Repo) -> Result<Vec<PullRequest>, Error> {
     let mut pull_requests = BTreeMap::<_, PullRequest>::new();
     let mut cursor = None;
 
     loop {
         let response = repository
-            .graphql(token)
+            .graphql()
             .json(&Query {
                 query: ALL_QUERY,
                 variables: Variables {
@@ -301,18 +300,13 @@ query($owner: String!, $name: String!, $to: String!, $cursor: String) {
 "#;
 
 /// Gets pull requests until the specified ref.
-fn until(
-    repository: &Repo,
-    to: &str,
-    sha: &str,
-    token: Option<&str>,
-) -> Result<Vec<PullRequest>, Error> {
+fn until(repository: &Repo, to: &str, sha: &str) -> Result<Vec<PullRequest>, Error> {
     let mut pull_requests = BTreeMap::<_, PullRequest>::new();
     let mut cursor = None;
 
     loop {
         let response = repository
-            .graphql(token)
+            .graphql()
             .json(&Query {
                 query: UNTIL_QUERY,
                 variables: Variables {
@@ -391,18 +385,13 @@ query($owner: String!, $name: String!, $from: String!, $to: String!, $cursor: St
 "#;
 
 /// Gets pull requests between two refs.
-fn between(
-    repository: &Repo,
-    from: &str,
-    to: &str,
-    token: Option<&str>,
-) -> Result<Vec<PullRequest>, Error> {
+fn between(repository: &Repo, from: &str, to: &str) -> Result<Vec<PullRequest>, Error> {
     let mut pull_requests = BTreeMap::<_, PullRequest>::new();
     let mut cursor = None;
 
     loop {
         let response = repository
-            .graphql(token)
+            .graphql()
             .json(&Query {
                 query: BETWEEN_QUERY,
                 variables: Variables {

--- a/packages/ploys/src/repository/types/github/mod.rs
+++ b/packages/ploys/src/repository/types/github/mod.rs
@@ -72,17 +72,17 @@ impl GitHub {
 
     /// Builds the repository with the given authentication token.
     pub fn with_authentication_token(mut self, token: impl Into<String>) -> Self {
-        self.inner.inner.inner_mut().token = Some(token.into());
+        self.inner
+            .inner
+            .inner_mut()
+            .repository
+            .set_access_token(token.into());
         self
     }
 
     /// Builds the repository with validation to ensure it exists.
     pub fn validated(self) -> Result<Self, Error> {
-        self.inner
-            .inner
-            .inner()
-            .repository
-            .validate(self.inner.inner.inner().token.as_deref())?;
+        self.inner.inner.inner().repository.validate()?;
 
         Ok(self)
     }
@@ -114,7 +114,7 @@ impl GitHub {
                     .inner
                     .inner()
                     .repository
-                    .get("git/trees/HEAD", self.inner.inner.inner().token.as_deref())
+                    .get("git/trees/HEAD")
                     .header("Accept", "application/vnd.github+json")
                     .header("X-GitHub-Api-Version", "2022-11-28")
                     .send()?
@@ -130,10 +130,7 @@ impl GitHub {
                     .inner
                     .inner()
                     .repository
-                    .get(
-                        format!("git/ref/{reference}"),
-                        self.inner.inner.inner().token.as_deref(),
-                    )
+                    .get(format!("git/ref/{reference}"))
                     .header("Accept", "application/vnd.github+json")
                     .header("X-GitHub-Api-Version", "2022-11-28")
                     .send()?
@@ -253,7 +250,7 @@ impl Commit for GitHub {
                         .inner
                         .inner()
                         .repository
-                        .post("git/blobs", self.inner.inner.inner().token.as_deref())
+                        .post("git/blobs")
                         .header("Accept", "application/vnd.github+json")
                         .header("X-GitHub-Api-Version", "2022-11-28")
                         .json(&payload)
@@ -288,7 +285,7 @@ impl Commit for GitHub {
             .inner
             .inner()
             .repository
-            .post("git/trees", self.inner.inner.inner().token.as_deref())
+            .post("git/trees")
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28")
             .json(&tree)
@@ -305,7 +302,7 @@ impl Commit for GitHub {
             .inner
             .inner()
             .repository
-            .post("git/commits", self.inner.inner.inner().token.as_deref())
+            .post("git/commits")
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28")
             .json(&CreateCommit {
@@ -357,7 +354,6 @@ impl Open for GitHub {
                 Cached::new(Inner {
                     repository: Repo::new(ctx.try_into().map_err(Into::into)?)?,
                     revision: Revision::head(),
-                    token: None,
                 })
                 .enabled(false),
             ),
@@ -369,7 +365,6 @@ impl Open for GitHub {
 struct Inner {
     repository: Repo,
     revision: Revision,
-    token: Option<String>,
 }
 
 impl Repository for Inner {
@@ -378,10 +373,7 @@ impl Repository for Inner {
     fn get_file(&self, path: impl AsRef<RelativePath>) -> Result<Option<Bytes>, Self::Error> {
         let mut response = self
             .repository
-            .get(
-                format!("contents/{}?ref={}", path.as_ref(), self.revision),
-                self.token.as_deref(),
-            )
+            .get(format!("contents/{}?ref={}", path.as_ref(), self.revision))
             .header("Accept", "application/vnd.github.raw")
             .header("X-GitHub-Api-Version", "2022-11-28")
             .send()?
@@ -416,10 +408,7 @@ impl Repository for Inner {
 
         let entries = self
             .repository
-            .get(
-                format!("git/trees/{}", self.revision),
-                self.token.as_deref(),
-            )
+            .get(format!("git/trees/{}", self.revision))
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28")
             .query(&[("recursive", "true")])
@@ -506,7 +495,7 @@ impl GitLike for GitHub {
                 .inner
                 .inner()
                 .repository
-                .post("git/blobs", self.inner.inner.inner().token.as_deref())
+                .post("git/blobs")
                 .header("Accept", "application/vnd.github+json")
                 .header("X-GitHub-Api-Version", "2022-11-28")
                 .json(&CreateBlob {
@@ -534,7 +523,7 @@ impl GitLike for GitHub {
             .inner
             .inner()
             .repository
-            .post("git/trees", self.inner.inner.inner().token.as_deref())
+            .post("git/trees")
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28")
             .json(&tree)
@@ -551,7 +540,7 @@ impl GitLike for GitHub {
             .inner
             .inner()
             .repository
-            .post("git/commits", self.inner.inner.inner().token.as_deref())
+            .post("git/commits")
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28")
             .json(&CreateCommit {
@@ -581,7 +570,7 @@ impl GitLike for GitHub {
             .inner
             .inner()
             .repository
-            .get("", self.inner.inner.inner().token.as_deref())
+            .get("")
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28")
             .send()
@@ -608,7 +597,7 @@ impl GitLike for GitHub {
             .inner
             .inner()
             .repository
-            .post("git/refs", self.inner.inner.inner().token.as_deref())
+            .post("git/refs")
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28")
             .json(&NewBranch {
@@ -633,10 +622,7 @@ impl GitLike for GitHub {
             .inner
             .inner()
             .repository
-            .patch(
-                format!("git/refs/heads/{name}"),
-                self.inner.inner.inner().token.as_deref(),
-            )
+            .patch(format!("git/refs/heads/{name}"))
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28")
             .json(&UpdateRef {
@@ -673,7 +659,7 @@ impl Remote for GitHub {
             .inner
             .inner()
             .repository
-            .post("dispatches", self.inner.inner.inner().token.as_deref())
+            .post("dispatches")
             .header("X-GitHub-Api-Version", "2022-11-28")
             .json(&RepositoryDispatchEvent {
                 event_type: String::from("ploys-package-release-request"),
@@ -701,7 +687,6 @@ impl Remote for GitHub {
             package,
             version,
             is_primary,
-            self.inner.inner.inner().token.as_deref(),
         )
     }
 
@@ -730,7 +715,7 @@ impl Remote for GitHub {
             .inner
             .inner()
             .repository
-            .post("pulls", self.inner.inner.inner().token.as_deref())
+            .post("pulls")
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28")
             .json(&NewPullRequest {
@@ -797,7 +782,7 @@ impl Remote for GitHub {
             .inner
             .inner()
             .repository
-            .post("releases", self.inner.inner.inner().token.as_deref())
+            .post("releases")
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28")
             .json(&NewRelease {

--- a/packages/ploys/src/repository/types/github/repo.rs
+++ b/packages/ploys/src/repository/types/github/repo.rs
@@ -1,7 +1,7 @@
 use reqwest::Method;
-use reqwest::blocking::{Client, RequestBuilder};
-use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
+use reqwest::blocking::RequestBuilder;
 
+use crate::client::{Client, Credentials, Error as ClientError, Token};
 use crate::repository::addr::RepoAddr;
 
 use super::Error;
@@ -16,13 +16,13 @@ pub struct Repo {
 impl Repo {
     /// Constructs a new repository.
     pub(crate) fn new(addr: impl Into<RepoAddr>) -> Result<Self, Error> {
-        let mut headers = HeaderMap::new();
-
-        headers.insert(USER_AGENT, HeaderValue::from_static("ploys/ploys"));
-
         Ok(Self {
             addr: addr.into(),
-            client: Client::builder().default_headers(headers).build()?,
+            client: match Client::new() {
+                Ok(client) => client,
+                Err(ClientError::Request(err)) => return Err(Error::Request(err)),
+                Err(_) => unreachable!("client constructor only returns request error"),
+            },
         })
     }
 
@@ -36,9 +36,15 @@ impl Repo {
         self.addr.name()
     }
 
+    /// Sets the access token.
+    pub(super) fn set_access_token(&mut self, token: impl Into<Token>) {
+        self.client
+            .set_credentials(Credentials::new().with_access_token(token));
+    }
+
     /// Validates whether the remote repository exists.
-    pub(super) fn validate(&self, token: Option<&str>) -> Result<(), Error> {
-        self.head("", token).send()?.error_for_status()?;
+    pub(super) fn validate(&self) -> Result<(), Error> {
+        self.head("").send()?.error_for_status()?;
 
         Ok(())
     }
@@ -61,13 +67,16 @@ impl Repo {
     }
 
     /// Creates a HTTP request.
-    pub(super) fn request<P>(&self, method: Method, path: P, token: Option<&str>) -> RequestBuilder
+    pub(super) fn request<P>(&self, method: Method, path: P) -> RequestBuilder
     where
         P: AsRef<str>,
     {
-        let mut request = self.client.request(method, self.endpoint(path));
+        let mut request = self
+            .client
+            .http_client()
+            .request(method, self.endpoint(path));
 
-        if let Some(token) = token {
+        if let Some(token) = self.client.get_access_token() {
             request = request.bearer_auth(token);
         }
 
@@ -75,42 +84,45 @@ impl Repo {
     }
 
     /// Creates a HEAD request.
-    pub(super) fn head<P>(&self, path: P, token: Option<&str>) -> RequestBuilder
+    pub(super) fn head<P>(&self, path: P) -> RequestBuilder
     where
         P: AsRef<str>,
     {
-        self.request(Method::HEAD, path, token)
+        self.request(Method::HEAD, path)
     }
 
     /// Creates a GET request.
-    pub(super) fn get<P>(&self, path: P, token: Option<&str>) -> RequestBuilder
+    pub(super) fn get<P>(&self, path: P) -> RequestBuilder
     where
         P: AsRef<str>,
     {
-        self.request(Method::GET, path, token)
+        self.request(Method::GET, path)
     }
 
     /// Creates a POST request.
-    pub(super) fn post<P>(&self, path: P, token: Option<&str>) -> RequestBuilder
+    pub(super) fn post<P>(&self, path: P) -> RequestBuilder
     where
         P: AsRef<str>,
     {
-        self.request(Method::POST, path, token)
+        self.request(Method::POST, path)
     }
 
     /// Creates a PATCH request.
-    pub(super) fn patch<P>(&self, path: P, token: Option<&str>) -> RequestBuilder
+    pub(super) fn patch<P>(&self, path: P) -> RequestBuilder
     where
         P: AsRef<str>,
     {
-        self.request(Method::PATCH, path, token)
+        self.request(Method::PATCH, path)
     }
 
     /// Creates a GraphQL HTTP request.
-    pub(super) fn graphql(&self, token: Option<&str>) -> RequestBuilder {
-        let mut request = self.client.post("https://api.github.com/graphql");
+    pub(super) fn graphql(&self) -> RequestBuilder {
+        let mut request = self
+            .client
+            .http_client()
+            .post("https://api.github.com/graphql");
 
-        if let Some(token) = token {
+        if let Some(token) = self.client.get_access_token() {
             request = request.bearer_auth(token);
         }
 


### PR DESCRIPTION
This adds a new project management client to the `ploys` package.

## Motivation

As this project moves towards being remote-first, there is a benefit in having a central client from which to make API requests to both the server component and GitHub itself. This would allow authentication to be handled centrally with projects using a shared client such that support for refresh tokens can eventually be introduced.

## Implementation

This introduces a new `Client` type under the `client` module that combines a blocking HTTP client from `reqwest` and a custom `Credentials` type used to store an access `Token`. This establishes the foundations for building out refresh token support in the future.

The new `Client` is now the foundation of the GitHub `Repo` type, allowing it to use the internal access token and simplifying the various methods that no longer need a separate token argument.

The `ploys-api` and `ploys-cli` packages have not yet been updated to support the new client as the API may change as the client is built out to support additional authentication flows.