### PR TITLE
Add client builder

### DIFF
--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -82,7 +82,9 @@ fn create_release_sync(
     release: String,
     payload: PullRequestPayload,
 ) -> Result<(), Error> {
-    let client = Client::new().with_credentials(Credentials::new().with_access_token(token));
+    let client = Client::build()
+        .with_credentials(Credentials::new().with_access_token(token))
+        .finished()?;
     let project = client.get_project(&payload.repository.full_name)?;
 
     let package = project
@@ -136,7 +138,9 @@ async fn request_release(
 fn create_release_request(token: Token, payload: RepositoryDispatchPayload) -> Result<(), Error> {
     let ClientPayload { package, version } = serde_json::from_value(payload.client_payload)?;
 
-    let client = Client::new().with_credentials(Credentials::new().with_access_token(token));
+    let client = Client::build()
+        .with_credentials(Credentials::new().with_access_token(token))
+        .finished()?;
     let project = client.get_project(&payload.repository.full_name)?;
     let package = project
         .get_package(&package)

--- a/packages/ploys-cli/src/package/changelog.rs
+++ b/packages/ploys-cli/src/package/changelog.rs
@@ -45,7 +45,7 @@ impl Changelog {
         };
 
         let credentials = Credentials::new().with_access_token(self.token);
-        let client = Client::new().with_credentials(credentials);
+        let client = Client::build().with_credentials(credentials).finished()?;
         let project = client.get_project(repo)?;
         let package = project
             .get_package(&self.package)

--- a/packages/ploys-cli/src/package/release.rs
+++ b/packages/ploys-cli/src/package/release.rs
@@ -36,7 +36,7 @@ impl Release {
         };
 
         let credentials = Credentials::new().with_access_token(self.token);
-        let client = Client::new().with_credentials(credentials);
+        let client = Client::build().with_credentials(credentials).finished()?;
         let project = client.get_project(repo)?;
 
         project

--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -18,11 +18,12 @@ pub struct Info {
 impl Info {
     /// Executes the command.
     pub fn exec(self) -> Result<(), Error> {
-        let mut client = Client::new();
-
-        if let Some(token) = self.token {
-            client.set_credentials(Credentials::new().with_access_token(token));
-        }
+        let client = match self.token {
+            Some(token) => Client::build()
+                .with_credentials(Credentials::new().with_access_token(token))
+                .finished()?,
+            None => Client::build().finished()?,
+        };
 
         let project = client.get_project(self.repo)?;
 

--- a/packages/ploys/src/client/builder.rs
+++ b/packages/ploys/src/client/builder.rs
@@ -1,0 +1,41 @@
+use std::sync::{Arc, RwLock};
+
+use reqwest::blocking::Client as HttpClient;
+
+use super::{Client, Credentials, Error};
+
+/// The project management client builder.
+#[derive(Clone, Debug, Default)]
+pub struct Builder {
+    credentials: Option<Credentials>,
+}
+
+impl Builder {
+    /// Constructs a new project management client builder.
+    pub fn new() -> Self {
+        Self { credentials: None }
+    }
+
+    /// Builds the client with the given authentication credentials.
+    pub fn with_credentials(mut self, credentials: impl Into<Credentials>) -> Self {
+        self.set_credentials(credentials);
+        self
+    }
+
+    /// Finishes building the client.
+    pub fn finished(self) -> Result<Client, Error> {
+        Ok(Client {
+            credentials: Arc::new(RwLock::new(self.credentials)),
+            http_client: HttpClient::builder()
+                .user_agent(concat!("ploys/", env!("CARGO_PKG_VERSION")))
+                .build()?,
+        })
+    }
+}
+
+impl Builder {
+    /// Sets the client authentication credentials.
+    pub fn set_credentials(&mut self, credentials: impl Into<Credentials>) {
+        self.credentials = Some(credentials.into());
+    }
+}

--- a/packages/ploys/src/client/mod.rs
+++ b/packages/ploys/src/client/mod.rs
@@ -1,40 +1,35 @@
+mod builder;
 mod credentials;
 mod error;
 
 use std::sync::{Arc, RwLock};
 
-use once_cell::sync::OnceCell;
 use reqwest::blocking::Client as HttpClient;
 
 use crate::project::{Error as ProjError, Project};
 use crate::repository::RepoAddr;
 use crate::repository::types::github::{Error as RepoError, GitHub};
 
+pub use self::builder::Builder;
 pub use self::credentials::{Credentials, Token, TokenError};
 pub use self::error::Error;
 
 /// The project management client.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Client {
     credentials: Arc<RwLock<Option<Credentials>>>,
-    http_client: Arc<OnceCell<HttpClient>>,
+    http_client: HttpClient,
 }
 
 impl Client {
     /// Constructs a new project management client.
-    pub fn new() -> Self {
-        Self {
-            credentials: Arc::new(RwLock::new(None)),
-            http_client: Arc::new(OnceCell::new()),
-        }
+    pub fn new(credentials: impl Into<Credentials>) -> Result<Self, Error> {
+        Self::build().with_credentials(credentials).finished()
     }
 
-    /// Builds the client with the given authentication credentials.
-    ///
-    /// See [`Self::set_credentials`] for more information.
-    pub fn with_credentials(mut self, credentials: impl Into<Credentials>) -> Self {
-        self.set_credentials(credentials);
-        self
+    /// Build a new project management client.
+    pub fn build() -> Builder {
+        Builder::new()
     }
 }
 
@@ -49,25 +44,12 @@ impl Client {
 
         Ok(proj)
     }
-
-    /// Sets the client authentication credentials.
-    ///
-    /// Note that this method overrides the credentials for this client instance
-    /// only. Prior clones will share the previous credentials unless those
-    /// instances are also updated.
-    pub fn set_credentials(&mut self, credentials: impl Into<Credentials>) {
-        self.credentials = Arc::new(RwLock::new(Some(credentials.into())));
-    }
 }
 
 impl Client {
     /// Gets the HTTP client.
-    pub(crate) fn http_client(&self) -> Result<&HttpClient, reqwest::Error> {
-        self.http_client.get_or_try_init(|| {
-            HttpClient::builder()
-                .user_agent(concat!("ploys/", env!("CARGO_PKG_VERSION")))
-                .build()
-        })
+    pub(crate) fn http_client(&self) -> &HttpClient {
+        &self.http_client
     }
 
     /// Gets the authentication credentials access token.

--- a/packages/ploys/src/repository/types/github/mod.rs
+++ b/packages/ploys/src/repository/types/github/mod.rs
@@ -19,7 +19,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 
 use crate::changelog::Release;
-use crate::client::Client;
+use crate::client::{Client, Error as ClientError};
 use crate::package::BumpOrVersion;
 use crate::repository::adapters::cached::Cached;
 use crate::repository::adapters::staged::Staged;
@@ -352,7 +352,11 @@ impl Open for GitHub {
         T: TryInto<Self::Context, Error = E>,
         E: Into<Self::Error>,
     {
-        Self::new(Client::new(), ctx)
+        match Client::build().finished() {
+            Ok(client) => Self::new(client, ctx),
+            Err(ClientError::Request(err)) => Err(Error::Request(err)),
+            Err(_) => unreachable!("client only uses `Request` error variant"),
+        }
     }
 }
 

--- a/packages/ploys/src/repository/types/github/repo.rs
+++ b/packages/ploys/src/repository/types/github/repo.rs
@@ -60,7 +60,7 @@ impl Repo {
     {
         let mut request = self
             .client
-            .http_client()?
+            .http_client()
             .request(method, self.endpoint(path));
 
         if let Some(token) = self.client.get_access_token() {
@@ -106,7 +106,7 @@ impl Repo {
     pub(super) fn graphql(&self) -> Result<RequestBuilder, Error> {
         let mut request = self
             .client
-            .http_client()?
+            .http_client()
             .post("https://api.github.com/graphql");
 
         if let Some(token) = self.client.get_access_token() {

--- a/packages/ploys/tests/github.rs
+++ b/packages/ploys/tests/github.rs
@@ -3,11 +3,12 @@ use ploys::client::{Client, Credentials, Error, Token};
 #[test]
 #[ignore]
 fn test_project() -> Result<(), Error> {
-    let mut client = Client::new();
-
-    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-        client.set_credentials(Credentials::new().with_access_token(Token::new(token).unwrap()));
-    }
+    let client = match std::env::var("GITHUB_TOKEN") {
+        Ok(token) => Client::build()
+            .with_credentials(Credentials::new().with_access_token(Token::new(token).unwrap()))
+            .finished()?,
+        Err(_) => Client::build().finished()?,
+    };
 
     let project = client.get_project("ploys/ploys")?;
 


### PR DESCRIPTION
This adds a new `Builder` type to construct a `Client`.

## Motivation

After further consideration, the changes made in #346 and #348 regarding client construction and credential configuration are not ideal and the introduction of a client builder would be more useful with the upcoming changes.

The change in #346 removed the error condition from client construction by moving the interior HTTP client to be lazily initialised. This added a negligible overhead for each and every request, but would surface the error when retrieving the first package.  However, there are potentially other error conditions that may arise once authentication flows in #245 are added so exposing a construction error may still be preferred.

The change in #348 updated the inner credentials storage to be shared across cloned client instances, but the implementation of `set_credentials` and `with_credentials` posed a question as to what would happen if the credentials were manually changed on one of the instances. The implementation simply replaced the credentials for that instance only, but what would happen once authentication flow support is added? Once the credentials expire and the authentication flow is used again then it would diverge and the instances would potentially conflict.

The answer to both of these issues would be to use a client builder, much like the HTTP client builder. This would allow the client to be constructed with credentials but not allow them to be manually altered and would therefore not cause the clones to diverge.

## Implementation

This change introduce a new client `Builder` type and moves the `set_credentials` and `with_credentials` methods to it so that a `Client` is effectively immutable. This will support generic authentication flows in the future without altering the type signature of the client.

This required a few changes in the `ploys-api` and `ploys-cli` packages and removed the implementation of `Default` for `Client` as construction is now fallible again. The HTTP client is now constructed when the builder is finished, removing the need to use `OnceCell` and effectively undoing the changes in #346.

The builder can be constructed by calling `Client::build` and the client can be constructed by calling `finished`. This name was chosen over `finish` or `build` to support the naming convention for methods that take ownership compared to those that borrow.