### PR TITLE
Remove package release request event dispatch

### DIFF
--- a/packages/ploys-api/src/github/webhook/mod.rs
+++ b/packages/ploys-api/src/github/webhook/mod.rs
@@ -7,10 +7,7 @@ pub mod secret;
 use axum::extract::State;
 use axum_extra::TypedHeader;
 use ploys::client::{Client, Token};
-use ploys::package::BumpOrVersion;
 use semver::Version;
-use serde::Deserialize;
-use serde_with::{DisplayFromStr, serde_as};
 use tracing::{debug, error, instrument};
 
 use crate::state::AppState;
@@ -18,7 +15,7 @@ use crate::state::AppState;
 use self::auth::get_installation_access_token;
 use self::error::Error;
 use self::header::XGitHubDelivery;
-use self::payload::{Payload, PullRequestPayload, RepositoryDispatchPayload};
+use self::payload::{Payload, PullRequestPayload};
 
 /// Receives the GitHub webhook event payload.
 #[instrument(skip_all, fields(delivery = %delivery.into_inner(), event_name = payload.event_name()))]
@@ -40,14 +37,6 @@ pub async fn receive(
                     )
                     .await?;
                 }
-
-                Ok(())
-            }
-            _ => Ok(()),
-        },
-        Payload::RepositoryDispatch(payload) => match &*payload.action {
-            "ploys-package-release-request" => {
-                request_release(payload, &state).await?;
 
                 Ok(())
             }
@@ -105,57 +94,6 @@ fn create_release_sync(
         .map_err(ploys::project::Error::Repository)?;
 
     Ok(())
-}
-
-/// Requests the package release.
-///
-/// This does not yet support parallel release branches so simply ensures that
-/// all new versions are greater than the previous.
-async fn request_release(
-    payload: RepositoryDispatchPayload,
-    state: &AppState,
-) -> Result<(), Error> {
-    let token =
-        get_installation_access_token(payload.installation.id, payload.repository.id, state)
-            .await?;
-
-    tokio::task::spawn_blocking(move || {
-        if let Err(err) = create_release_request(token, payload) {
-            error!("Error creating release request: {err}");
-        }
-    });
-
-    Ok(())
-}
-
-/// Creates the release request.
-///
-/// The `Project` is currently using blocking requests so this should be spawned
-/// using `tokio::task::spawn_blocking`. This also avoids any timeout issues for
-/// completing the webhook event request.
-fn create_release_request(token: Token, payload: RepositoryDispatchPayload) -> Result<(), Error> {
-    let ClientPayload { package, version } = serde_json::from_value(payload.client_payload)?;
-
-    let client = Client::build().with_access_token_flow(token).finished()?;
-    let project = client.get_project(&payload.repository.full_name)?;
-    let package = project
-        .get_package(&package)
-        .ok_or(ploys::package::Error::NotFound(package))
-        .map_err(ploys::project::Error::Package)?;
-
-    project
-        .create_package_release_request(package.name(), version)?
-        .finish()?;
-
-    Ok(())
-}
-
-#[serde_as]
-#[derive(Deserialize)]
-struct ClientPayload {
-    package: String,
-    #[serde_as(as = "DisplayFromStr")]
-    version: BumpOrVersion,
 }
 
 #[cfg(test)]

--- a/packages/ploys-api/src/github/webhook/payload.rs
+++ b/packages/ploys-api/src/github/webhook/payload.rs
@@ -23,7 +23,6 @@ use super::secret::WebhookSecret;
 #[derive(Debug)]
 pub enum Payload {
     PullRequest(PullRequestPayload),
-    RepositoryDispatch(RepositoryDispatchPayload),
     #[allow(dead_code)]
     Other(String, Value),
 }
@@ -33,7 +32,6 @@ impl Payload {
     pub fn event_name(&self) -> &str {
         match self {
             Payload::PullRequest(_) => "pull_request",
-            Payload::RepositoryDispatch(_) => "repository_dispatch",
             Payload::Other(name, _) => name,
         }
     }
@@ -76,7 +74,6 @@ where
 
         Ok(match event.as_str() {
             "pull_request" => Self::PullRequest(serde_json::from_slice(&bytes)?),
-            "repository_dispatch" => Self::RepositoryDispatch(serde_json::from_slice(&bytes)?),
             _ => Self::Other(event, serde_json::from_slice(&bytes)?),
         })
     }
@@ -87,15 +84,6 @@ where
 pub struct PullRequestPayload {
     pub action: String,
     pub pull_request: PullRequest,
-    pub repository: Repository,
-    pub installation: Installation,
-}
-
-/// The `repository_dispatch` webhook payload.
-#[derive(Debug, Deserialize)]
-pub struct RepositoryDispatchPayload {
-    pub action: String,
-    pub client_payload: Value,
     pub repository: Repository,
     pub installation: Installation,
 }

--- a/packages/ploys/src/package/mod.rs
+++ b/packages/ploys/src/package/mod.rs
@@ -16,7 +16,6 @@ use bytes::Bytes;
 use either::Either;
 use relative_path::{RelativePath, RelativePathBuf};
 use semver::Version;
-use tracing::info;
 use url::Url;
 
 use crate::changelog::Changelog;
@@ -403,27 +402,6 @@ impl<T> Package<T>
 where
     T: Remote,
 {
-    /// Requests the release of the specified package version.
-    ///
-    /// It does not yet support parallel release or hotfix branches and expects
-    /// all development to be on the default branch in the repository settings.
-    pub fn request_release(&self, version: impl Into<BumpOrVersion>) -> Result<(), T::Error> {
-        let version = version.into();
-
-        info!(
-            package = self.name(),
-            version = %self.version(),
-            request = %version,
-            "Requesting release"
-        );
-
-        self.repository
-            .inner()
-            .request_package_release(self.name(), version)?;
-
-        Ok(())
-    }
-
     /// Builds the changelog release for the given package version.
     ///
     /// This method queries the GitHub API to generate new release information

--- a/packages/ploys/src/repository/remote.rs
+++ b/packages/ploys/src/repository/remote.rs
@@ -1,7 +1,6 @@
 use semver::Version;
 
 use crate::changelog::Release;
-use crate::package::BumpOrVersion;
 
 use super::GitLike;
 
@@ -10,13 +9,6 @@ use super::GitLike;
 /// This defines the shared API of a remote repository to simplify feature flag
 /// handling.
 pub trait Remote: GitLike {
-    /// Requests a package release.
-    fn request_package_release(
-        &self,
-        package: &str,
-        version: BumpOrVersion,
-    ) -> Result<(), Self::Error>;
-
     /// Gets the changelog release for the given package version.
     fn get_changelog_release(
         &self,
@@ -50,14 +42,6 @@ impl<T> Remote for &T
 where
     T: Remote,
 {
-    fn request_package_release(
-        &self,
-        package: &str,
-        version: BumpOrVersion,
-    ) -> Result<(), Self::Error> {
-        (**self).request_package_release(package, version)
-    }
-
     fn get_changelog_release(
         &self,
         package: &str,
@@ -94,14 +78,6 @@ impl<T> Remote for &mut T
 where
     T: Remote,
 {
-    fn request_package_release(
-        &self,
-        package: &str,
-        version: BumpOrVersion,
-    ) -> Result<(), Self::Error> {
-        (**self).request_package_release(package, version)
-    }
-
     fn get_changelog_release(
         &self,
         package: &str,

--- a/packages/ploys/src/repository/types/github/mod.rs
+++ b/packages/ploys/src/repository/types/github/mod.rs
@@ -20,7 +20,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::changelog::Release;
 use crate::client::{Client, Error as ClientError};
-use crate::package::BumpOrVersion;
 use crate::repository::adapters::cached::Cached;
 use crate::repository::adapters::staged::Staged;
 use crate::repository::addr::RepoAddr;
@@ -630,44 +629,6 @@ impl GitLike for GitHub {
 }
 
 impl Remote for GitHub {
-    fn request_package_release(
-        &self,
-        package: &str,
-        version: BumpOrVersion,
-    ) -> Result<(), Self::Error> {
-        #[derive(Serialize)]
-        struct ClientPayload {
-            package: String,
-            version: String,
-        }
-
-        #[derive(Serialize)]
-        struct RepositoryDispatchEvent<T> {
-            event_type: String,
-            client_payload: T,
-        }
-
-        self.inner
-            .inner
-            .inner()
-            .repository
-            .post("dispatches")?
-            .header("X-GitHub-Api-Version", "2022-11-28")
-            .json(&RepositoryDispatchEvent {
-                event_type: String::from("ploys-package-release-request"),
-                client_payload: ClientPayload {
-                    package: package.to_owned(),
-                    version: version.to_string(),
-                },
-            })
-            .send()
-            .map_err(Error::from)?
-            .error_for_status()
-            .map_err(Error::from)?;
-
-        Ok(())
-    }
-
     fn get_changelog_release(
         &self,
         package: &str,


### PR DESCRIPTION
This is a follow-up to #368 to remove the unused package release event dispatch.

## Motivation

The `package release` command no longer sends a repository dispatch event and instead creates the release request locally. The old functionality should therefore be removed to simplify the codebase.

## Implementation

This simply removes the `ploys-package-release-request` event handling from both `ploys` and `ploys-api`. This includes removing the `Package::request_release` and `Remote::request_package_release` methods.