### PR TITLE
Add device code authentication flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2566,6 +2566,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_with",
  "strum",
  "tempfile",
  "time",

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -26,6 +26,7 @@ once_map = "0.4.22"
 relative-path = { version = "2.0.1", features = ["serde"] }
 semver = "1.0.19"
 serde = { version = "1.0.185", features = ["derive"] }
+serde_with = "3.17.0"
 strum = { version = "0.26.3", features = ["derive"] }
 time = { version = "0.3.36", features = ["serde", "formatting", "parsing"] }
 toml_edit = { version = "0.22.14", features = ["serde"] }

--- a/packages/ploys/src/client/builder.rs
+++ b/packages/ploys/src/client/builder.rs
@@ -4,7 +4,8 @@ use reqwest::blocking::Client as HttpClient;
 
 use super::flows::Authenticate;
 use super::flows::access_token::AccessTokenFlow;
-use super::{Client, Credentials, Error, Token};
+use super::flows::device_code::DeviceCodeFlow;
+use super::{Client, Credentials, Error, ServAddr, Token};
 
 /// The project management client builder.
 #[derive(Clone, Debug, Default)]
@@ -36,6 +37,14 @@ impl Builder {
     /// flow.
     pub fn with_access_token_flow(self, token: impl Into<Token>) -> Builder<AccessTokenFlow> {
         self.with_authentication_flow(AccessTokenFlow::new(token))
+    }
+
+    /// Builds the client with the device code authentication flow.
+    ///
+    /// See [`DeviceCodeFlow`] for more information about this authentication
+    /// flow.
+    pub fn with_device_code_flow(self, server: impl Into<ServAddr>) -> Builder<DeviceCodeFlow> {
+        self.with_authentication_flow(DeviceCodeFlow::new(server))
     }
 }
 

--- a/packages/ploys/src/client/flows/device_code/error.rs
+++ b/packages/ploys/src/client/flows/device_code/error.rs
@@ -1,0 +1,30 @@
+use std::fmt::{self, Display};
+
+/// The device code authentication flow error.
+#[derive(Debug)]
+pub enum Error {
+    /// A timeout error.
+    Timeout,
+    /// A request error.
+    Request(reqwest::Error),
+    /// Any other error when polling for the token.
+    Other(String),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Timeout => write!(f, "Timed out waiting for user input"),
+            Self::Request(err) => Display::fmt(err, f),
+            Self::Other(err) => Display::fmt(err, f),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
+        Self::Request(err)
+    }
+}

--- a/packages/ploys/src/client/flows/device_code/mod.rs
+++ b/packages/ploys/src/client/flows/device_code/mod.rs
@@ -1,0 +1,161 @@
+mod error;
+
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use reqwest::blocking::Client as HttpClient;
+use serde::Deserialize;
+use serde_with::{DisplayFromStr, serde_as};
+use time::OffsetDateTime;
+use url::Url;
+
+use crate::client::{Credentials, ServAddr, Token};
+
+pub use self::error::Error;
+
+use super::Authenticate;
+
+/// The device code authentication flow.
+#[derive(Clone, Debug)]
+pub struct DeviceCodeFlow {
+    server: ServAddr,
+}
+
+impl DeviceCodeFlow {
+    /// Constructs a new device code authentication flow.
+    pub fn new(server: impl Into<ServAddr>) -> Self {
+        Self {
+            server: server.into(),
+        }
+    }
+}
+
+impl Authenticate for DeviceCodeFlow {
+    type Error = Error;
+
+    fn authenticate(
+        &self,
+        credentials: &mut Option<Credentials>,
+        http_client: &HttpClient,
+    ) -> Result<(), Self::Error> {
+        let client_id = http_client
+            .get(format!("https://{}/github", self.server))
+            .send()?
+            .error_for_status()?
+            .json::<AppInfo>()?
+            .client_id;
+
+        let code_response: CodeResponse = http_client
+            .post("https://github.com/login/device/code")
+            .header("Accept", "application/json")
+            .form(&[("client_id", client_id.as_str())])
+            .send()?
+            .error_for_status()?
+            .json()?;
+
+        println!(
+            "Enter code `{}` at `{}`.",
+            code_response.user_code, code_response.verification_uri
+        );
+
+        let start = Instant::now();
+        let expires_in = Duration::from_secs(code_response.expires_in);
+        let mut interval = Duration::from_secs(code_response.interval);
+
+        loop {
+            if start.elapsed() >= expires_in {
+                return Err(Error::Timeout);
+            }
+
+            let token_response: TokenResponse = http_client
+                .post("https://github.com/login/oauth/access_token")
+                .header("Accept", "application/json")
+                .form(&[
+                    ("client_id", client_id.as_str()),
+                    ("device_code", &code_response.device_code),
+                    ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+                ])
+                .send()?
+                .error_for_status()?
+                .json()?;
+
+            match token_response {
+                TokenResponse::Error(error) => match error.error.as_str() {
+                    "authorization_pending" => {
+                        sleep(interval);
+                    }
+                    "slow_down" => {
+                        interval += Duration::from_secs(5);
+
+                        sleep(interval);
+                    }
+                    "expired_token" => return Err(Error::Timeout),
+                    s => return Err(Error::Other(s.to_string())),
+                },
+                TokenResponse::Success(success) => {
+                    let now = OffsetDateTime::now_utc();
+                    let mut token = success.access_token;
+
+                    if let Some(expires_in) = success.expires_in {
+                        token.set_expiry(now + time::Duration::seconds(expires_in));
+                    }
+
+                    let user = http_client
+                        .get("https://api.github.com/user")
+                        .header("Accept", "application/vnd.github+json")
+                        .header("X-GitHub-Api-Version", "2026-03-10")
+                        .bearer_auth(token.value())
+                        .send()?
+                        .error_for_status()?
+                        .json::<UserResponse>()?
+                        .login;
+
+                    *credentials = Some(Credentials::new(self.server.clone(), user, token));
+
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+struct AppInfo {
+    client_id: String,
+}
+
+#[derive(Deserialize)]
+struct CodeResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: Url,
+    expires_in: u64,
+    interval: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum TokenResponse {
+    Error(ErrorTokenResponse),
+    Success(SuccessTokenResponse),
+}
+
+#[derive(Deserialize)]
+struct ErrorTokenResponse {
+    error: String,
+}
+
+#[serde_as]
+#[derive(Deserialize)]
+struct SuccessTokenResponse {
+    #[serde_as(as = "DisplayFromStr")]
+    access_token: Token,
+    expires_in: Option<i64>,
+}
+
+#[derive(Deserialize)]
+struct UserResponse {
+    login: String,
+}

--- a/packages/ploys/src/client/flows/mod.rs
+++ b/packages/ploys/src/client/flows/mod.rs
@@ -1,4 +1,5 @@
 pub mod access_token;
+pub mod device_code;
 
 use std::convert::Infallible;
 use std::error::Error;


### PR DESCRIPTION
This adds a new device code authentication flow.

## Motivation

The device code authentication flow described in #245 would allow users to authenticate with GitHub so that PRs and commits can be attributed to both the user and the application. This seemed to be a better option than using a separate OAuth App but required some overhead of specifying the server address.

## Implementation

This change introduces a new `DeviceCodeFlow` authentication flow that takes a `ServAddr` from #353, uses it to obtain the GitHub App's client identifier, and waits for the user to input the device code at the specified URL.

This also updates the `Builder` type with a new `with_device_code_flow` method to simplify construction of this flow.

The flow has been manually tested as there is no way to automate testing without mocking the authentication flow.