### PR TITLE
Fix missing `TokenType` enum export

### DIFF
--- a/packages/ploys/src/client/credentials/mod.rs
+++ b/packages/ploys/src/client/credentials/mod.rs
@@ -1,6 +1,6 @@
 mod token;
 
-pub use self::token::{Error as TokenError, Token};
+pub use self::token::{Error as TokenError, Token, TokenType};
 
 /// The client authentication credentials.
 #[derive(Clone, Debug, Default)]

--- a/packages/ploys/src/client/mod.rs
+++ b/packages/ploys/src/client/mod.rs
@@ -11,7 +11,7 @@ use crate::repository::RepoAddr;
 use crate::repository::types::github::{Error as RepoError, GitHub};
 
 pub use self::builder::Builder;
-pub use self::credentials::{Credentials, Token, TokenError};
+pub use self::credentials::{Credentials, Token, TokenError, TokenType};
 pub use self::error::Error;
 
 /// The project management client.


### PR DESCRIPTION
This exposes the `TokenType` enum to allow it to be matched by other crates.

## Motivation

The `TokenType` enum was introduced in #343 as part of the authentication token validation. This was used publicly in the `Token::token_type` method but was not used externally and _clippy_ did not pick up the issue of the type not being exported.

## Implementation

This simply "fixes" the issue by properly exporting the `TokenType` enum.