### PR TITLE
Add refresh token authentication flow adapter

### DIFF
--- a/packages/ploys/src/client/builder.rs
+++ b/packages/ploys/src/client/builder.rs
@@ -7,6 +7,7 @@ use super::flows::Authenticate;
 use super::flows::access_token::AccessTokenFlow;
 use super::flows::device_code::DeviceCodeFlow;
 use super::flows::keyring::KeyringFlow;
+use super::flows::refresh_token::RefreshTokenFlow;
 use super::{Client, Credentials, Error, ServAddr, Token};
 
 /// The project management client builder.
@@ -53,6 +54,14 @@ impl Builder {
 }
 
 impl<T> Builder<T> {
+    /// Builds the client with the refresh token flow.
+    ///
+    /// See [`RefreshTokenFlow`] for more information about this authentication
+    /// flow adapter.
+    pub fn with_refresh_token_flow(self) -> Builder<RefreshTokenFlow<T>> {
+        self.map_authentication_flow(RefreshTokenFlow::new)
+    }
+
     /// Builds the client with the given keyring credential store.
     ///
     /// See [`KeyringFlow`] for more information about this authentication

--- a/packages/ploys/src/client/flows/mod.rs
+++ b/packages/ploys/src/client/flows/mod.rs
@@ -1,6 +1,7 @@
 pub mod access_token;
 pub mod device_code;
 pub mod keyring;
+pub mod refresh_token;
 
 use std::convert::Infallible;
 use std::error::Error;

--- a/packages/ploys/src/client/flows/refresh_token/error.rs
+++ b/packages/ploys/src/client/flows/refresh_token/error.rs
@@ -1,0 +1,30 @@
+use std::fmt::{self, Display};
+
+/// The refresh token authentication flow adapter error.
+#[derive(Debug)]
+pub enum Error<T> {
+    /// A request error.
+    Request(reqwest::Error),
+    /// An error with the adapted authentication flow.
+    Inner(T),
+}
+
+impl<T> Display for Error<T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Request(err) => Display::fmt(err, f),
+            Self::Inner(err) => Display::fmt(err, f),
+        }
+    }
+}
+
+impl<T> std::error::Error for Error<T> where T: std::error::Error {}
+
+impl<T> From<reqwest::Error> for Error<T> {
+    fn from(err: reqwest::Error) -> Self {
+        Self::Request(err)
+    }
+}

--- a/packages/ploys/src/client/flows/refresh_token/mod.rs
+++ b/packages/ploys/src/client/flows/refresh_token/mod.rs
@@ -1,0 +1,139 @@
+mod error;
+
+use std::sync::Arc;
+
+use once_cell::sync::OnceCell;
+use reqwest::blocking::Client as HttpClient;
+use serde::Deserialize;
+use serde_with::{DisplayFromStr, serde_as};
+use time::OffsetDateTime;
+
+use crate::client::{Credentials, ServAddr, Token};
+
+pub use self::error::Error;
+
+use super::Authenticate;
+
+/// The refresh token authentication flow adapter.
+///
+/// Note that this currently only supports refreshing credentials created via
+/// the device code flow.
+#[derive(Clone, Debug, Default)]
+pub struct RefreshTokenFlow<T> {
+    client_id: OnceCell<Arc<str>>,
+    auth_flow: T,
+}
+
+impl<T> RefreshTokenFlow<T> {
+    /// Constructs a new refresh token authentication flow adapter.
+    pub fn new(auth_flow: T) -> Self {
+        Self {
+            client_id: OnceCell::new(),
+            auth_flow,
+        }
+    }
+}
+
+impl<T> Authenticate for RefreshTokenFlow<T>
+where
+    T: Authenticate,
+{
+    type Error = Error<T::Error>;
+
+    fn authenticate(
+        &self,
+        credentials: &mut Option<Credentials>,
+        http_client: &HttpClient,
+        server: &ServAddr,
+    ) -> Result<(), Self::Error> {
+        let refresh_token = match credentials.as_ref().and_then(Credentials::refresh_token) {
+            Some(refresh_token) if refresh_token.is_expired() => None,
+            Some(refresh_token) => Some(refresh_token),
+            None => None,
+        };
+
+        let Some(refresh_token) = refresh_token else {
+            self.auth_flow
+                .authenticate(credentials, http_client, server)
+                .map_err(Error::Inner)?;
+
+            return Ok(());
+        };
+
+        let client_id = self.client_id.get_or_try_init(|| {
+            Ok::<_, Error<T::Error>>(
+                http_client
+                    .get(format!("https://{server}/github"))
+                    .send()?
+                    .error_for_status()?
+                    .json::<AppInfo>()?
+                    .client_id
+                    .into(),
+            )
+        })?;
+
+        let token_response: TokenResponse = http_client
+            .post("https://github.com/login/oauth/access_token")
+            .header("Accept", "application/json")
+            .form(&[
+                ("client_id", &**client_id),
+                ("grant_type", "refresh_token"),
+                ("refresh_token", refresh_token.value()),
+            ])
+            .send()?
+            .error_for_status()?
+            .json()?;
+
+        let now = OffsetDateTime::now_utc();
+        let mut access_token = token_response.access_token;
+
+        if let Some(expires_in) = token_response.expires_in {
+            access_token.set_expiry(now + time::Duration::seconds(expires_in));
+        }
+
+        let user = http_client
+            .get("https://api.github.com/user")
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2026-03-10")
+            .bearer_auth(access_token.value())
+            .send()?
+            .error_for_status()?
+            .json::<UserResponse>()?
+            .login;
+
+        let mut creds = Credentials::new(user, access_token);
+
+        if let Some(mut refresh_token) = token_response.refresh_token {
+            if let Some(expires_in) = token_response.refresh_token_expires_in {
+                refresh_token.set_expiry(now + time::Duration::seconds(expires_in));
+            }
+
+            creds.set_refresh_token(refresh_token);
+        }
+
+        *credentials = Some(creds);
+
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+struct AppInfo {
+    client_id: String,
+}
+
+#[serde_as]
+#[derive(Deserialize)]
+struct TokenResponse {
+    #[serde_as(as = "DisplayFromStr")]
+    access_token: Token,
+    expires_in: Option<i64>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    refresh_token: Option<Token>,
+    refresh_token_expires_in: Option<i64>,
+}
+
+#[derive(Deserialize)]
+struct UserResponse {
+    login: String,
+}


### PR DESCRIPTION
This is a follow-up to #358 that adds a new refresh token authentication flow adapter.

## Motivation

The GitHub refresh token authentication flow allows an access token to be refreshed with a refresh token. By creating an authentication flow adapter, it would be possible to support refreshing tokens in combination with the device code flow or separately when a CLI command shouldn't prompt for new authentication.

## Implementation

This change adds a new `RefreshTokenFlow` authentication flow adapter that refreshes an expired access token. It also adds a new `Builder` method to wrap an existing authentication flow.

The flow currently only supports the device code flow but it would be possible to add support for a web-based flow by storing the client secret in the flow. It would also be possible to add a method to set the client identifier to avoid requesting it from the server endpoint as this flow would run on the server.