### PR TITLE
Remove unsupported release on commit SHA

### DIFF
--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -8,7 +8,6 @@ use axum::extract::State;
 use axum_extra::TypedHeader;
 use ploys::package::BumpOrVersion;
 use ploys::project::Project;
-use ploys::repository::revision::Revision;
 use semver::Version;
 use serde::Deserialize;
 use serde_with::{DisplayFromStr, serde_as};
@@ -33,12 +32,9 @@ pub async fn receive(
     match payload {
         Payload::PullRequest(payload) => match &*payload.action {
             "closed" if payload.pull_request.merged => {
-                if payload.pull_request.head.r#ref.starts_with("release/")
-                    && let Some(sha) = &payload.pull_request.merge_commit_sha
-                {
+                if payload.pull_request.head.r#ref.starts_with("release/") {
                     create_release(
                         payload.pull_request.head.r#ref[8..].to_owned(),
-                        sha.clone(),
                         payload,
                         &state,
                     )
@@ -64,7 +60,6 @@ pub async fn receive(
 /// Creates a new release.
 async fn create_release(
     release: String,
-    sha: String,
     payload: PullRequestPayload,
     state: &AppState,
 ) -> Result<(), Error> {
@@ -73,7 +68,7 @@ async fn create_release(
             .await?;
 
     tokio::task::spawn_blocking(move || {
-        if let Err(err) = create_release_sync(token, release, sha, payload) {
+        if let Err(err) = create_release_sync(token, release, payload) {
             error!("Error creating release: {err}");
         }
     });
@@ -85,14 +80,9 @@ async fn create_release(
 fn create_release_sync(
     token: String,
     release: String,
-    sha: String,
     payload: PullRequestPayload,
 ) -> Result<(), Error> {
-    let project = Project::github_with_revision_and_authentication_token(
-        &payload.repository.full_name,
-        Revision::sha(sha),
-        &token,
-    )?;
+    let project = Project::github_with_authentication_token(&payload.repository.full_name, &token)?;
 
     let package = project
         .packages()
@@ -145,11 +135,7 @@ async fn request_release(
 fn create_release_request(token: String, payload: RepositoryDispatchPayload) -> Result<(), Error> {
     let ClientPayload { package, version } = serde_json::from_value(payload.client_payload)?;
 
-    let project = Project::github_with_revision_and_authentication_token(
-        &payload.repository.full_name,
-        Revision::branch(&payload.branch),
-        &token,
-    )?;
+    let project = Project::github_with_authentication_token(&payload.repository.full_name, &token)?;
 
     let package = project
         .get_package(&package)

--- a/packages/ploys-api/src/github/webhook/payload.rs
+++ b/packages/ploys-api/src/github/webhook/payload.rs
@@ -95,7 +95,6 @@ pub struct PullRequestPayload {
 #[derive(Debug, Deserialize)]
 pub struct RepositoryDispatchPayload {
     pub action: String,
-    pub branch: String,
     pub client_payload: Value,
     pub repository: Repository,
     pub installation: Installation,
@@ -116,7 +115,6 @@ pub struct Installation {
 pub struct PullRequest {
     pub head: Branch,
     pub merged: bool,
-    pub merge_commit_sha: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
This removes the unsupported package release on commit SHAs.

## Motivation

The project intended to not only support releasing the latest version of the codebase, but also to support releases targeting older versions, e.g. a release of `1.1.0` after `2.0.0` has been released or `1.0.1` after `1.1.0` has been released. However, this is not currently supported by the CLI and is therefore untested in the API.

In order to facilitate future changes, this functionality should be removed. This is somewhat covered by #91 and should be restored when it is time to be implemented.

## Implementation

This change updates the `ploys-api` package to remove references to the commit SHA from the release process, and also removes the branch from the repository dispatch event as that should always be the default branch.