### PR TITLE
Add `project list` command

### DIFF
--- a/packages/ploys-cli/src/project/list.rs
+++ b/packages/ploys-cli/src/project/list.rs
@@ -1,0 +1,57 @@
+use anyhow::Error;
+use clap::Args;
+use console::style;
+use ploys::client::{Client, ServAddr, Token};
+
+use crate::auth::init_keyring;
+
+/// The `project list` command.
+#[derive(Args)]
+pub struct List {
+    /// The project management server.
+    #[arg(long, default_value = "api.ploys.dev")]
+    server: ServAddr,
+
+    /// The authentication token for GitHub API access.
+    #[arg(long, env = "GITHUB_TOKEN", hide_env_values = true)]
+    token: Option<Token>,
+}
+
+impl List {
+    /// Executes the command.
+    pub fn exec(self) -> Result<(), Error> {
+        let client = match self.token {
+            Some(token) => Client::build()
+                .with_server(self.server)
+                .with_access_token_flow(token)
+                .finished()?,
+            None => Client::build()
+                .with_server(self.server)
+                .with_refresh_token_flow()
+                .with_keyring_store(init_keyring()?)
+                .finished()?,
+        };
+
+        client.login()?;
+
+        println!("{}:\n", style("Projects").underlined().bold());
+
+        let projects = client.projects().flatten().collect::<Vec<_>>();
+
+        let max_name_len = projects
+            .iter()
+            .map(|project| project.name().len())
+            .max()
+            .unwrap_or_default();
+
+        for project in projects {
+            println!(
+                "{:<max_name_len$}  {}",
+                project.name(),
+                project.description().unwrap_or_default()
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/packages/ploys-cli/src/project/mod.rs
+++ b/packages/ploys-cli/src/project/mod.rs
@@ -1,11 +1,13 @@
 mod info;
 mod init;
+mod list;
 
 use anyhow::Error;
 use clap::{Args, Subcommand};
 
 use self::info::Info;
 use self::init::Init;
+use self::list::List;
 
 /// The project command.
 #[derive(Args)]
@@ -20,6 +22,7 @@ impl Project {
         match self.command {
             Command::Info(info) => info.exec(),
             Command::Init(init) => init.exec(),
+            Command::List(list) => list.exec(),
         }
     }
 }
@@ -31,4 +34,6 @@ enum Command {
     Info(Info),
     /// Initializes a new project.
     Init(Init),
+    /// Lists managed projects.
+    List(List),
 }


### PR DESCRIPTION
Closes #332.

This adds a new `project list` command to list managed projects.

## Motivation

It would be beneficial to users if it was possible to list all available projects that they are involved with that are managed by the system provided by this project.

## Implementation

This change introduces a new `project list` command that calls the `Client::projects` method from #364 and displays the result.