### PR TITLE
Remove `GitHub::with_authentication_token` method

### DIFF
--- a/packages/ploys/src/repository/types/github/mod.rs
+++ b/packages/ploys/src/repository/types/github/mod.rs
@@ -346,8 +346,7 @@ impl Open for GitHub {
     /// Opens a GitHub repository.
     ///
     /// Note that this does not validate the existence of the repository as it
-    /// may require an authentication token. Call `validated` to ensure that a
-    /// private repository exists after calling `with_authentication_token`.
+    /// may require an authentication token.
     fn open<T, E>(ctx: T) -> Result<Self, Self::Error>
     where
         T: TryInto<Self::Context, Error = E>,

--- a/packages/ploys/src/repository/types/github/mod.rs
+++ b/packages/ploys/src/repository/types/github/mod.rs
@@ -19,7 +19,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 
 use crate::changelog::Release;
-use crate::client::{Client, Token};
+use crate::client::Client;
 use crate::package::BumpOrVersion;
 use crate::repository::adapters::cached::Cached;
 use crate::repository::adapters::staged::Staged;
@@ -81,16 +81,6 @@ impl GitHub {
     /// Builds the repository with the given revision.
     pub fn with_revision(mut self, revision: impl Into<Revision>) -> Self {
         self.set_revision(revision);
-        self
-    }
-
-    /// Builds the repository with the given authentication token.
-    pub fn with_authentication_token(mut self, token: impl Into<Token>) -> Self {
-        self.inner
-            .inner
-            .inner_mut()
-            .repository
-            .set_access_token(token.into());
         self
     }
 

--- a/packages/ploys/src/repository/types/github/repo.rs
+++ b/packages/ploys/src/repository/types/github/repo.rs
@@ -1,7 +1,7 @@
 use reqwest::Method;
 use reqwest::blocking::RequestBuilder;
 
-use crate::client::{Client, Credentials, Token};
+use crate::client::Client;
 use crate::repository::addr::RepoAddr;
 
 use super::Error;
@@ -27,12 +27,6 @@ impl Repo {
     /// Gets the repository name.
     pub fn name(&self) -> &str {
         self.addr.name()
-    }
-
-    /// Sets the access token.
-    pub(super) fn set_access_token(&mut self, token: impl Into<Token>) {
-        self.client
-            .set_credentials(Credentials::new().with_access_token(token));
     }
 
     /// Validates whether the remote repository exists.


### PR DESCRIPTION
This removes the `GitHub::with_authentication_token` method.

## Motivation

The `GitHub` repository type contains a `Client` that currently supports setting an authentication token. However, the plan is to embed the token into a new authentication flow that wouldn't allow it to be changed once configured. This means exposing the ability to change it in the `GitHub` repository would be problematic as it would necessitate constructing a new client.

Fortunately, the code does not currently use this method and removing it would be the simplest option. However, it does limit how the `GitHub` repository type can be used as there would be no way to provide an authentication token once constructed.

# Implementation

This change simply removes the public `with_authentication_token` method on the `GitHub` repository type, and removes other internal code that it uses to set the token.