### PR TITLE
Add client credentials server address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3790,6 +3790,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -30,7 +30,7 @@ strum = { version = "0.26.3", features = ["derive"] }
 time = { version = "0.3.36", features = ["serde", "formatting", "parsing"] }
 toml_edit = { version = "0.22.14", features = ["serde"] }
 tracing = "0.1.41"
-url = "2.4.0"
+url = { version = "2.4.0", features = ["serde"] }
 walkdir = { version = "2.5.0", optional = true }
 
 [dependencies.reqwest]

--- a/packages/ploys/src/client/credentials/mod.rs
+++ b/packages/ploys/src/client/credentials/mod.rs
@@ -1,18 +1,26 @@
+mod server;
 mod token;
 
+pub use self::server::ServAddr;
 pub use self::token::{Error as TokenError, Token, TokenType};
 
 /// The client authentication credentials.
 #[derive(Clone, Debug)]
 pub struct Credentials {
+    server: ServAddr,
     user: String,
     access_token: Token,
 }
 
 impl Credentials {
     /// Constructs new client authentication credentials.
-    pub(crate) fn new(user: impl Into<String>, access_token: impl Into<Token>) -> Self {
+    pub(crate) fn new(
+        server: impl Into<ServAddr>,
+        user: impl Into<String>,
+        access_token: impl Into<Token>,
+    ) -> Self {
         Self {
+            server: server.into(),
             user: user.into(),
             access_token: access_token.into(),
         }
@@ -20,6 +28,11 @@ impl Credentials {
 }
 
 impl Credentials {
+    /// Gets the server address.
+    pub fn server(&self) -> &ServAddr {
+        &self.server
+    }
+
     /// Gets the user login name.
     ///
     /// Note that for an app installation this would contain the `[bot]` suffix

--- a/packages/ploys/src/client/credentials/server.rs
+++ b/packages/ploys/src/client/credentials/server.rs
@@ -1,0 +1,30 @@
+use std::fmt::{self, Display};
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use url::{Host, ParseError};
+
+/// The server address.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ServAddr(Host);
+
+impl Display for ServAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Default for ServAddr {
+    fn default() -> Self {
+        Self(Host::Domain(String::from("api.ploys.dev")))
+    }
+}
+
+impl FromStr for ServAddr {
+    type Err = ParseError;
+
+    fn from_str(host: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Host::parse(host)?))
+    }
+}

--- a/packages/ploys/src/client/flows/access_token/mod.rs
+++ b/packages/ploys/src/client/flows/access_token/mod.rs
@@ -3,6 +3,7 @@ mod error;
 use reqwest::blocking::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 
+use crate::client::credentials::ServAddr;
 use crate::client::{Credentials, Token, TokenType};
 
 pub use self::error::Error;
@@ -47,7 +48,11 @@ impl Authenticate for AccessTokenFlow {
                     .json::<UserResponse>()?
                     .login;
 
-                *credentials = Some(Credentials::new(user, self.token.clone()));
+                *credentials = Some(Credentials::new(
+                    ServAddr::default(),
+                    user,
+                    self.token.clone(),
+                ));
 
                 Ok(())
             }
@@ -65,7 +70,11 @@ impl Authenticate for AccessTokenFlow {
                     .viewer
                     .login;
 
-                *credentials = Some(Credentials::new(user, self.token.clone()));
+                *credentials = Some(Credentials::new(
+                    ServAddr::default(),
+                    user,
+                    self.token.clone(),
+                ));
 
                 Ok(())
             }

--- a/packages/ploys/src/client/mod.rs
+++ b/packages/ploys/src/client/mod.rs
@@ -12,7 +12,7 @@ use crate::repository::RepoAddr;
 use crate::repository::types::github::{Error as RepoError, GitHub};
 
 pub use self::builder::Builder;
-pub use self::credentials::{Credentials, Token, TokenError, TokenType};
+pub use self::credentials::{Credentials, ServAddr, Token, TokenError, TokenType};
 pub use self::error::Error;
 
 use self::flows::DynAuthenticate;


### PR DESCRIPTION
This adds a new `ServAddr` type and server field to the `Credentials` type.

## Motivation

In order to support the device code authentication flow in #245 there needs to be a way to obtain the GitHub App's client identifier. This was exposed via the API in #334 so the user can provide the server address instead of the identifier. However,  this should be tied to the credentials so that it can be used later.

## Implementation

This change introduces a new `ServAddr` type that wraps a `url::Host` and exposes it as part of the `Credentials` structure under the `server` field.

## Concerns

The concern with this approach is that the server address is currently only relevant to the user token generated by the upcoming device code flow. The server endpoint is currently unused for any other access tokens and there is no way to authenticate with the server regardless of token type so it is unlikely to be useful.