### PR TITLE
Add client identifier caching to device code flow

### DIFF
--- a/packages/ploys/src/client/flows/device_code/mod.rs
+++ b/packages/ploys/src/client/flows/device_code/mod.rs
@@ -1,8 +1,10 @@
 mod error;
 
+use std::sync::Arc;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
+use once_cell::sync::OnceCell;
 use reqwest::blocking::Client as HttpClient;
 use serde::Deserialize;
 use serde_with::{DisplayFromStr, serde_as};
@@ -16,15 +18,20 @@ pub use self::error::Error;
 use super::Authenticate;
 
 /// The device code authentication flow.
+///
+/// Note that authentication will cache the GitHub App's client identifier from
+/// the server address endpoint to avoid repeated requests.
 #[derive(Clone, Debug, Default)]
 pub struct DeviceCodeFlow {
-    _private: (),
+    client_id: OnceCell<Arc<str>>,
 }
 
 impl DeviceCodeFlow {
     /// Constructs a new device code authentication flow.
     pub fn new() -> Self {
-        Self { _private: () }
+        Self {
+            client_id: OnceCell::new(),
+        }
     }
 }
 
@@ -37,17 +44,22 @@ impl Authenticate for DeviceCodeFlow {
         http_client: &HttpClient,
         server: &ServAddr,
     ) -> Result<(), Self::Error> {
-        let client_id = http_client
-            .get(format!("https://{server}/github"))
-            .send()?
-            .error_for_status()?
-            .json::<AppInfo>()?
-            .client_id;
+        let client_id = self.client_id.get_or_try_init(|| {
+            Ok::<_, Error>(
+                http_client
+                    .get(format!("https://{server}/github"))
+                    .send()?
+                    .error_for_status()?
+                    .json::<AppInfo>()?
+                    .client_id
+                    .into(),
+            )
+        })?;
 
         let code_response: CodeResponse = http_client
             .post("https://github.com/login/device/code")
             .header("Accept", "application/json")
-            .form(&[("client_id", client_id.as_str())])
+            .form(&[("client_id", &**client_id)])
             .send()?
             .error_for_status()?
             .json()?;
@@ -70,7 +82,7 @@ impl Authenticate for DeviceCodeFlow {
                 .post("https://github.com/login/oauth/access_token")
                 .header("Accept", "application/json")
                 .form(&[
-                    ("client_id", client_id.as_str()),
+                    ("client_id", &**client_id),
                     ("device_code", &code_response.device_code),
                     ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
                 ])


### PR DESCRIPTION
This adds caching for the client identifier in the device code authentication flow.

## Motivation

The device code authentication flow was introduced in #354 and initially required a server address. As part of moving the server address to the client in #355 the `DeviceCodeFlow` struct no longer contained any data. Instead, a private zero-sized field was added to ensure that it could only be constructed via the `new` constructor. The point of this was that additional fields may be added later to further configure the authentication flow.

The authentication flow requests the client identifier from the server endpoint as it cannot be hardcoded into the library and/or executable. If the flow is called again then it will make a new request but this may be redundant.

With the above in mind, caching the client identifier would prevent additional requests and store private data within the struct.

## Implementation

This change uses stores a `OnceCell<Arc<str>>` inside the `DeviceCodeFlow` and uses the `get_or_try_init` method to handle the caching in a fallible way. This was used over the standard `OnceLock` because the equivalent fallible API is not yet stable.

## Concerns

The caching is largely irrelevant and potentially adds extra overhead because the flow is unlikely to be called again. This is because usage will primarily be via the CLI for this authentication method which will not persist the data between command calls.

It also affects how calling the `authenticate` method would function outside of a client. Inside a client the authentication flow is immutable so it makes sense to cache it. However, outside of a client there may be a need to call it for multiple different server addresses. The caching option seems to be the best as this is currently unlikely to ever be used in that way.