### PR TITLE
Update commands with new client authentication flows

### DIFF
--- a/packages/ploys-cli/src/package/changelog.rs
+++ b/packages/ploys-cli/src/package/changelog.rs
@@ -1,53 +1,59 @@
 use std::convert::Infallible;
 
-use anyhow::{Context, Error, bail};
+use anyhow::{Error, bail};
 use clap::Args;
-use ploys::client::{Client, Token};
-use ploys::project::Project;
+use ploys::client::{Client, ServAddr, Token};
 use ploys::repository::RepoAddr;
 use semver::Version;
+
+use crate::auth::init_keyring;
 
 /// The changelog command.
 #[derive(Args)]
 pub struct Changelog {
+    /// The repository address (owner/name) or GitHub URL.
+    repo: RepoAddr,
+
     /// The package identifier.
     package: String,
 
     /// Query the specified version.
-    #[clap(long, conflicts_with_all = ["latest", "unreleased"])]
+    #[arg(long, conflicts_with_all = ["latest", "unreleased"])]
     version: Option<Version>,
 
     /// Query only the latest changes.
-    #[clap(long, conflicts_with_all = ["version", "unreleased"])]
+    #[arg(long, conflicts_with_all = ["version", "unreleased"])]
     latest: bool,
 
     /// Query only the unreleased changes.
-    #[clap(long, conflicts_with_all = ["version", "latest"])]
+    #[arg(long, conflicts_with_all = ["version", "latest"])]
     unreleased: bool,
 
-    /// The remote GitHub repository owner/name or URL.
-    #[clap(long)]
-    remote: Option<RepoAddr>,
+    /// The management server address.
+    #[arg(long, default_value = "api.ploys.dev")]
+    server: ServAddr,
 
     /// The authentication token for GitHub API access.
-    #[clap(long, env = "GITHUB_TOKEN", hide_env_values = true)]
-    token: Token,
+    #[arg(long, env = "GITHUB_TOKEN", hide_env_values = true)]
+    token: Option<Token>,
 }
 
 impl Changelog {
     /// Executes the command.
     pub fn exec(self) -> Result<(), Error> {
-        let repo = match self.remote {
-            Some(repo) => repo,
-            None => Project::git(".")?
-                .repository()
-                .context("Missing remote repository")?,
+        let client = match self.token {
+            Some(token) => Client::build()
+                .with_server(self.server)
+                .with_access_token_flow(token)
+                .finished()?,
+            None => Client::build()
+                .with_server(self.server)
+                .with_refresh_token_flow()
+                .with_keyring_store(init_keyring()?)
+                .finished()?,
         };
 
-        let client = Client::build()
-            .with_access_token_flow(self.token)
-            .finished()?;
-        let project = client.get_project(repo)?;
+        let project = client.get_project(self.repo)?;
         let package = project
             .get_package(&self.package)
             .ok_or(ploys::package::Error::<Infallible>::NotFound(self.package))?;

--- a/packages/ploys-cli/src/package/release.rs
+++ b/packages/ploys-cli/src/package/release.rs
@@ -1,44 +1,50 @@
 use std::convert::Infallible;
 
-use anyhow::{Context, Error};
+use anyhow::Error;
 use clap::Args;
-use ploys::client::{Client, Token};
+use ploys::client::{Client, ServAddr, Token};
 use ploys::package::BumpOrVersion;
-use ploys::project::Project;
 use ploys::repository::RepoAddr;
+
+use crate::auth::init_keyring;
 
 /// The release command.
 #[derive(Args)]
 pub struct Release {
+    /// The repository address (owner/name) or GitHub URL.
+    repo: RepoAddr,
+
     /// The package identifier.
     package: String,
 
     /// The package version or level (major, minor, patch, rc, beta, alpha).
     version: BumpOrVersion,
 
-    /// The remote GitHub repository owner/name or URL.
-    #[clap(long)]
-    remote: Option<RepoAddr>,
+    /// The management server address.
+    #[arg(long, default_value = "api.ploys.dev")]
+    server: ServAddr,
 
     /// The authentication token for GitHub API access.
-    #[clap(long, env = "GITHUB_TOKEN", hide_env_values = true)]
-    token: Token,
+    #[arg(long, env = "GITHUB_TOKEN", hide_env_values = true)]
+    token: Option<Token>,
 }
 
 impl Release {
     /// Executes the command.
     pub fn exec(self) -> Result<(), Error> {
-        let repo = match self.remote {
-            Some(repo) => repo,
-            None => Project::git(".")?
-                .repository()
-                .context("Missing remote repository")?,
+        let client = match self.token {
+            Some(token) => Client::build()
+                .with_server(self.server)
+                .with_access_token_flow(token)
+                .finished()?,
+            None => Client::build()
+                .with_server(self.server)
+                .with_refresh_token_flow()
+                .with_keyring_store(init_keyring()?)
+                .finished()?,
         };
 
-        let client = Client::build()
-            .with_access_token_flow(self.token)
-            .finished()?;
-        let project = client.get_project(repo)?;
+        let project = client.get_project(self.repo)?;
 
         project
             .get_package(&self.package)

--- a/packages/ploys-cli/src/project/info.rs
+++ b/packages/ploys-cli/src/project/info.rs
@@ -1,14 +1,20 @@
 use anyhow::Error;
 use clap::Args;
 use console::style;
-use ploys::client::{Client, Token};
+use ploys::client::{Client, ServAddr, Token};
 use ploys::repository::RepoAddr;
+
+use crate::auth::init_keyring;
 
 /// Gets the project information.
 #[derive(Args)]
 pub struct Info {
     /// The repository address (owner/name) or GitHub URL.
     repo: RepoAddr,
+
+    /// The management server address.
+    #[arg(long, default_value = "api.ploys.dev")]
+    server: ServAddr,
 
     /// The authentication token for GitHub API access.
     #[arg(long, env = "GITHUB_TOKEN", hide_env_values = true)]
@@ -19,8 +25,15 @@ impl Info {
     /// Executes the command.
     pub fn exec(self) -> Result<(), Error> {
         let client = match self.token {
-            Some(token) => Client::build().with_access_token_flow(token).finished()?,
-            None => Client::build().finished()?,
+            Some(token) => Client::build()
+                .with_server(self.server)
+                .with_access_token_flow(token)
+                .finished()?,
+            None => Client::build()
+                .with_server(self.server)
+                .with_refresh_token_flow()
+                .with_keyring_store(init_keyring()?)
+                .finished()?,
         };
 
         let project = client.get_project(self.repo)?;


### PR DESCRIPTION
Closes #245.

This is the culmination of various changes to support client authentication flows in CLI commands.

## Motivation

The access token, refresh token, device code and keyring authentication flows were introduced to allow users to sign-in to the CLI and securely store the credentials so that subsequent commands can use those credentials. This avoids having the user manually manage an access token externally. Now that the functionality has been added, it is time to update the existing commands to use it.

## Implementation

This change updates the `package changelog`, `package release`, and `project info` commands to use the new authentication flows. This means that these commands now all act on the remote project rather than the local workspace.

The `project info` command had previously been updated to only work remotely, but now the `package` commands have been updated to match. The `project init` and `package init` commands have not yet been updated as it is not yet clear how these would work and there is further changes to be made to establish a new `Workspace` type.

Each of these commands uses the access token flow if given an access token and the refresh token flow with keyring adapter when not given an access token.