### PR TITLE
Add client authentication flow support

### DIFF
--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -6,7 +6,7 @@ pub mod secret;
 
 use axum::extract::State;
 use axum_extra::TypedHeader;
-use ploys::client::{Client, Credentials, Token};
+use ploys::client::{Client, Token};
 use ploys::package::BumpOrVersion;
 use semver::Version;
 use serde::Deserialize;
@@ -82,9 +82,7 @@ fn create_release_sync(
     release: String,
     payload: PullRequestPayload,
 ) -> Result<(), Error> {
-    let client = Client::build()
-        .with_credentials(Credentials::new().with_access_token(token))
-        .finished()?;
+    let client = Client::build().with_access_token_flow(token).finished()?;
     let project = client.get_project(&payload.repository.full_name)?;
 
     let package = project
@@ -138,9 +136,7 @@ async fn request_release(
 fn create_release_request(token: Token, payload: RepositoryDispatchPayload) -> Result<(), Error> {
     let ClientPayload { package, version } = serde_json::from_value(payload.client_payload)?;
 
-    let client = Client::build()
-        .with_credentials(Credentials::new().with_access_token(token))
-        .finished()?;
+    let client = Client::build().with_access_token_flow(token).finished()?;
     let project = client.get_project(&payload.repository.full_name)?;
     let package = project
         .get_package(&package)

--- a/packages/ploys-cli/src/package/changelog.rs
+++ b/packages/ploys-cli/src/package/changelog.rs
@@ -2,7 +2,7 @@ use std::convert::Infallible;
 
 use anyhow::{Context, Error, bail};
 use clap::Args;
-use ploys::client::{Client, Credentials, Token};
+use ploys::client::{Client, Token};
 use ploys::project::Project;
 use ploys::repository::RepoAddr;
 use semver::Version;
@@ -44,8 +44,9 @@ impl Changelog {
                 .context("Missing remote repository")?,
         };
 
-        let credentials = Credentials::new().with_access_token(self.token);
-        let client = Client::build().with_credentials(credentials).finished()?;
+        let client = Client::build()
+            .with_access_token_flow(self.token)
+            .finished()?;
         let project = client.get_project(repo)?;
         let package = project
             .get_package(&self.package)

--- a/packages/ploys-cli/src/package/release.rs
+++ b/packages/ploys-cli/src/package/release.rs
@@ -2,7 +2,7 @@ use std::convert::Infallible;
 
 use anyhow::{Context, Error};
 use clap::Args;
-use ploys::client::{Client, Credentials, Token};
+use ploys::client::{Client, Token};
 use ploys::package::BumpOrVersion;
 use ploys::project::Project;
 use ploys::repository::RepoAddr;
@@ -35,8 +35,9 @@ impl Release {
                 .context("Missing remote repository")?,
         };
 
-        let credentials = Credentials::new().with_access_token(self.token);
-        let client = Client::build().with_credentials(credentials).finished()?;
+        let client = Client::build()
+            .with_access_token_flow(self.token)
+            .finished()?;
         let project = client.get_project(repo)?;
 
         project

--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use clap::Args;
 use console::style;
-use ploys::client::{Client, Credentials, Token};
+use ploys::client::{Client, Token};
 use ploys::repository::RepoAddr;
 
 /// Gets the project information.
@@ -19,9 +19,7 @@ impl Info {
     /// Executes the command.
     pub fn exec(self) -> Result<(), Error> {
         let client = match self.token {
-            Some(token) => Client::build()
-                .with_credentials(Credentials::new().with_access_token(token))
-                .finished()?,
+            Some(token) => Client::build().with_access_token_flow(token).finished()?,
             None => Client::build().finished()?,
         };
 

--- a/packages/ploys/src/client/builder.rs
+++ b/packages/ploys/src/client/builder.rs
@@ -2,18 +2,47 @@ use std::sync::{Arc, RwLock};
 
 use reqwest::blocking::Client as HttpClient;
 
-use super::{Client, Credentials, Error};
+use super::flows::Authenticate;
+use super::flows::access_token::AccessTokenFlow;
+use super::{Client, Credentials, Error, Token};
 
 /// The project management client builder.
 #[derive(Clone, Debug, Default)]
-pub struct Builder {
+pub struct Builder<T = ()> {
+    auth_flow: T,
     credentials: Option<Credentials>,
 }
 
 impl Builder {
     /// Constructs a new project management client builder.
     pub fn new() -> Self {
-        Self { credentials: None }
+        Self {
+            auth_flow: (),
+            credentials: None,
+        }
+    }
+
+    /// Builds the client with the given authentication flow.
+    pub fn with_authentication_flow<T>(self, auth_flow: T) -> Builder<T>
+    where
+        T: Authenticate,
+    {
+        self.map_authentication_flow(|_| auth_flow)
+    }
+
+    /// Builds the client with the access token authentication flow.
+    ///
+    /// See [`AccessTokenFlow`] for more information about this authentication
+    /// flow.
+    pub fn with_access_token_flow(self, token: impl Into<Token>) -> Builder<AccessTokenFlow> {
+        self.with_authentication_flow(AccessTokenFlow::new(token))
+    }
+}
+
+impl<T> Builder<T> {
+    /// Sets the client authentication credentials.
+    pub fn set_credentials(&mut self, credentials: impl Into<Credentials>) {
+        self.credentials = Some(credentials.into());
     }
 
     /// Builds the client with the given authentication credentials.
@@ -22,20 +51,27 @@ impl Builder {
         self
     }
 
+    /// Maps the authentication flow.
+    pub fn map_authentication_flow<U>(self, f: impl FnOnce(T) -> U) -> Builder<U> {
+        Builder {
+            auth_flow: f(self.auth_flow),
+            credentials: self.credentials,
+        }
+    }
+}
+
+impl<T> Builder<T>
+where
+    T: Authenticate,
+{
     /// Finishes building the client.
     pub fn finished(self) -> Result<Client, Error> {
         Ok(Client {
+            auth_flow: Arc::new(self.auth_flow),
             credentials: Arc::new(RwLock::new(self.credentials)),
             http_client: HttpClient::builder()
                 .user_agent(concat!("ploys/", env!("CARGO_PKG_VERSION")))
                 .build()?,
         })
-    }
-}
-
-impl Builder {
-    /// Sets the client authentication credentials.
-    pub fn set_credentials(&mut self, credentials: impl Into<Credentials>) {
-        self.credentials = Some(credentials.into());
     }
 }

--- a/packages/ploys/src/client/credentials/mod.rs
+++ b/packages/ploys/src/client/credentials/mod.rs
@@ -3,32 +3,33 @@ mod token;
 pub use self::token::{Error as TokenError, Token, TokenType};
 
 /// The client authentication credentials.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Credentials {
-    access_token: Option<Token>,
+    access_token: Token,
 }
 
 impl Credentials {
     /// Constructs new client authentication credentials.
-    pub fn new() -> Self {
-        Self { access_token: None }
-    }
-
-    /// Builds the credentials with the given access token.
-    pub fn with_access_token(mut self, token: impl Into<Token>) -> Self {
-        self.set_access_token(token);
-        self
+    pub(crate) fn new(access_token: impl Into<Token>) -> Self {
+        Self {
+            access_token: access_token.into(),
+        }
     }
 }
 
 impl Credentials {
     /// Gets the access token.
-    pub fn get_access_token(&self) -> Option<Token> {
-        self.access_token.clone()
+    pub fn access_token(&self) -> &Token {
+        &self.access_token
     }
 
     /// Sets the access token.
     pub fn set_access_token(&mut self, token: impl Into<Token>) {
-        self.access_token = Some(token.into());
+        self.access_token = token.into();
+    }
+
+    /// Checks if the credentials have expired.
+    pub fn is_expired(&self) -> bool {
+        self.access_token.is_expired()
     }
 }

--- a/packages/ploys/src/client/credentials/token/mod.rs
+++ b/packages/ploys/src/client/credentials/token/mod.rs
@@ -173,7 +173,7 @@ impl TryFrom<&str> for Token {
 }
 
 /// The type of authentication token.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, strum::Display)]
 #[non_exhaustive]
 pub enum TokenType {
     /// A personal access token.

--- a/packages/ploys/src/client/error.rs
+++ b/packages/ploys/src/client/error.rs
@@ -7,6 +7,8 @@ pub enum Error {
     Request(reqwest::Error),
     /// A project error.
     Project(crate::project::Error<crate::repository::types::github::Error>),
+    /// An authentication error.
+    Auth(Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl Display for Error {
@@ -14,6 +16,7 @@ impl Display for Error {
         match self {
             Self::Request(err) => Display::fmt(err, f),
             Self::Project(err) => Display::fmt(err, f),
+            Self::Auth(err) => Display::fmt(err, f),
         }
     }
 }

--- a/packages/ploys/src/client/flows/access_token/error.rs
+++ b/packages/ploys/src/client/flows/access_token/error.rs
@@ -1,0 +1,20 @@
+use std::fmt::{self, Display};
+
+use crate::client::TokenType;
+
+/// The access token authentication flow error.
+#[derive(Debug)]
+pub enum Error {
+    /// An unsupported token type.
+    UnsupportedTokenType(TokenType),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedTokenType(ty) => write!(f, "Unsupported token type: {ty}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/packages/ploys/src/client/flows/access_token/mod.rs
+++ b/packages/ploys/src/client/flows/access_token/mod.rs
@@ -1,0 +1,46 @@
+mod error;
+
+use reqwest::blocking::Client as HttpClient;
+
+use crate::client::{Credentials, Token, TokenType};
+
+pub use self::error::Error;
+
+use super::Authenticate;
+
+/// The access token authentication flow.
+///
+/// This authentication flow uses the stored access token to obtain credentials
+/// for an authenticated user or app installation.
+#[derive(Clone, Debug)]
+pub struct AccessTokenFlow {
+    token: Token,
+}
+
+impl AccessTokenFlow {
+    /// Constructs a new access token authentication flow.
+    pub fn new(token: impl Into<Token>) -> Self {
+        Self {
+            token: token.into(),
+        }
+    }
+}
+
+impl Authenticate for AccessTokenFlow {
+    type Error = Error;
+
+    fn authenticate(
+        &self,
+        credentials: &mut Option<Credentials>,
+        _: &HttpClient,
+    ) -> Result<(), Self::Error> {
+        match self.token.token_type() {
+            TokenType::Personal | TokenType::OAuth | TokenType::User | TokenType::Installation => {
+                *credentials = Some(Credentials::new(self.token.clone()));
+
+                Ok(())
+            }
+            ty @ TokenType::Refresh => Err(Error::UnsupportedTokenType(ty)),
+        }
+    }
+}

--- a/packages/ploys/src/client/flows/mod.rs
+++ b/packages/ploys/src/client/flows/mod.rs
@@ -1,0 +1,50 @@
+pub mod access_token;
+
+use std::convert::Infallible;
+use std::error::Error;
+use std::fmt::Debug;
+
+use reqwest::blocking::Client as HttpClient;
+
+use super::Credentials;
+
+pub trait Authenticate: Debug + Send + Sync + 'static {
+    type Error: Error + Send + Sync + 'static;
+
+    fn authenticate(
+        &self,
+        credentials: &mut Option<Credentials>,
+        http_client: &HttpClient,
+    ) -> Result<(), Self::Error>;
+}
+
+impl Authenticate for () {
+    type Error = Infallible;
+
+    fn authenticate(&self, _: &mut Option<Credentials>, _: &HttpClient) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+pub(super) trait DynAuthenticate: Debug {
+    fn dyn_authenticate(
+        &self,
+        credentials: &mut Option<Credentials>,
+        http_client: &HttpClient,
+    ) -> Result<(), Box<dyn Error + Send + Sync>>;
+}
+
+impl<T> DynAuthenticate for T
+where
+    T: Authenticate,
+{
+    fn dyn_authenticate(
+        &self,
+        credentials: &mut Option<Credentials>,
+        http_client: &HttpClient,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.authenticate(credentials, http_client)
+            .map_err(Box::new)
+            .map_err(Into::into)
+    }
+}

--- a/packages/ploys/src/client/mod.rs
+++ b/packages/ploys/src/client/mod.rs
@@ -1,6 +1,7 @@
 mod builder;
 mod credentials;
 mod error;
+pub mod flows;
 
 use std::sync::{Arc, RwLock};
 
@@ -14,9 +15,12 @@ pub use self::builder::Builder;
 pub use self::credentials::{Credentials, Token, TokenError, TokenType};
 pub use self::error::Error;
 
+use self::flows::DynAuthenticate;
+
 /// The project management client.
 #[derive(Clone, Debug)]
 pub struct Client {
+    auth_flow: Arc<dyn DynAuthenticate>,
     credentials: Arc<RwLock<Option<Credentials>>>,
     http_client: HttpClient,
 }
@@ -53,15 +57,22 @@ impl Client {
     }
 
     /// Gets the authentication credentials access token.
-    pub(crate) fn get_access_token(&self) -> Option<Token> {
-        let credentials = self
+    pub(crate) fn authenticate(
+        &self,
+    ) -> Result<Option<Token>, Box<dyn std::error::Error + Send + Sync>> {
+        let mut credentials = self
             .credentials
-            .read()
+            .write()
             .unwrap_or_else(|err| err.into_inner());
 
+        if credentials.is_none() || credentials.as_ref().is_some_and(|c| c.is_expired()) {
+            self.auth_flow
+                .dyn_authenticate(&mut credentials, &self.http_client)?;
+        }
+
         match &*credentials {
-            Some(credentials) => credentials.get_access_token(),
-            None => None,
+            Some(credentials) => Ok(Some(credentials.access_token().clone())),
+            None => Ok(None),
         }
     }
 }

--- a/packages/ploys/src/repository/types/github/error.rs
+++ b/packages/ploys/src/repository/types/github/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     Io(io::Error),
     /// An address error.
     Addr(RepoAddrError),
+    /// An authentication error.
+    Auth(Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl Display for Error {
@@ -24,6 +26,7 @@ impl Display for Error {
             Self::Request(transport) => Display::fmt(transport, f),
             Self::Io(err) => Display::fmt(err, f),
             Self::Addr(err) => Display::fmt(err, f),
+            Self::Auth(err) => Display::fmt(err, f),
         }
     }
 }
@@ -35,6 +38,7 @@ impl std::error::Error for Error {
             Self::Request(err) => Some(err),
             Self::Io(err) => Some(err),
             Self::Addr(err) => Some(err),
+            Self::Auth(_) => None,
         }
     }
 }

--- a/packages/ploys/src/repository/types/github/repo.rs
+++ b/packages/ploys/src/repository/types/github/repo.rs
@@ -63,7 +63,7 @@ impl Repo {
             .http_client()
             .request(method, self.endpoint(path));
 
-        if let Some(token) = self.client.get_access_token() {
+        if let Some(token) = self.client.authenticate().map_err(Error::Auth)? {
             request = request.bearer_auth(token);
         }
 
@@ -109,7 +109,7 @@ impl Repo {
             .http_client()
             .post("https://api.github.com/graphql");
 
-        if let Some(token) = self.client.get_access_token() {
+        if let Some(token) = self.client.authenticate().map_err(Error::Auth)? {
             request = request.bearer_auth(token);
         }
 

--- a/packages/ploys/tests/github.rs
+++ b/packages/ploys/tests/github.rs
@@ -1,11 +1,11 @@
-use ploys::client::{Client, Credentials, Error, Token};
+use ploys::client::{Client, Error, Token};
 
 #[test]
 #[ignore]
 fn test_project() -> Result<(), Error> {
     let client = match std::env::var("GITHUB_TOKEN") {
         Ok(token) => Client::build()
-            .with_credentials(Credentials::new().with_access_token(Token::new(token).unwrap()))
+            .with_access_token_flow(Token::new(token).unwrap())
             .finished()?,
         Err(_) => Client::build().finished()?,
     };


### PR DESCRIPTION
This adds support for client authentication flows.

## Motivation

The current implementation of the `Client` type requires that custom `Credentials` be passed into the `Builder` during client construction. This is necessary to bypass rate limits and access private repositories but there is no built-in way to refresh the credentials or obtain new ones. It would be up to users to manage this externally and perform any client actions before token expiry.

Support for the device code flow in #245 would allow the CLI to authenticate without manually passing in the token or setting an environment variable. Using the native platform keychain would also allow credentials to persist across calls. All of this could be implemented in `ploys-cli` but the better option would be for the client to support different authentication flows that can be configured depending on the command. This could support refreshing tokens, re-authentication, and loading from the keychain.

## Implementation

This change introduces a new `Authenticate` trait and an internal `DynAuthenticate` trait so that the client can dynamically support any authentication method. They are currently restricted to require `Debug`, `Send`, `Sync` and `'static`, but this may potentially be relaxed in the future. These are used by the client when performing an API request with missing or expired credentials.

The `Credentials` type has been updated to require an access token and the `new` constructor is now private to prevent invalid credentials from being constructed as new fields are added in the future. Places where the credentials were constructed and passed in have been substituted with a new authentication flow.

The `AccessTokenFlow` authentication flow now exists to authenticate with a single token. This handles situations where a refresh token is incorrectly passed in and simply sets the credentials to use the token as-is otherwise. Although this is not strictly an OAuth flow, it makes sense as an authentication flow as it will allow the credentials to be verified and additional information such as the login name to be requested in the future.

The default unit `()` authentication flow is simply a no-op and allows unauthenticated access.


