### PR TITLE
Add project builder

### DIFF
--- a/packages/ploys/src/client/mod.rs
+++ b/packages/ploys/src/client/mod.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, RwLock};
 
 use reqwest::blocking::Client as HttpClient;
 
-use crate::project::{Error as ProjError, Project};
+use crate::project::{Builder as ProjectBuilder, Error as ProjError, Project};
 use crate::repository::RepoAddr;
 use crate::repository::types::github::{Error as RepoError, GitHub};
 
@@ -53,6 +53,19 @@ impl Client {
         let proj = Project::open(repo)?;
 
         Ok(proj)
+    }
+
+    /// Creates a new project at the given repository address.
+    pub fn create_project<R>(&self, repo: R) -> Result<ProjectBuilder, Error>
+    where
+        R: TryInto<RepoAddr, Error: Into<RepoError>>,
+    {
+        let repo = repo
+            .try_into()
+            .map_err(Into::into)
+            .map_err(ProjError::Repository)?;
+
+        Ok(ProjectBuilder::new(repo, self.clone()))
     }
 
     /// Iterates over managed projects.

--- a/packages/ploys/src/project/builder.rs
+++ b/packages/ploys/src/project/builder.rs
@@ -1,0 +1,171 @@
+use serde::Serialize;
+
+use crate::client::{Client, Credentials, Error as ClientError};
+use crate::project::Config;
+use crate::repository::revision::Revision;
+use crate::repository::types::github::GitHub;
+use crate::repository::{GitLike, RepoAddr};
+
+use super::{Error as ProjError, Project};
+
+/// The project builder.
+pub struct Builder {
+    repo: RepoAddr,
+    client: Client,
+    description: Option<String>,
+    authors: Vec<String>,
+    private: bool,
+}
+
+impl Builder {
+    /// Constructs a new project builder.
+    pub(crate) fn new(repo: RepoAddr, client: Client) -> Self {
+        Self {
+            repo,
+            client,
+            description: None,
+            authors: Vec::new(),
+            private: false,
+        }
+    }
+}
+
+impl Builder {
+    /// Builds the project with the given description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Builds the project with the given authors.
+    pub fn with_authors(mut self, authors: impl IntoIterator<Item = String>) -> Self {
+        self.authors = authors.into_iter().collect();
+        self
+    }
+
+    /// Builds the project with private visibility.
+    pub fn with_private_visibility(mut self) -> Self {
+        self.private = true;
+        self
+    }
+
+    /// Finishes creating the project.
+    pub fn finished(self) -> Result<Project<GitHub>, ClientError> {
+        let credentials = self.client.login()?;
+        let (repo, branch) = self.init_repo(&credentials)?;
+        let config = self.init_config();
+
+        self.commit_config(&repo, &branch, config)?;
+
+        Ok(Project::open(repo)?)
+    }
+}
+
+impl Builder {
+    /// Initialises the repository.
+    ///
+    /// This passes the `auto_init` parameter to initialise the repository with
+    /// an initial commit containing a basic `README.md`. This is necessary to
+    /// ensure that the commit is signed by GitHub when using a GitHub App user
+    /// access token.
+    ///
+    /// The only alternative would be using the App installation to listen to
+    /// repository creation and create a commit. However, that would not work
+    /// with a personal access token because the app would not be installed on
+    /// the repository. It would also be limited in the configuration options.
+    ///
+    /// The `createCommitOnBranch` mutation does not work on an empty repo, the
+    /// file contents endpoint doesn't sign the commit and is limited to a
+    /// single file per commit, and the git commits endpoint only signs when
+    /// using an App installation access token.
+    fn init_repo(&self, credentials: &Credentials) -> Result<(GitHub, String), ClientError> {
+        let url = match self.repo.owner() == credentials.user() {
+            true => String::from("https://api.github.com/user/repos"),
+            false => format!("https://api.github.com/orgs/{}/repos", self.repo.owner()),
+        };
+
+        self.client
+            .http_client()
+            .post(url)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2026-03-10")
+            .bearer_auth(credentials.access_token().value())
+            .json(&RepoParams {
+                name: self.repo.name().to_owned(),
+                description: self.description.clone(),
+                private: self.private,
+                auto_init: true,
+                has_issues: true,
+                has_projects: true,
+                allow_squash_merge: true,
+                allow_merge_commit: false,
+                allow_rebase_merge: false,
+                delete_branch_on_merge: true,
+                squash_merge_commit_title: SquashMergeCommitTitle::Pr,
+            })
+            .send()?
+            .error_for_status()?;
+
+        let mut repo =
+            GitHub::new(self.client.clone(), self.repo.clone()).map_err(ProjError::Repository)?;
+
+        let branch = repo.get_default_branch().map_err(ProjError::Repository)?;
+
+        repo.set_revision(Revision::branch(&branch));
+
+        Ok((repo, branch))
+    }
+
+    /// Creates the project configuration.
+    fn init_config(&self) -> Config {
+        let mut config = Config::new(self.repo.name());
+
+        if let Some(description) = &self.description {
+            config.set_project_description(description);
+        }
+
+        if !self.authors.is_empty() {
+            config.set_project_authors(self.authors.clone());
+        }
+
+        config.set_project_repository(self.repo.clone());
+        config
+    }
+
+    /// Commits the project configuration.
+    fn commit_config(
+        &self,
+        repo: &GitHub,
+        branch: &str,
+        config: Config,
+    ) -> Result<(), ClientError> {
+        let files = vec![("Ploys.toml".into(), config.to_string())];
+
+        repo.commit_branch(branch, "Add project configuration", files)
+            .map_err(ProjError::Repository)?;
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize)]
+struct RepoParams {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    private: bool,
+    auto_init: bool,
+    has_issues: bool,
+    has_projects: bool,
+    allow_squash_merge: bool,
+    allow_merge_commit: bool,
+    allow_rebase_merge: bool,
+    delete_branch_on_merge: bool,
+    squash_merge_commit_title: SquashMergeCommitTitle,
+}
+
+#[derive(Serialize)]
+enum SquashMergeCommitTitle {
+    #[serde(rename = "PR_TITLE")]
+    Pr,
+}

--- a/packages/ploys/src/project/mod.rs
+++ b/packages/ploys/src/project/mod.rs
@@ -5,6 +5,8 @@
 //! remote GitHub repository.
 
 pub mod config;
+
+mod builder;
 mod error;
 mod packages;
 mod release;
@@ -21,6 +23,7 @@ use crate::package::{BumpOrVersion, Package, PackageKind};
 use crate::repository::types::staging::Staging;
 use crate::repository::{Remote, RepoAddr, Repository, Stage};
 
+pub use self::builder::Builder;
 pub use self::config::Config;
 pub use self::error::Error;
 pub use self::packages::Packages;


### PR DESCRIPTION
This adds a new project `Builder` type.

## Motivation

The current `Project` type provides the ability to alter its configuration and add files to the internal repository. However, the current plan is to perform alterations through a new `Workspace` type (#339) and use the `Project` as the remote representation.

The CLI command `project init` uses the `Project` type with a `Staging` repository and commits the changes to the filesystem by calling the `write` method. As projects should now represent the GitHub repository and not any repository, there is a need for a new API.

## Implementation

This change introduces a new `Builder` type for the `Project` type and exposes it via a new `Client::create_project` method that constructs the builder. Calling `finished` calls the API to create a new repository to represent the project.

The `Builder` itself covers the configurable fields from the `project init` command and includes the ability to set the repository to private.

The implementation makes some compromises in order to ensure that the commits are all signed. The `createCommitOnBranch` GraphQL mutation cannot be used to initialise a repository and the various REST API endpoints that would (contents, git commits) only sign when using an installation access token. Therefore the `auto_init` parameter is used so that GitHub creates an initial commit containing a basic `README.md` file. Then the mutation can be used to create a second commit.

The alternatives to the above were to either create an initial unsigned commit, or to let the GitHub App create the initial commit. The former shouldn't have been a problem, but the latter would not have worked with personal access tokens as the app would not be installed. It would also have limited the future configuration options as there is no way to pass them before the repository has been initialised.

## Alternatives

There is a potential alternative implementation where the project configuration is added in a pull request. This would allow a user to configure the project and add packages, but it isn't clear how that would work with the CLI. At the very least the `Project` type would need to be updated to support an exists but uninitialised state.