### PR TITLE
Add refresh token support

### DIFF
--- a/packages/ploys/src/client/credentials/mod.rs
+++ b/packages/ploys/src/client/credentials/mod.rs
@@ -1,6 +1,7 @@
 mod token;
 
 use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 
 pub use self::token::{Error as TokenError, Token, TokenType};
 
@@ -9,6 +10,7 @@ pub use self::token::{Error as TokenError, Token, TokenType};
 pub struct Credentials {
     user: String,
     access_token: Token,
+    refresh_token: Option<Token>,
 }
 
 impl Credentials {
@@ -17,6 +19,7 @@ impl Credentials {
         Self {
             user: user.into(),
             access_token: access_token.into(),
+            refresh_token: None,
         }
     }
 }
@@ -40,8 +43,35 @@ impl Credentials {
         self.access_token = token.into();
     }
 
+    /// Gets the refresh token.
+    pub fn refresh_token(&self) -> Option<&Token> {
+        self.refresh_token.as_ref()
+    }
+
+    /// Sets the refresh token.
+    pub fn set_refresh_token(&mut self, token: impl Into<Token>) {
+        self.refresh_token = Some(token.into());
+    }
+
+    /// Builds the credentials with the given refresh token.
+    pub fn with_refresh_token(mut self, token: impl Into<Token>) -> Self {
+        self.set_refresh_token(token);
+        self
+    }
+
+    /// Gets the credentials expiry.
+    pub fn expiry(&self) -> Option<&OffsetDateTime> {
+        match self.refresh_token() {
+            Some(refresh_token) => refresh_token.expiry(),
+            None => self.access_token.expiry(),
+        }
+    }
+
     /// Checks if the credentials have expired.
     pub fn is_expired(&self) -> bool {
-        self.access_token.is_expired()
+        match self.refresh_token() {
+            Some(refresh_token) => refresh_token.is_expired(),
+            None => self.access_token.is_expired(),
+        }
     }
 }

--- a/packages/ploys/src/client/flows/device_code/mod.rs
+++ b/packages/ploys/src/client/flows/device_code/mod.rs
@@ -105,23 +105,33 @@ impl Authenticate for DeviceCodeFlow {
                 },
                 TokenResponse::Success(success) => {
                     let now = OffsetDateTime::now_utc();
-                    let mut token = success.access_token;
+                    let mut access_token = success.access_token;
 
                     if let Some(expires_in) = success.expires_in {
-                        token.set_expiry(now + time::Duration::seconds(expires_in));
+                        access_token.set_expiry(now + time::Duration::seconds(expires_in));
                     }
 
                     let user = http_client
                         .get("https://api.github.com/user")
                         .header("Accept", "application/vnd.github+json")
                         .header("X-GitHub-Api-Version", "2026-03-10")
-                        .bearer_auth(token.value())
+                        .bearer_auth(access_token.value())
                         .send()?
                         .error_for_status()?
                         .json::<UserResponse>()?
                         .login;
 
-                    *credentials = Some(Credentials::new(user, token));
+                    let mut creds = Credentials::new(user, access_token);
+
+                    if let Some(mut refresh_token) = success.refresh_token {
+                        if let Some(expires_in) = success.refresh_token_expires_in {
+                            refresh_token.set_expiry(now + time::Duration::seconds(expires_in));
+                        }
+
+                        creds.set_refresh_token(refresh_token);
+                    }
+
+                    *credentials = Some(creds);
 
                     break;
                 }
@@ -164,6 +174,9 @@ struct SuccessTokenResponse {
     #[serde_as(as = "DisplayFromStr")]
     access_token: Token,
     expires_in: Option<i64>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    refresh_token: Option<Token>,
+    refresh_token_expires_in: Option<i64>,
 }
 
 #[derive(Deserialize)]

--- a/packages/ploys/src/client/flows/keyring/mod.rs
+++ b/packages/ploys/src/client/flows/keyring/mod.rs
@@ -122,7 +122,7 @@ where
                 let secret = entry.get_secret()?;
                 let creds = serde_json::from_slice::<Credentials>(&secret)?;
 
-                if creds.is_expired() {
+                if creds.access_token().is_expired() {
                     *credentials = Some(creds);
 
                     self.auth_flow

--- a/packages/ploys/src/client/mod.rs
+++ b/packages/ploys/src/client/mod.rs
@@ -68,7 +68,11 @@ impl Client {
             .write()
             .unwrap_or_else(|err| err.into_inner());
 
-        if credentials.is_none() || credentials.as_ref().is_some_and(|c| c.is_expired()) {
+        if credentials.is_none()
+            || credentials
+                .as_ref()
+                .is_some_and(|credentials| credentials.access_token().is_expired())
+        {
             self.auth_flow
                 .dyn_authenticate(&mut credentials, &self.http_client, &self.server)?;
         }


### PR DESCRIPTION
This adds supports for handling refresh tokens in the client and authentication flows.

## Motivation

The device code flow returns a short-lived access token that isn't particularly useful to store on its own. However, the flow may also return a refresh token that may be used to generate a new access token without needing to initiate the device flow again. Supporting this along with the refresh token flow would finally allow the CLI to be updated to support the new authentication methods.

Refresh tokens are already technically supported because the token type is supported, but they are not yet retrieved or stored.

## Implementation

This change adds a new optional refresh token field to the existing `Credentials` type with the various getters, setters, and builders. It also updates the existing device code flow to retrieve the refresh token when it obtains the access token, and stores it in the credentials.

A new `expiry` method has also been introduced on `Credentials` to go with the existing `is_expired` method to mirror the `Token` type. The implementation of `is_expired` and `expiry` now refer to the entire credentials having expired rather than just the access token. This required both the client and keyring authentication flow to be updated to explicitly refer to the access token expiration such that the refresh token flow would not be skipped.

This does not introduce the actual refresh token flow as that can be added in a follow-up PR.