### PR TITLE
Add `Client::login` method

### DIFF
--- a/packages/ploys/src/client/error.rs
+++ b/packages/ploys/src/client/error.rs
@@ -34,3 +34,15 @@ impl From<crate::project::Error<crate::repository::types::github::Error>> for Er
         Self::Project(err)
     }
 }
+
+/// The missing credentials error.
+#[derive(Debug)]
+pub struct MissingCredentials;
+
+impl Display for MissingCredentials {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Missing credentials")
+    }
+}
+
+impl std::error::Error for MissingCredentials {}

--- a/packages/ploys/src/client/mod.rs
+++ b/packages/ploys/src/client/mod.rs
@@ -17,6 +17,7 @@ pub use self::credentials::{Credentials, Token, TokenError, TokenType};
 pub use self::error::Error;
 pub use self::server::ServAddr;
 
+use self::error::MissingCredentials;
 use self::flows::DynAuthenticate;
 
 /// The project management client.
@@ -54,15 +55,30 @@ impl Client {
 }
 
 impl Client {
+    /// Obtains the authentication credentials.
+    ///
+    /// This method returns cached credentials if they have not yet expired, or
+    /// initiates a new authentication flow to request updated credentials if
+    /// they have expired. The returned credentials may no longer be valid if
+    /// they have been externally revoked or the expiration date is unknown.
+    pub fn login(&self) -> Result<Credentials, Error> {
+        match self.get_credentials().map_err(Error::Auth)? {
+            Some(credentials) => Ok(credentials),
+            None => Err(Error::Auth(Box::new(MissingCredentials))),
+        }
+    }
+}
+
+impl Client {
     /// Gets the HTTP client.
     pub(crate) fn http_client(&self) -> &HttpClient {
         &self.http_client
     }
 
-    /// Gets the authentication credentials access token.
-    pub(crate) fn authenticate(
+    /// Gets the authentication credentials.
+    pub(crate) fn get_credentials(
         &self,
-    ) -> Result<Option<Token>, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Option<Credentials>, Box<dyn std::error::Error + Send + Sync>> {
         let mut credentials = self
             .credentials
             .write()
@@ -77,9 +93,15 @@ impl Client {
                 .dyn_authenticate(&mut credentials, &self.http_client, &self.server)?;
         }
 
-        match &*credentials {
-            Some(credentials) => Ok(Some(credentials.access_token().clone())),
-            None => Ok(None),
-        }
+        Ok(credentials.clone())
+    }
+
+    /// Gets the authentication credentials access token.
+    pub(crate) fn authenticate(
+        &self,
+    ) -> Result<Option<Token>, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(self
+            .get_credentials()?
+            .map(|credentials| credentials.access_token().clone()))
     }
 }


### PR DESCRIPTION
This adds a new `login` method to the `Client` type.

## Motivation

The `Client` type currently does not have a way to retrieve the stored credentials outside of the library. There is also no way to trigger the authentication flow without attempting to get a package. However, this needs to be possible in order to provide a `login` command.

## Implementation

This change adds a new `Client::login` method that either retrieves the cached credentials or triggers the authentication flow. This should be sufficient to address the above requirement as a CLI command should not cache credentials between calls.

Internally, the `MissingCredentials` error type has been introduced to handle the situation where no credentials are returned from the authentication flow or found in the cache.

The private `Client::authenticate` method has been split out into a separate `get_credentials` method that can be called by both `login` and `authenticate`, but there are optimisations that could be done here in the future to avoid unnecessary cloning.