### PR TITLE
Add keyring authentication flow adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,6 +2267,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "kstring"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,11 +2561,13 @@ version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "dialoguer",
  "either",
  "gix",
  "globset",
  "indoc",
  "itertools 0.14.0",
+ "keyring-core",
  "markdown",
  "once_cell",
  "once_map",

--- a/packages/ploys/Cargo.toml
+++ b/packages/ploys/Cargo.toml
@@ -16,16 +16,19 @@ git = ["dep:gix"]
 [dependencies]
 base64 = "0.22.1"
 bytes = "1.10.1"
+dialoguer = "0.11.0"
 either = "1.13.0"
 gix = { version = "0.73.0", features = ["tree-editor"], optional = true }
 globset = "0.4.13"
 itertools = "0.14.0"
+keyring-core = "1.0.0"
 markdown = "1.0.0"
 once_cell = "1.20.2"
 once_map = "0.4.22"
 relative-path = { version = "2.0.1", features = ["serde"] }
 semver = "1.0.19"
 serde = { version = "1.0.185", features = ["derive"] }
+serde_json = "1.0.149"
 serde_with = "3.17.0"
 strum = { version = "0.26.3", features = ["derive"] }
 time = { version = "0.3.36", features = ["serde", "formatting", "parsing"] }

--- a/packages/ploys/src/client/builder.rs
+++ b/packages/ploys/src/client/builder.rs
@@ -1,10 +1,12 @@
 use std::sync::{Arc, RwLock};
 
+use keyring_core::CredentialStore;
 use reqwest::blocking::Client as HttpClient;
 
 use super::flows::Authenticate;
 use super::flows::access_token::AccessTokenFlow;
 use super::flows::device_code::DeviceCodeFlow;
+use super::flows::keyring::KeyringFlow;
 use super::{Client, Credentials, Error, ServAddr, Token};
 
 /// The project management client builder.
@@ -47,6 +49,24 @@ impl Builder {
     /// flow.
     pub fn with_device_code_flow(self) -> Builder<DeviceCodeFlow> {
         self.with_authentication_flow(DeviceCodeFlow::new())
+    }
+}
+
+impl<T> Builder<T> {
+    /// Builds the client with the given keyring credential store.
+    ///
+    /// See [`KeyringFlow`] for more information about this authentication
+    /// flow adapter.
+    pub fn with_keyring_store(self, store: Arc<CredentialStore>) -> Builder<KeyringFlow<T>> {
+        self.map_authentication_flow(|auth_flow| KeyringFlow::new(auth_flow).with_store(store))
+    }
+
+    /// Builds the client with the default keyring credential store.
+    ///
+    /// See [`KeyringFlow`] for more information about this authentication
+    /// flow adapter.
+    pub fn with_keyring_store_default(self) -> Builder<KeyringFlow<T>> {
+        self.map_authentication_flow(|auth_flow| KeyringFlow::new(auth_flow))
     }
 }
 

--- a/packages/ploys/src/client/credentials/mod.rs
+++ b/packages/ploys/src/client/credentials/mod.rs
@@ -1,9 +1,11 @@
 mod token;
 
+use serde::{Deserialize, Serialize};
+
 pub use self::token::{Error as TokenError, Token, TokenType};
 
 /// The client authentication credentials.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Credentials {
     user: String,
     access_token: Token,

--- a/packages/ploys/src/client/flows/keyring/error.rs
+++ b/packages/ploys/src/client/flows/keyring/error.rs
@@ -1,0 +1,48 @@
+use std::fmt::{self, Display};
+
+/// The keyring authentication flow adapter error.
+#[derive(Debug)]
+pub enum Error<T> {
+    /// A keyring error.
+    Keyring(keyring_core::Error),
+    /// A prompt error.
+    Prompt(dialoguer::Error),
+    /// A JSON de/serialization error.
+    Json(serde_json::Error),
+    /// An error with the adapted authentication flow.
+    Inner(T),
+}
+
+impl<T> Display for Error<T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Keyring(err) => Display::fmt(err, f),
+            Self::Prompt(err) => Display::fmt(err, f),
+            Self::Json(err) => Display::fmt(err, f),
+            Self::Inner(err) => Display::fmt(err, f),
+        }
+    }
+}
+
+impl<T> std::error::Error for Error<T> where T: std::error::Error {}
+
+impl<T> From<keyring_core::Error> for Error<T> {
+    fn from(err: keyring_core::Error) -> Self {
+        Self::Keyring(err)
+    }
+}
+
+impl<T> From<dialoguer::Error> for Error<T> {
+    fn from(err: dialoguer::Error) -> Self {
+        Self::Prompt(err)
+    }
+}
+
+impl<T> From<serde_json::Error> for Error<T> {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Json(err)
+    }
+}

--- a/packages/ploys/src/client/flows/keyring/mod.rs
+++ b/packages/ploys/src/client/flows/keyring/mod.rs
@@ -1,0 +1,161 @@
+mod error;
+
+use std::collections::HashMap;
+use std::io::IsTerminal;
+use std::sync::Arc;
+
+use dialoguer::Select;
+use keyring_core::CredentialStore;
+use reqwest::blocking::Client as HttpClient;
+
+use crate::client::{Credentials, ServAddr};
+
+pub use self::error::Error;
+
+use super::Authenticate;
+
+/// The keyring authentication flow adapter.
+///
+/// Note that this defaults to using the default shared credential store if it
+/// exists. Otherwise, this can be overridden by calling [`Self::with_store`]
+/// or [`Self::set_store`] when building the authentication flow adapter.
+#[derive(Clone, Debug, Default)]
+pub struct KeyringFlow<T> {
+    store: Option<Arc<CredentialStore>>,
+    auth_flow: T,
+}
+
+impl<T> KeyringFlow<T> {
+    /// Constructs a new keyring authentication flow adapter.
+    pub fn new(auth_flow: T) -> Self {
+        Self {
+            store: None,
+            auth_flow,
+        }
+    }
+}
+
+impl<T> KeyringFlow<T> {
+    /// Sets the credential store.
+    pub fn set_store(&mut self, store: Arc<CredentialStore>) {
+        self.store = Some(store);
+    }
+
+    /// Builds the flow with the given credential store.
+    pub fn with_store(mut self, store: Arc<CredentialStore>) -> Self {
+        self.set_store(store);
+        self
+    }
+}
+
+impl<T> KeyringFlow<T>
+where
+    T: Authenticate,
+{
+    /// Gets the configured store or the default store.
+    fn get_store(&self) -> Result<Arc<CredentialStore>, Error<T::Error>> {
+        self.store
+            .as_ref()
+            .cloned()
+            .or_else(keyring_core::get_default_store)
+            .ok_or_else(|| keyring_core::Error::NoDefaultStore)
+            .map_err(Error::Keyring)
+    }
+}
+
+impl<T> Authenticate for KeyringFlow<T>
+where
+    T: Authenticate,
+{
+    type Error = Error<T::Error>;
+
+    fn authenticate(
+        &self,
+        credentials: &mut Option<Credentials>,
+        http_client: &HttpClient,
+        server: &ServAddr,
+    ) -> Result<(), Self::Error> {
+        let store = self.get_store()?;
+        let service = format!("ploys:{server}");
+        let entry = match credentials {
+            Some(credentials) => Some(store.build(&service, credentials.user(), None)?),
+            None => {
+                let mut options = store.search(&{
+                    let mut map = HashMap::new();
+
+                    map.insert("service", &*service);
+                    map
+                })?;
+
+                if options.len() > 1 && std::io::stdin().is_terminal() {
+                    let mut select = Select::new().with_prompt("User");
+
+                    for option in &options {
+                        if let Some((svc, user)) = option.get_specifiers() {
+                            select = select.item(format!("{user} ({svc})"));
+                        } else {
+                            select = select.item(String::from("unknown (unknown)"));
+                        }
+                    }
+
+                    match select.interact_opt()? {
+                        Some(option) => options.into_iter().nth(option),
+                        None => None,
+                    }
+                } else {
+                    options.pop()
+                }
+            }
+        };
+
+        let entry = match entry {
+            Some(entry) => match entry.get_credential() {
+                Ok(entry) => Some(entry),
+                Err(keyring_core::Error::NoEntry) => None,
+                Err(err) => return Err(err.into()),
+            },
+            None => None,
+        };
+
+        match entry {
+            Some(entry) => {
+                let secret = entry.get_secret()?;
+                let creds = serde_json::from_slice::<Credentials>(&secret)?;
+
+                if creds.is_expired() {
+                    *credentials = Some(creds);
+
+                    self.auth_flow
+                        .authenticate(credentials, http_client, server)
+                        .map_err(Error::Inner)?;
+
+                    if let Some(credentials) = credentials {
+                        let secret = serde_json::to_vec(&credentials)?;
+
+                        entry.set_secret(&secret)?;
+                    } else {
+                        entry.delete_credential()?;
+                    }
+                } else {
+                    *credentials = Some(creds);
+                }
+
+                Ok(())
+            }
+            None => {
+                self.auth_flow
+                    .authenticate(credentials, http_client, server)
+                    .map_err(Error::Inner)?;
+
+                if let Some(credentials) = credentials {
+                    let entry = store.build(&service, credentials.user(), None)?;
+                    let secret = serde_json::to_vec(&credentials)?;
+
+                    entry.set_secret(&secret)?;
+                }
+
+                Ok(())
+            }
+        }
+    }
+}

--- a/packages/ploys/src/client/flows/mod.rs
+++ b/packages/ploys/src/client/flows/mod.rs
@@ -1,5 +1,6 @@
 pub mod access_token;
 pub mod device_code;
+pub mod keyring;
 
 use std::convert::Infallible;
 use std::error::Error;


### PR DESCRIPTION
This adds a new authentication flow adapter that uses a credential store from the `keyring-core` crate.

## Motivation

The CLI currently supports passing an authentication token to various commands to bypass rate limits and perform tasks that require authentication, such as creating a release request. However, requiring users to manually manage this token externally is problematic and #245 was opened to support the device code authentication flow.

The device code flow itself has been merged in #354, but using this would still require submitting the device code every time a command is called. Therefore, storing the token in the local keychain would solve the issue while keeping the credentials secure.

## Implementation

This change introduces a new `KeyringFlow` authentication flow adapter that uses the `keyring-core` crate to support reading and writing to a given credential store.

The logic for this flow is as follows:

1. The credential store is checked for a credential that matches:
  a. The existing credential in case it has expired.
  b. The service if there is no matching credential.
2. If multiple matching credentials are found:
  a. If the terminal is interactive then the user is prompted to select one.
  b. If the terminal is not interactive then the first option is selected.
3. If there was no match or if the credentials have expired then the adapted authentication flow is called.
4. The credential store is updated with the new credentials.