### PR TITLE
Share client credentials across clones

### DIFF
--- a/packages/ploys/src/client/mod.rs
+++ b/packages/ploys/src/client/mod.rs
@@ -1,7 +1,7 @@
 mod credentials;
 mod error;
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use once_cell::sync::OnceCell;
 use reqwest::blocking::Client as HttpClient;
@@ -16,7 +16,7 @@ pub use self::error::Error;
 /// The project management client.
 #[derive(Clone, Debug, Default)]
 pub struct Client {
-    credentials: Option<Credentials>,
+    credentials: Arc<RwLock<Option<Credentials>>>,
     http_client: Arc<OnceCell<HttpClient>>,
 }
 
@@ -24,12 +24,14 @@ impl Client {
     /// Constructs a new project management client.
     pub fn new() -> Self {
         Self {
-            credentials: None,
+            credentials: Arc::new(RwLock::new(None)),
             http_client: Arc::new(OnceCell::new()),
         }
     }
 
     /// Builds the client with the given authentication credentials.
+    ///
+    /// See [`Self::set_credentials`] for more information.
     pub fn with_credentials(mut self, credentials: impl Into<Credentials>) -> Self {
         self.set_credentials(credentials);
         self
@@ -49,8 +51,12 @@ impl Client {
     }
 
     /// Sets the client authentication credentials.
+    ///
+    /// Note that this method overrides the credentials for this client instance
+    /// only. Prior clones will share the previous credentials unless those
+    /// instances are also updated.
     pub fn set_credentials(&mut self, credentials: impl Into<Credentials>) {
-        self.credentials = Some(credentials.into());
+        self.credentials = Arc::new(RwLock::new(Some(credentials.into())));
     }
 }
 
@@ -66,7 +72,12 @@ impl Client {
 
     /// Gets the authentication credentials access token.
     pub(crate) fn get_access_token(&self) -> Option<Token> {
-        match &self.credentials {
+        let credentials = self
+            .credentials
+            .read()
+            .unwrap_or_else(|err| err.into_inner());
+
+        match &*credentials {
             Some(credentials) => credentials.get_access_token(),
             None => None,
         }


### PR DESCRIPTION
This shares client credentials across client instances created by calling `clone`.

## Motivation

The `Client` type is used to retrieve packages and handle communication with the _GitHub_ API. When a package is retrieved, the client is cloned and stored within the inner repository. This currently clones the credentials, but the plan is to support using an authentication flow to retrieve new credentials. In order to avoid refreshing the credentials for each package instance the credentials need to be shared across each instance.

## Implementation

This change uses `Arc` and `RwLock` to allow the credentials to be shared across cloned instances while still being mutable.

Getting the credentials ignores lock poisoning as the credentials should either be read or overwritten and never enter an invalid state. Once the authentication flow support is added then it may be possible for the lock to become poisoned while it is held but that should not affect the credentials in any way. The `parking_lot` crate could have been used but it didn't seem necessary.

The `set_credentials` and `with_credentials` methods don't actually use the lock and simply replace the entire `Arc<RwLock<Credentials>>` whenever they are called. This means that the lock isn't technically used in this change but it will be necessary to introduce authentication flow support. The idea was that manually setting the credentials after calling `get_package` or `clone` would be confusing, but internally calling the authentication flow and updating the credentials across multiple instances would not.