### PR TITLE
Add client credentials user field

### DIFF
--- a/packages/ploys/src/client/credentials/mod.rs
+++ b/packages/ploys/src/client/credentials/mod.rs
@@ -5,19 +5,29 @@ pub use self::token::{Error as TokenError, Token, TokenType};
 /// The client authentication credentials.
 #[derive(Clone, Debug)]
 pub struct Credentials {
+    user: String,
     access_token: Token,
 }
 
 impl Credentials {
     /// Constructs new client authentication credentials.
-    pub(crate) fn new(access_token: impl Into<Token>) -> Self {
+    pub(crate) fn new(user: impl Into<String>, access_token: impl Into<Token>) -> Self {
         Self {
+            user: user.into(),
             access_token: access_token.into(),
         }
     }
 }
 
 impl Credentials {
+    /// Gets the user login name.
+    ///
+    /// Note that for an app installation this would contain the `[bot]` suffix
+    /// to differentiate between users and apps.
+    pub fn user(&self) -> &str {
+        &self.user
+    }
+
     /// Gets the access token.
     pub fn access_token(&self) -> &Token {
         &self.access_token

--- a/packages/ploys/src/client/flows/access_token/error.rs
+++ b/packages/ploys/src/client/flows/access_token/error.rs
@@ -7,14 +7,23 @@ use crate::client::TokenType;
 pub enum Error {
     /// An unsupported token type.
     UnsupportedTokenType(TokenType),
+    /// A request error.
+    Request(reqwest::Error),
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::UnsupportedTokenType(ty) => write!(f, "Unsupported token type: {ty}"),
+            Self::Request(err) => Display::fmt(err, f),
         }
     }
 }
 
 impl std::error::Error for Error {}
+
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
+        Self::Request(err)
+    }
+}

--- a/packages/ploys/src/client/flows/access_token/mod.rs
+++ b/packages/ploys/src/client/flows/access_token/mod.rs
@@ -1,6 +1,7 @@
 mod error;
 
 use reqwest::blocking::Client as HttpClient;
+use serde::{Deserialize, Serialize};
 
 use crate::client::{Credentials, Token, TokenType};
 
@@ -32,15 +33,68 @@ impl Authenticate for AccessTokenFlow {
     fn authenticate(
         &self,
         credentials: &mut Option<Credentials>,
-        _: &HttpClient,
+        http_client: &HttpClient,
     ) -> Result<(), Self::Error> {
         match self.token.token_type() {
-            TokenType::Personal | TokenType::OAuth | TokenType::User | TokenType::Installation => {
-                *credentials = Some(Credentials::new(self.token.clone()));
+            TokenType::Personal | TokenType::OAuth | TokenType::User => {
+                let user = http_client
+                    .get("https://api.github.com/user")
+                    .header("Accept", "application/vnd.github+json")
+                    .header("X-GitHub-Api-Version", "2026-03-10")
+                    .bearer_auth(self.token.value())
+                    .send()?
+                    .error_for_status()?
+                    .json::<UserResponse>()?
+                    .login;
+
+                *credentials = Some(Credentials::new(user, self.token.clone()));
+
+                Ok(())
+            }
+            TokenType::Installation => {
+                let user = http_client
+                    .post("https://api.github.com/graphql")
+                    .bearer_auth(self.token.value())
+                    .json(&GraphQLPayload {
+                        query: "query { viewer { login } }",
+                    })
+                    .send()?
+                    .error_for_status()?
+                    .json::<InstallationResponse>()?
+                    .data
+                    .viewer
+                    .login;
+
+                *credentials = Some(Credentials::new(user, self.token.clone()));
 
                 Ok(())
             }
             ty @ TokenType::Refresh => Err(Error::UnsupportedTokenType(ty)),
         }
     }
+}
+
+#[derive(Deserialize)]
+struct UserResponse {
+    login: String,
+}
+
+#[derive(Serialize)]
+struct GraphQLPayload {
+    query: &'static str,
+}
+
+#[derive(Deserialize)]
+struct InstallationResponse {
+    data: InstallationResponseData,
+}
+
+#[derive(Deserialize)]
+struct InstallationResponseData {
+    viewer: InstallationResponseViewer,
+}
+
+#[derive(Deserialize)]
+struct InstallationResponseViewer {
+    login: String,
 }


### PR DESCRIPTION
This updates the client `Credentials` type to store a user field.

## Motivation

The ability to store credentials in a keychain was discussed in #245 as a way to persist the authentication retrieved via the device code flow. This authentication flow has not yet been implemented but the credentials are now in a position to be updated to support this.

Looking at the `keyring-core` crate, the [`Entry`](https://docs.rs/keyring-core/1.0.0/keyring_core/struct.Entry.html) type requires both a service (`ploys`) and a user (the _GitHub_ login). In order to support this, the credentials should therefore store the user/login so that they can be easily persisted.

## Implementation

This change updates the `Credentials` type to store a new `user` field that maps to the `login` field from the GitHub API.

This also updates the `AccessTokenFlow` authentication flow to request this field from the API. Internally this uses the `/user` endpoint for user access tokens and the GraphQL API for installation access tokens, although the latter could presumably be used for all types.

This change has been manually tested with both user and installation access tokens as it isn't simple to automate this testing. The CI would use the GitHub Actions token which is an installation access token. In the future it may be possible to introduce a restricted personal access token but that would not cover OAuth and app user tokens.

The downside to this change is that manually passing an access token will require an extra API request in order to retrieve the user which may not always be required. However, this acts as an upfront authentication check so it is somewhat beneficial over trying another endpoint that may fail for another reason before it can be determined whether the token has expired. When the device code flow is implemented and keychains are supported then this can be bypassed by loading the stored user.

