### PR TITLE
Update `package release` command to run locally

### DIFF
--- a/packages/ploys-cli/src/package/release.rs
+++ b/packages/ploys-cli/src/package/release.rs
@@ -42,13 +42,13 @@ impl Release {
                 .finished()?,
         };
 
-        let release_id = client
+        let id = client
             .get_project(self.repo.clone())?
             .create_package_release_request(self.package, self.version)?
             .finish()?
             .id();
 
-        println!("Release created at `{}/pull/{release_id}`", self.repo.url());
+        println!("Release request created at `{}/pull/{id}`", self.repo.url());
 
         Ok(())
     }

--- a/packages/ploys-cli/src/package/release.rs
+++ b/packages/ploys-cli/src/package/release.rs
@@ -1,5 +1,3 @@
-use std::convert::Infallible;
-
 use anyhow::Error;
 use clap::Args;
 use ploys::client::{Client, ServAddr, Token};
@@ -44,12 +42,13 @@ impl Release {
                 .finished()?,
         };
 
-        let project = client.get_project(self.repo)?;
+        let release_id = client
+            .get_project(self.repo.clone())?
+            .create_package_release_request(self.package, self.version)?
+            .finish()?
+            .id();
 
-        project
-            .get_package(&self.package)
-            .ok_or(ploys::package::Error::<Infallible>::NotFound(self.package))?
-            .request_release(self.version)?;
+        println!("Release created at `{}/pull/{release_id}`", self.repo.url());
 
         Ok(())
     }


### PR DESCRIPTION
Closes #366.

This updates the `package release` command to execute requests locally as the user instead of app.

## Motivation

The `package release` command currently sends a webhook event that is picked up by the server in order to create a new release request. This has some security implications that would be resolved by running it locally. It would also allow the command to fail appropriately.

## Implementation

This changes the `package release` command's implementation to call `create_package_release_request` on the project instead of `request_release` on the package. It also adds an output linking to the pull request that was not previously possible without adding some kind of polling.